### PR TITLE
docs: remove GitHub Pages setup section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,23 +604,6 @@ Generate FFT report for baseline_1.csv
 
 ---
 
-## 🌐 GitHub Pages (Marketing + SEO)
-
-To improve discoverability and onboarding, this repository includes a dedicated landing page for GitHub Pages:
-
-- **Landing page source**: [`docs/index.md`](docs/index.md)
-- **SEO configuration**: [`docs/_config.yml`](docs/_config.yml)
-
-### Enable in 30 seconds
-
-1. Go to **GitHub → Settings → Pages**
-2. Under **Build and deployment**, choose **Deploy from a branch**
-3. Select branch `main` and folder `/docs`
-4. Save
-
-Your project page will be published at:
-`https://<your-github-username>.github.io/predictive-maintenance-mcp/`
-
 ## 🧪 Testing
 
 This project includes a comprehensive test suite covering all analysis tools:


### PR DESCRIPTION
### Motivation
- The README contained an internal GitHub Pages marketing/setup block that is not useful for readers and reveals repository-specific instructions and a publish URL, so it should be removed to keep the docs focused.

### Description
- Remove the entire "🌐 GitHub Pages (Marketing + SEO)" section from `README.md`, including references to `docs/index.md`, `docs/_config.yml`, the enablement steps, and the repository-specific publication URL.

### Testing
- Confirmed the removal with `rg -n "GitHub Pages|Landing page source|SEO configuration|Enable in 30 seconds|predictive-maintenance-mcp/" README.md -S`, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a97f647e9c8336b9a21a918c67a34e)