### PR TITLE
feat: split monolith into ISO 13374 tool modules + notebooks

### DIFF
--- a/notebooks/01_getting_started.ipynb
+++ b/notebooks/01_getting_started.ipynb
@@ -1,0 +1,214 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting Started: Load and Analyze Your First Signal\n",
+    "\n",
+    "This notebook demonstrates the core workflow of `predictive-maintenance-mcp`:\n",
+    "1. Generate a synthetic vibration signal\n",
+    "2. Load it into the Signal Repository\n",
+    "3. Run spectral analysis (FFT, PSD, STFT)\n",
+    "4. Assess vibration severity per ISO 10816"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "import sys, os\n",
+    "\n",
+    "# Add project root to path\n",
+    "project_root = Path('.').resolve().parent\n",
+    "sys.path.insert(0, str(project_root / 'src'))\n",
+    "os.chdir(project_root)\n",
+    "\n",
+    "print(f'Project root: {project_root}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Generate a Test Signal\n",
+    "\n",
+    "We create a synthetic bearing vibration signal with known characteristics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs = 10000  # 10 kHz sampling rate\n",
+    "duration = 2.0  # 2 seconds\n",
+    "t = np.arange(0, duration, 1/fs)\n",
+    "\n",
+    "# Shaft rotation: 30 Hz (1800 RPM)\n",
+    "f_shaft = 30.0\n",
+    "\n",
+    "# Simulate bearing outer race fault at BPFO = 120 Hz\n",
+    "bpfo = 120.0\n",
+    "signal = (\n",
+    "    0.5 * np.sin(2 * np.pi * f_shaft * t)           # shaft imbalance\n",
+    "    + 0.3 * np.sin(2 * np.pi * bpfo * t)            # BPFO fundamental\n",
+    "    + 0.15 * np.sin(2 * np.pi * 2 * bpfo * t)       # 2x BPFO harmonic\n",
+    "    + 0.08 * np.sin(2 * np.pi * 3 * bpfo * t)       # 3x BPFO harmonic\n",
+    "    + 0.2 * np.random.randn(len(t))                   # noise\n",
+    ")\n",
+    "\n",
+    "print(f'Signal: {len(signal)} samples, {duration}s at {fs} Hz')\n",
+    "print(f'Expected peaks: shaft={f_shaft} Hz, BPFO={bpfo} Hz, 2xBPFO={2*bpfo} Hz')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save to CSV\n",
+    "signal_dir = project_root / 'data' / 'signals'\n",
+    "signal_dir.mkdir(parents=True, exist_ok=True)\n",
+    "signal_path = signal_dir / 'tutorial_bearing.csv'\n",
+    "pd.DataFrame(signal).to_csv(signal_path, header=False, index=False)\n",
+    "\n",
+    "# Save metadata\n",
+    "import json\n",
+    "meta_path = signal_dir / 'tutorial_bearing_metadata.json'\n",
+    "with open(meta_path, 'w') as f:\n",
+    "    json.dump({'sampling_rate': fs, 'signal_unit': 'g'}, f)\n",
+    "\n",
+    "print(f'Saved: {signal_path}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Load into Signal Repository\n",
+    "\n",
+    "The Signal Repository caches signals in memory for fast repeated analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from predictive_maintenance_mcp.signal_acquisition import SignalRepository\n",
+    "\n",
+    "repo = SignalRepository(max_memory_bytes=1 * 1024**3)  # 1 GB cap\n",
+    "info = repo.load_signal(str(signal_path), signal_id='tutorial_bearing', sampling_rate=fs)\n",
+    "\n",
+    "print(f'Loaded signal: {info[\"signal_id\"]}')\n",
+    "print(f'  Samples: {info[\"num_samples\"]}')\n",
+    "print(f'  Duration: {info[\"duration_s\"]}s')\n",
+    "print(f'  Size: {info[\"size_bytes\"] / 1024:.1f} KB')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Spectral Analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from predictive_maintenance_mcp.signal_processing import compute_psd, compute_stft_spectrogram\n",
+    "\n",
+    "# Power Spectral Density (Welch)\n",
+    "psd = compute_psd(signal, fs, nperseg=1024, num_peaks=10)\n",
+    "\n",
+    "print('Top PSD peaks:')\n",
+    "for i, peak in enumerate(psd['top_peaks'][:5], 1):\n",
+    "    print(f'  {i}. {peak[\"frequency_hz\"]:8.2f} Hz  ({peak[\"magnitude_db\"]:+.1f} dB)')\n",
+    "\n",
+    "print(f'\\nTotal power: {psd[\"total_power\"]:.4f}')\n",
+    "print(f'Frequency resolution: {psd[\"frequency_resolution\"]:.2f} Hz')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# STFT Spectrogram summary\n",
+    "stft_result = compute_stft_spectrogram(signal, fs, nperseg=512)\n",
+    "\n",
+    "print('STFT Spectrogram summary:')\n",
+    "print(f'  Time bins: {stft_result[\"num_time_bins\"]}')\n",
+    "print(f'  Freq bins: {stft_result[\"num_freq_bins\"]}')\n",
+    "print(f'  Max power at: {stft_result[\"max_power_freq_hz\"]:.1f} Hz, t={stft_result[\"max_power_time_s\"]:.3f}s')\n",
+    "print('\\nEnergy per band:')\n",
+    "for band in stft_result['energy_per_band']:\n",
+    "    print(f'  {band[\"band\"]:>15s}: {band[\"energy\"]:.4f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: ISO 10816 Severity Assessment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from predictive_maintenance_mcp.diagnostics import assess_vibration_severity\n",
+    "\n",
+    "severity = assess_vibration_severity(signal, fs, machine_class='II', signal_unit='g')\n",
+    "\n",
+    "print(f'ISO 10816 Assessment:')\n",
+    "print(f'  Zone: {severity[\"zone\"]} ({severity[\"severity\"]})')\n",
+    "print(f'  Velocity RMS: {severity[\"velocity_rms_mm_s\"]:.2f} mm/s')\n",
+    "print(f'  Recommendation: {severity[\"recommendation\"]}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "1. Generated a synthetic bearing fault signal with known frequencies\n",
+    "2. Loaded it into the Signal Repository for efficient caching\n",
+    "3. Ran PSD and STFT analysis to identify dominant frequencies\n",
+    "4. Assessed vibration severity per ISO 10816\n",
+    "\n",
+    "**Next**: See `02_bearing_diagnostics.ipynb` for bearing-specific fault detection."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/02_bearing_diagnostics.ipynb
+++ b/notebooks/02_bearing_diagnostics.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bearing Diagnostics Step-by-Step\n",
+    "\n",
+    "This notebook demonstrates the bearing fault detection pipeline:\n",
+    "1. Look up bearing specifications from the catalog\n",
+    "2. Compute characteristic fault frequencies (BPFO, BPFI, BSF, FTF)\n",
+    "3. Run envelope spectrum analysis\n",
+    "4. Check for fault peaks with confidence scoring\n",
+    "5. Get a full diagnostic summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from pathlib import Path\n",
+    "import sys, os\n",
+    "\n",
+    "project_root = Path('.').resolve().parent\n",
+    "sys.path.insert(0, str(project_root / 'src'))\n",
+    "os.chdir(project_root)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Bearing Catalog Lookup\n",
+    "\n",
+    "The catalog contains 22+ bearings from SKF, FAG, Timken, and NSK."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from predictive_maintenance_mcp.diagnostics import (\n",
+    "    lookup_bearing, compute_fault_frequencies, list_catalog_bearings\n",
+    ")\n",
+    "\n",
+    "# List available bearings\n",
+    "catalog = list_catalog_bearings()\n",
+    "print(f'Catalog contains {len(catalog)} bearings:')\n",
+    "for b in catalog[:5]:\n",
+    "    print(f'  {b}')\n",
+    "print(f'  ... and {len(catalog)-5} more')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look up a specific bearing\n",
+    "bearing = lookup_bearing('6205')\n",
+    "if bearing:\n",
+    "    print(f'Bearing: {bearing.get(\"designation\", \"6205\")}')\n",
+    "    for k, v in bearing.items():\n",
+    "        if k != 'designation':\n",
+    "            print(f'  {k}: {v}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Compute Fault Frequencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rpm = 1800  # shaft speed\n",
+    "\n",
+    "freqs = compute_fault_frequencies('6205', rpm)\n",
+    "if freqs:\n",
+    "    print(f'Fault frequencies at {rpm} RPM:')\n",
+    "    for name, val in freqs.items():\n",
+    "        if isinstance(val, (int, float)):\n",
+    "            print(f'  {name}: {val:.2f} Hz')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Generate a Faulty Signal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs = 10000\n",
+    "duration = 2.0\n",
+    "t = np.arange(0, duration, 1/fs)\n",
+    "\n",
+    "# Use actual BPFO from catalog\n",
+    "bpfo = freqs['BPFO'] if freqs else 120.0\n",
+    "f_shaft = rpm / 60.0\n",
+    "\n",
+    "# Outer race fault signal\n",
+    "signal = (\n",
+    "    0.3 * np.sin(2 * np.pi * f_shaft * t)\n",
+    "    + 0.4 * np.sin(2 * np.pi * bpfo * t)\n",
+    "    + 0.2 * np.sin(2 * np.pi * 2 * bpfo * t)\n",
+    "    + 0.1 * np.sin(2 * np.pi * 3 * bpfo * t)\n",
+    "    + 0.15 * np.random.randn(len(t))\n",
+    ")\n",
+    "\n",
+    "print(f'Synthetic outer race fault signal: {len(signal)} samples')\n",
+    "print(f'BPFO = {bpfo:.2f} Hz, shaft = {f_shaft:.1f} Hz')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Envelope Spectrum Analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from predictive_maintenance_mcp.signal_processing import compute_envelope_spectrum\n",
+    "\n",
+    "env = compute_envelope_spectrum(signal, fs, frequency_range=(50, 4000), num_peaks=15)\n",
+    "\n",
+    "print('Envelope spectrum peaks:')\n",
+    "for i, peak in enumerate(env['top_peaks'][:8], 1):\n",
+    "    # Check if near a fault frequency\n",
+    "    note = ''\n",
+    "    if freqs:\n",
+    "        for name, fval in freqs.items():\n",
+    "            if isinstance(fval, (int, float)) and abs(peak['frequency_hz'] - fval) / fval < 0.05:\n",
+    "                note = f'  <-- {name}'\n",
+    "                break\n",
+    "        for n in range(2, 4):\n",
+    "            if isinstance(freqs.get('BPFO'), (int, float)):\n",
+    "                if abs(peak['frequency_hz'] - n * freqs['BPFO']) / (n * freqs['BPFO']) < 0.05:\n",
+    "                    note = f'  <-- {n}x BPFO'\n",
+    "    print(f'  {i}. {peak[\"frequency_hz\"]:8.2f} Hz  ({peak[\"magnitude_db\"]:+.1f} dB){note}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Fault Detection with Confidence Scoring"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from predictive_maintenance_mcp.diagnostics import check_all_bearing_faults\n",
+    "\n",
+    "faults = check_all_bearing_faults(signal, fs, bearing_id='6205', rpm=rpm)\n",
+    "\n",
+    "print(f'Bearing fault check results ({len(faults)} fault types):')\n",
+    "for fault in faults:\n",
+    "    status = 'DETECTED' if fault.get('detected') else 'not detected'\n",
+    "    conf = fault.get('confidence', 'N/A')\n",
+    "    print(f'  {fault[\"fault_type\"]:15s}: {status} (confidence: {conf})')\n",
+    "    if fault.get('detected'):\n",
+    "        print(f'    Expected freq: {fault.get(\"expected_frequency\", \"?\")} Hz')\n",
+    "        print(f'    Peak amplitude: {fault.get(\"peak_amplitude\", \"?\")}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated:\n",
+    "1. Looking up bearing specs from the 22+ bearing catalog\n",
+    "2. Computing characteristic fault frequencies (BPFO, BPFI, BSF, FTF)\n",
+    "3. Envelope spectrum analysis to reveal fault-related frequencies\n",
+    "4. Automated fault detection with confidence scoring\n",
+    "\n",
+    "**Next**: See `03_condition_monitoring.ipynb` for the full diagnosis pipeline."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/03_condition_monitoring.ipynb
+++ b/notebooks/03_condition_monitoring.ipynb
@@ -1,0 +1,225 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Condition Monitoring: Full Diagnosis Pipeline\n",
+    "\n",
+    "This notebook demonstrates the integrated diagnosis pipeline that combines:\n",
+    "- FFT spectral analysis\n",
+    "- Power Spectral Density (Welch)\n",
+    "- STFT time-frequency analysis\n",
+    "- Bearing fault detection\n",
+    "- ISO 10816 severity assessment\n",
+    "- Anomaly detection (OneClassSVM)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from pathlib import Path\n",
+    "import sys, os\n",
+    "\n",
+    "project_root = Path('.').resolve().parent\n",
+    "sys.path.insert(0, str(project_root / 'src'))\n",
+    "os.chdir(project_root)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Create Test Signals (Healthy + Faulty)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs = 10000\n",
+    "duration = 2.0\n",
+    "t = np.arange(0, duration, 1/fs)\n",
+    "rpm = 1800\n",
+    "f_shaft = rpm / 60.0\n",
+    "\n",
+    "# Healthy signal: shaft + noise\n",
+    "healthy = (\n",
+    "    0.3 * np.sin(2 * np.pi * f_shaft * t)\n",
+    "    + 0.1 * np.sin(2 * np.pi * 2 * f_shaft * t)\n",
+    "    + 0.15 * np.random.randn(len(t))\n",
+    ")\n",
+    "\n",
+    "# Faulty signal: shaft + bearing fault + noise\n",
+    "bpfo = 120.0\n",
+    "faulty = (\n",
+    "    0.3 * np.sin(2 * np.pi * f_shaft * t)\n",
+    "    + 0.5 * np.sin(2 * np.pi * bpfo * t)\n",
+    "    + 0.25 * np.sin(2 * np.pi * 2 * bpfo * t)\n",
+    "    + 0.1 * np.sin(2 * np.pi * 3 * bpfo * t)\n",
+    "    + 0.2 * np.random.randn(len(t))\n",
+    ")\n",
+    "\n",
+    "print(f'Created healthy signal: RMS = {np.sqrt(np.mean(healthy**2)):.4f}')\n",
+    "print(f'Created faulty signal:  RMS = {np.sqrt(np.mean(faulty**2)):.4f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Run Full Diagnosis Pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from predictive_maintenance_mcp.decision_support import diagnose_vibration\n",
+    "\n",
+    "# Diagnose the healthy signal\n",
+    "healthy_diag = diagnose_vibration(\n",
+    "    signal=healthy, fs=fs, rpm=rpm,\n",
+    "    machine_class='II', signal_unit='g'\n",
+    ")\n",
+    "\n",
+    "print('=== HEALTHY SIGNAL DIAGNOSIS ===')\n",
+    "print(f'Overall: {healthy_diag.get(\"overall_condition\", \"N/A\")}')\n",
+    "print(f'Confidence: {healthy_diag.get(\"confidence\", \"N/A\")}')\n",
+    "print(f'ISO Zone: {healthy_diag.get(\"iso_severity\", {}).get(\"zone\", \"N/A\")}')\n",
+    "if healthy_diag.get('recommendations'):\n",
+    "    print('Recommendations:')\n",
+    "    for r in healthy_diag['recommendations'][:3]:\n",
+    "        print(f'  - {r}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Diagnose the faulty signal\n",
+    "faulty_diag = diagnose_vibration(\n",
+    "    signal=faulty, fs=fs, rpm=rpm,\n",
+    "    bearing_id='6205',\n",
+    "    machine_class='II', signal_unit='g'\n",
+    ")\n",
+    "\n",
+    "print('=== FAULTY SIGNAL DIAGNOSIS ===')\n",
+    "print(f'Overall: {faulty_diag.get(\"overall_condition\", \"N/A\")}')\n",
+    "print(f'Confidence: {faulty_diag.get(\"confidence\", \"N/A\")}')\n",
+    "print(f'ISO Zone: {faulty_diag.get(\"iso_severity\", {}).get(\"zone\", \"N/A\")}')\n",
+    "\n",
+    "# Bearing faults found\n",
+    "bearing_results = faulty_diag.get('bearing_faults', [])\n",
+    "if bearing_results:\n",
+    "    print(f'\\nBearing faults detected ({len(bearing_results)}):')\n",
+    "    for fault in bearing_results:\n",
+    "        if fault.get('detected'):\n",
+    "            print(f'  {fault[\"fault_type\"]}: confidence={fault.get(\"confidence\", \"?\")}')\n",
+    "\n",
+    "if faulty_diag.get('recommendations'):\n",
+    "    print('\\nRecommendations:')\n",
+    "    for r in faulty_diag['recommendations'][:5]:\n",
+    "        print(f'  - {r}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Compare Spectral Signatures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from predictive_maintenance_mcp.signal_processing import compute_psd\n",
+    "\n",
+    "healthy_psd = compute_psd(healthy, fs, nperseg=1024, num_peaks=5)\n",
+    "faulty_psd = compute_psd(faulty, fs, nperseg=1024, num_peaks=5)\n",
+    "\n",
+    "print('Healthy PSD peaks:')\n",
+    "for p in healthy_psd['top_peaks']:\n",
+    "    print(f'  {p[\"frequency_hz\"]:8.2f} Hz  ({p[\"magnitude_db\"]:+.1f} dB)')\n",
+    "\n",
+    "print(f'\\nFaulty PSD peaks:')\n",
+    "for p in faulty_psd['top_peaks']:\n",
+    "    print(f'  {p[\"frequency_hz\"]:8.2f} Hz  ({p[\"magnitude_db\"]:+.1f} dB)')\n",
+    "\n",
+    "print(f'\\nPower ratio (faulty/healthy): {faulty_psd[\"total_power\"] / healthy_psd[\"total_power\"]:.2f}x')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: ISO 10816 Comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from predictive_maintenance_mcp.diagnostics import assess_vibration_severity\n",
+    "\n",
+    "h_sev = assess_vibration_severity(healthy, fs, machine_class='II', signal_unit='g')\n",
+    "f_sev = assess_vibration_severity(faulty, fs, machine_class='II', signal_unit='g')\n",
+    "\n",
+    "print(f'{\"Signal\":>10s} | {\"Zone\":>6s} | {\"Severity\":>15s} | {\"Vel RMS (mm/s)\":>14s}')\n",
+    "print('-' * 55)\n",
+    "print(f'{\"Healthy\":>10s} | {h_sev[\"zone\"]:>6s} | {h_sev[\"severity\"]:>15s} | {h_sev[\"velocity_rms_mm_s\"]:>14.2f}')\n",
+    "print(f'{\"Faulty\":>10s} | {f_sev[\"zone\"]:>6s} | {f_sev[\"severity\"]:>15s} | {f_sev[\"velocity_rms_mm_s\"]:>14.2f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated the complete condition monitoring workflow:\n",
+    "\n",
+    "1. **Signal comparison**: Healthy vs faulty signals side-by-side\n",
+    "2. **Integrated diagnosis**: `diagnose_vibration()` combines FFT + PSD + STFT + bearing + ISO\n",
+    "3. **Spectral signatures**: PSD reveals fault-related frequency components\n",
+    "4. **ISO severity**: Quantitative assessment against international standards\n",
+    "\n",
+    "### Architecture\n",
+    "\n",
+    "All processing follows the ISO 13374 6-block architecture:\n",
+    "- **Block 1** (`signal_acquisition`): Load and cache signals\n",
+    "- **Block 2** (`signal_processing`): Spectral analysis\n",
+    "- **Blocks 3-4** (`diagnostics`): Fault detection + severity\n",
+    "- **Block 6** (`decision_support`): Integrated diagnosis"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ packages = [
     "predictive_maintenance_mcp.diagnostics",
     "predictive_maintenance_mcp.decision_support",
     "predictive_maintenance_mcp.prognostics",
+    "predictive_maintenance_mcp.mcp_tools",
 ]
 
 [tool.setuptools.package-dir]
@@ -82,6 +83,7 @@ predictive_maintenance_mcp = "src"
 "predictive_maintenance_mcp.signal_processing" = "src/signal_processing"
 "predictive_maintenance_mcp.diagnostics" = "src/diagnostics"
 "predictive_maintenance_mcp.decision_support" = "src/decision_support"
+"predictive_maintenance_mcp.mcp_tools" = "src/mcp_tools"
 "predictive_maintenance_mcp.prognostics" = "src/prognostics"
 
 [project.optional-dependencies]

--- a/src/mcp_tools/__init__.py
+++ b/src/mcp_tools/__init__.py
@@ -1,0 +1,16 @@
+"""MCP tool modules organized by ISO 13374 blocks."""
+
+from . import acquisition_tools  # noqa: F401
+from . import analysis_tools  # noqa: F401
+from . import diagnostics_tools  # noqa: F401
+from . import report_tools  # noqa: F401
+from . import prompts  # noqa: F401
+
+
+def register_all(mcp):
+    """Register all MCP tools, resources, and prompts on the server."""
+    acquisition_tools.register(mcp)
+    analysis_tools.register(mcp)
+    diagnostics_tools.register(mcp)
+    report_tools.register(mcp)
+    prompts.register(mcp)

--- a/src/mcp_tools/acquisition_tools.py
+++ b/src/mcp_tools/acquisition_tools.py
@@ -1,0 +1,530 @@
+"""MCP tools for signal acquisition and data management (ISO 13374 Block 1)."""
+
+import logging
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+from mcp.server.fastmcp import FastMCP, Context
+
+from ..config import DATA_DIR, MODELS_DIR, RESOURCES_DIR, REPORTS_DIR
+from ..signal_loader import load_signal_data, SUPPORTED_EXTENSIONS, get_metadata_path
+from ..signal_repository import get_repository
+from ..models import StoredSignalInfo, SignalInfo
+from ..document_reader import extract_text_from_pdf
+
+logger = logging.getLogger(__name__)
+
+
+async def load_and_validate_metadata(
+    ctx: Context,
+    filename: str,
+    provided_sampling_rate: Optional[float],
+    default_sampling_rate: float,
+    provided_segment_duration: Optional[float],
+    default_segment_duration: float
+) -> tuple[float, float]:
+    """
+    Load metadata and validate/confirm analysis parameters with user.
+
+    Critical parameter validation strategy:
+    1. SAMPLING RATE:
+       - Check metadata file first
+       - If metadata exists: use it, notify user
+       - If no metadata AND user provided: use user value, warn no verification
+       - If no metadata AND no user input: CRITICAL WARNING, ask user to confirm
+
+    2. SEGMENT DURATION:
+       - Always notify user of value being used
+       - Suggest they can modify if needed
+
+    Args:
+        ctx: MCP context for user communication
+        filename: Signal filename
+        provided_sampling_rate: Sampling rate provided by user (None if using default)
+        default_sampling_rate: Default sampling rate (e.g., 1000.0)
+        provided_segment_duration: Segment duration provided by user (None if using default)
+        default_segment_duration: Default segment duration (e.g., 1.0)
+
+    Returns:
+        Tuple of (validated_sampling_rate, validated_segment_duration)
+    """
+    filepath = DATA_DIR / filename
+    metadata_file = filepath.parent / (filepath.stem + "_metadata.json")
+
+    # Initialize with provided or default values
+    sampling_rate = provided_sampling_rate if provided_sampling_rate is not None else default_sampling_rate
+    segment_duration = provided_segment_duration if provided_segment_duration is not None else default_segment_duration
+
+    # Check if user explicitly provided values (not using defaults)
+    user_provided_sampling_rate = (provided_sampling_rate is not None and provided_sampling_rate != default_sampling_rate)
+    user_provided_segment_duration = (provided_segment_duration is not None and provided_segment_duration != default_segment_duration)
+
+    # STEP 1: Validate SAMPLING RATE (CRITICAL)
+    metadata_found = False
+    if metadata_file.exists():
+        import json
+        with open(metadata_file, 'r') as f:
+            metadata = json.load(f)
+            if 'sampling_rate' in metadata:
+                metadata_sampling_rate = metadata['sampling_rate']
+                metadata_found = True
+
+                if user_provided_sampling_rate and abs(sampling_rate - metadata_sampling_rate) > 0.1:
+                    # User provided DIFFERENT value than metadata
+                    await ctx.info(f"⚠️  CONFLICT: User provided {sampling_rate} Hz, but metadata says {metadata_sampling_rate} Hz")
+                    await ctx.info(f"   Using METADATA value: {metadata_sampling_rate} Hz (more reliable)")
+                    sampling_rate = metadata_sampling_rate
+                else:
+                    # Metadata found, use it
+                    await ctx.info(f"✅ Metadata found: sampling_rate = {metadata_sampling_rate} Hz")
+                    sampling_rate = metadata_sampling_rate
+
+    # CRITICAL: No metadata found
+    if not metadata_found:
+        if user_provided_sampling_rate:
+            # User provided value, no metadata to verify
+            await ctx.info(f"📌 Using user-provided sampling_rate = {sampling_rate} Hz")
+            await ctx.info(f"   ⚠️  No metadata file to verify - cannot confirm correctness")
+        else:
+            # NO metadata, NO user input - CRITICAL!
+            await ctx.info(f"")
+            await ctx.info(f"❌ CRITICAL: No metadata found and no sampling_rate provided!")
+            await ctx.info(f"")
+            await ctx.info(f"   File: {filename}")
+            await ctx.info(f"   Expected metadata: {metadata_file.name}")
+            await ctx.info(f"")
+            await ctx.info(f"   Sampling rate is CRITICAL for frequency analysis accuracy.")
+            await ctx.info(f"   Using default {sampling_rate} Hz may give COMPLETELY WRONG results!")
+            await ctx.info(f"")
+            await ctx.info(f"⚠️  PLEASE CONFIRM:")
+            await ctx.info(f"   • Do you know the sampling rate for '{filename}'?")
+            await ctx.info(f"   • If YES: Please provide sampling_rate parameter and re-run")
+            await ctx.info(f"   • If NO: Results will be UNRELIABLE - interpretation requires caution")
+            await ctx.info(f"")
+            await ctx.info(f"⚠️  PROCEEDING WITH DEFAULT {sampling_rate} Hz (likely incorrect!)")
+            await ctx.info(f"")
+
+    # STEP 2: Validate SEGMENT DURATION (important but less critical)
+    if user_provided_segment_duration:
+        await ctx.info(f"📊 Using segment_duration = {segment_duration}s (user-provided)")
+    else:
+        await ctx.info(f"📊 Using segment_duration = {segment_duration}s (default)")
+        await ctx.info(f"   💡 You can modify by providing segment_duration parameter")
+
+    # Calculate signal info
+    try:
+        signal_data = load_signal_data(filename)
+        if signal_data is None:
+            raise ValueError(f"Could not load signal data from: {filename}")
+        signal_duration_sec = len(signal_data) / sampling_rate
+        await ctx.info(f"")
+        await ctx.info(f"📏 Signal info: {len(signal_data)} samples, {signal_duration_sec:.2f}s duration at {sampling_rate} Hz")
+
+        if segment_duration is not None and segment_duration < signal_duration_sec:
+            await ctx.info(f"   Analyzing {segment_duration}s segment from {signal_duration_sec:.2f}s total")
+        else:
+            await ctx.info(f"   Analyzing full signal")
+        await ctx.info(f"")
+    except Exception as e:
+        logger.warning(f"Could not load signal for info: {e}")
+
+    return sampling_rate, segment_duration
+
+
+def register(mcp: FastMCP) -> None:
+    """Register acquisition tools and resources on the given FastMCP instance."""
+
+    # ------------------------------------------------------------------
+    # RESOURCES
+    # ------------------------------------------------------------------
+
+    @mcp.resource("signal://list")
+    def list_available_signals() -> str:
+        """
+        List all available signals in the data/signals directory.
+
+        ⚠️ **CRITICAL - LLM Inference Policy:**
+        - Filenames are OPAQUE IDENTIFIERS ONLY
+        - NEVER infer signal content, fault type, or condition from filename
+        - "baseline" in filename ≠ healthy signal
+        - "InnerRaceFault" in filename ≠ inner race fault exists
+        - "OuterRaceFault" in filename ≠ outer race fault exists
+        - Filenames may be misleading or incorrect
+        - Base ALL analysis on signal data evidence ONLY
+
+        Returns:
+            JSON with the list of available signal files
+        """
+        try:
+            if not DATA_DIR.exists():
+                DATA_DIR.mkdir(parents=True, exist_ok=True)
+                return "[]"
+
+            signals = []
+            for file_path in DATA_DIR.glob("**/*"):
+                if file_path.is_file() and file_path.suffix in SUPPORTED_EXTENSIONS:
+                    signals.append({
+                        "filename": str(file_path.relative_to(DATA_DIR)).replace("\\", "/"),
+                        "path": str(file_path),
+                        "size_bytes": file_path.stat().st_size,
+                        "extension": file_path.suffix
+                    })
+
+            # Prepend critical warning to output
+            warning = (
+                "\n⚠️  CRITICAL: Filenames are OPAQUE IDENTIFIERS ONLY\n"
+                "DO NOT infer fault type, condition, or signal characteristics from filenames.\n"
+                "Filenames like 'baseline', 'InnerRaceFault', 'OuterRaceFault' may be MISLEADING.\n"
+                "Base ALL diagnostics on signal data analysis ONLY.\n\n"
+            )
+
+            return warning + pd.DataFrame(signals).to_json(orient="records", indent=2)
+
+        except Exception as e:
+            logger.error(f"Error listing signals: {e}")
+            return f'{{"error": "{str(e)}"}}'
+
+    @mcp.resource("signal://read/{filename}")
+    def read_signal_file(filename: str) -> str:
+        """
+        Read a signal file and return metadata summary.
+
+        Supports formats: CSV, TXT, NPY, MAT (MATLAB), WAV (audio), Parquet
+
+        NOTE: Returns metadata and statistics only — raw samples are NOT included
+        to avoid context overflow. Use plot_signal() for visual inspection or
+        load the signal in analysis tools (analyze_fft, analyze_envelope, etc.).
+
+        Args:
+            filename: Name of the file to read
+
+        Returns:
+            JSON with signal metadata and basic statistics (no raw data)
+        """
+        try:
+            file_path = DATA_DIR / filename
+
+            if not file_path.exists():
+                return f'{{"error": "File {filename} not found"}}'
+
+            # Use the unified loader for all supported formats
+            signal_array = load_signal_data(filename)
+
+            if signal_array is None:
+                return f'{{"error": "Could not load signal from {filename}. Unsupported format or read error."}}'
+
+            # Return metadata + statistics, NOT raw samples
+            rms = float(np.sqrt(np.mean(signal_array**2)))
+            result = {
+                "filename": filename,
+                "num_samples": len(signal_array),
+                "duration_hint": f"{len(signal_array)} samples (provide sampling_rate for duration in seconds)",
+                "statistics": {
+                    "rms": round(rms, 6),
+                    "peak": round(float(np.max(np.abs(signal_array))), 6),
+                    "mean": round(float(np.mean(signal_array)), 6),
+                    "std": round(float(np.std(signal_array)), 6),
+                    "min": round(float(np.min(signal_array)), 6),
+                    "max": round(float(np.max(signal_array)), 6),
+                },
+                "note": "Raw samples not included — use analysis tools or plot_signal() for inspection."
+            }
+
+            return json.dumps(result, indent=2)
+
+        except Exception as e:
+            logger.error(f"Error reading signal {filename}: {e}")
+            return f'{{"error": "{str(e)}"}}'
+
+    @mcp.resource("manual://list")
+    def list_manuals_resource() -> str:
+        """
+        List all available machine manuals (PDF and TXT) as MCP resource.
+
+        **IMPORTANT - LLM Usage Guidelines:**
+        - This resource returns ONLY the list of available files
+        - DO NOT make assumptions about manual content without reading it
+        - DO NOT infer specifications from filenames alone
+        - To access manual content, use manual://read/{filename} resource
+        - If user asks about manual content, read it first before answering
+
+        Returns:
+            JSON with list of available manuals
+
+        Example usage in Claude:
+            "Show me what machine manuals are available"
+        """
+        manuals_dir = RESOURCES_DIR / "machine_manuals"
+        manuals = []
+
+        # Include both PDF and TXT files
+        for manual_file in list(manuals_dir.glob("*.pdf")) + list(manuals_dir.glob("*.txt")):
+            stat = manual_file.stat()
+            manuals.append({
+                "filename": manual_file.name,
+                "type": manual_file.suffix.upper()[1:],  # PDF or TXT
+                "size_mb": round(stat.st_size / (1024 * 1024), 2),
+                "uri": f"manual://read/{manual_file.name}"
+            })
+
+        result = {
+            "total_manuals": len(manuals),
+            "manuals": sorted(manuals, key=lambda x: x['filename']),
+            "directory": str(manuals_dir.relative_to(RESOURCES_DIR.parent))
+        }
+
+        return json.dumps(result, indent=2)
+
+    @mcp.resource("manual://read/{filename}")
+    def read_manual_resource(filename: str) -> str:
+        """
+        Read machine manual (PDF or TXT) as text (MCP resource).
+
+        Extracts text from first 20 pages (PDF) or full text (TXT) to avoid token overflow.
+        For full manual, use read_manual_excerpt() tool with custom max_pages.
+
+        **IMPORTANT - LLM Usage Guidelines:**
+        - This resource returns ONLY the text from the manual file
+        - Base ALL answers EXCLUSIVELY on the returned text content
+        - DO NOT add information not present in the text
+        - DO NOT make assumptions about missing information
+        - If something is not in the text, say "Not found in the manual"
+        - ALWAYS cite the manual when answering: "According to {filename}..."
+        - If user needs complete manual, use read_manual_excerpt() tool
+
+        Args:
+            filename: Manual filename in resources/machine_manuals/ (PDF or TXT)
+
+        Returns:
+            Extracted text from manual
+
+        Example usage in Claude:
+            "Read the pump manual and tell me what bearings are specified"
+        """
+        try:
+            manual_path = RESOURCES_DIR / "machine_manuals" / filename
+
+            if not manual_path.exists():
+                return json.dumps({
+                    "error": f"Manual not found: {filename}",
+                    "available": [f.name for f in (RESOURCES_DIR / "machine_manuals").glob("*.pdf")] +
+                                [f.name for f in (RESOURCES_DIR / "machine_manuals").glob("*.txt")]
+                }, indent=2)
+
+            # Read based on file type
+            if manual_path.suffix.lower() == '.txt':
+                with open(manual_path, 'r', encoding='utf-8') as f:
+                    text = f.read()
+                pages_info = "full text file"
+            else:
+                # Extract text (limit to 20 pages to avoid token overflow)
+                text = extract_text_from_pdf(manual_path, max_pages=20)
+                pages_info = "first 20 pages"
+
+            result = {
+                "filename": filename,
+                "content_type": manual_path.suffix.lower(),
+                "pages_info": pages_info,
+                "text_length": len(text),
+                "text": text[:10000],  # First 10K chars
+                "note": f"Showing {pages_info}. Use read_manual_excerpt() tool for full access."
+            }
+
+            return json.dumps(result, indent=2)
+
+        except Exception as e:
+            logger.error(f"Error reading manual {filename}: {e}")
+            return json.dumps({"error": str(e)}, indent=2)
+
+    # ------------------------------------------------------------------
+    # TOOLS
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    def list_signals() -> str:
+        """
+        List all available signal files in the data/signals directory.
+
+        Returns:
+            A formatted text listing of all available signals
+        """
+        try:
+            if not DATA_DIR.exists():
+                return "No signals directory found"
+
+            signals = []
+            for file_path in DATA_DIR.glob("**/*"):
+                if file_path.is_file() and file_path.suffix in SUPPORTED_EXTENSIONS:
+                    relative_path = file_path.relative_to(DATA_DIR)
+                    signals.append(str(relative_path).replace("\\", "/"))
+
+            if not signals:
+                return "No signal files found"
+
+            # Group by directory
+            from collections import defaultdict
+            by_dir = defaultdict(list)
+            for sig in signals:
+                dir_name = sig.split('/')[0] if '/' in sig else "root"
+                by_dir[dir_name].append(sig)
+
+            # Format output
+            output = [f"Found {len(signals)} signal files:"]
+            for dir_name in sorted(by_dir.keys()):
+                files = by_dir[dir_name]
+                output.append(f"\n{dir_name}/ ({len(files)} files):")
+                for f in sorted(files):
+                    output.append(f"  - {f}")
+
+            return "\n".join(output)
+
+        except Exception as e:
+            return f"Error: {str(e)}"
+
+    @mcp.tool()
+    async def generate_test_signal(
+        signal_type: str = "bearing_fault",
+        duration: float = 10.0,
+        sampling_rate: float = 10000.0,
+        noise_level: float = 0.1,
+        ctx: Context = None
+    ) -> str:
+        """
+        Generate a test signal to validate analyses.
+
+        Useful for testing algorithms without having real data available.
+
+        Args:
+            signal_type: Signal type ("bearing_fault", "gear_fault", "imbalance", "normal")
+            duration: Signal duration in seconds (default: 10.0, gives 0.1 Hz frequency resolution)
+            sampling_rate: Sampling frequency in Hz (default: 10000)
+            noise_level: Noise level to add (default: 0.1)
+            ctx: Context for logging
+
+        Returns:
+            Generated file name
+        """
+        if ctx:
+            await ctx.info(f"Generating {signal_type} test signal...")
+
+        # Time parameters
+        t = np.linspace(0, duration, int(sampling_rate * duration))
+
+        # Generate signal based on type
+        if signal_type == "bearing_fault":
+            # Faulty bearing: periodic impulses + harmonics
+            fault_freq = 10.0  # Hz - fault frequency
+            carrier_freq = 1000.0  # Hz - carrier frequency
+
+            # Periodic impulses
+            impulses = np.zeros_like(t)
+            impulse_times = np.arange(0, duration, 1/fault_freq)
+            for imp_time in impulse_times:
+                idx = np.argmin(np.abs(t - imp_time))
+                impulses[idx] = 1.0
+
+            # Convolution with impulse response
+            impulse_response = np.exp(-50 * np.abs(t - t[len(t)//2]))
+            signal_clean = np.convolve(impulses, impulse_response, mode='same')
+
+            # Modulation with carrier
+            signal_clean = signal_clean * np.sin(2 * np.pi * carrier_freq * t)
+
+        elif signal_type == "gear_fault":
+            # Faulty gear: component at mesh frequency
+            mesh_freq = 200.0  # Hz
+            signal_clean = np.sin(2 * np.pi * mesh_freq * t)
+            # Add harmonics
+            signal_clean += 0.5 * np.sin(2 * np.pi * 2 * mesh_freq * t)
+            signal_clean += 0.3 * np.sin(2 * np.pi * 3 * mesh_freq * t)
+
+        elif signal_type == "imbalance":
+            # Imbalance: 1x RPM component
+            rpm = 1500  # RPM
+            rotation_freq = rpm / 60.0  # Hz
+            signal_clean = np.sin(2 * np.pi * rotation_freq * t)
+
+        else:  # "normal"
+            # Normal signal: broadband noise only
+            signal_clean = np.random.randn(len(t)) * 0.1
+
+        # Add noise
+        noise = np.random.randn(len(t)) * noise_level
+        signal_data = signal_clean + noise
+
+        # Save the signal
+        filename = f"test_{signal_type}_{int(sampling_rate)}Hz.csv"
+        filepath = DATA_DIR / filename
+
+        # Ensure directory exists
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+        # Save as CSV
+        pd.DataFrame(signal_data, columns=["amplitude"]).to_csv(filepath, index=False, header=False)
+
+        if ctx:
+            await ctx.info(f"Test signal saved to {filename}")
+            await ctx.info(f"Signal type: {signal_type}, Duration: {duration}s, Fs: {sampling_rate}Hz")
+
+        return f"Successfully generated test signal: {filename}"
+
+    @mcp.tool()
+    async def load_signal(
+        ctx: Context,
+        filepath: str,
+        signal_id: Optional[str] = None,
+        sampling_rate: Optional[float] = None,
+    ) -> StoredSignalInfo:
+        """Load a signal into the in-memory repository for fast repeated access.
+
+        Once loaded, reference the signal by its signal_id in other tools like
+        compute_power_spectral_density, diagnose_vibration, etc.
+
+        Args:
+            filepath: Filename relative to data/signals/, or absolute path.
+            signal_id: Custom ID (defaults to filename stem).
+            sampling_rate: Sampling rate in Hz (overrides metadata file).
+        """
+        repo = get_repository()
+        info = repo.load_signal(filepath, signal_id=signal_id, sampling_rate=sampling_rate)
+        if ctx:
+            await ctx.info(f"Loaded signal '{info['signal_id']}': {info['num_samples']} samples, {info['size_bytes'] / 1024:.1f} KB")
+        return StoredSignalInfo(**info)
+
+    @mcp.tool()
+    async def list_stored_signals(ctx: Context) -> list[StoredSignalInfo]:
+        """List all signals currently cached in the in-memory repository."""
+        repo = get_repository()
+        signals = repo.list_signals()
+        if ctx:
+            await ctx.info(f"{len(signals)} signal(s) in repository")
+        return [StoredSignalInfo(**s) for s in signals]
+
+    @mcp.tool()
+    async def get_signal_info(ctx: Context, signal_id: str) -> StoredSignalInfo:
+        """Get metadata for a stored signal without loading the full array."""
+        repo = get_repository()
+        info = repo.get_signal_info(signal_id)
+        return StoredSignalInfo(**info)
+
+    @mcp.tool()
+    async def clear_signal(ctx: Context, signal_id: str) -> dict[str, Any]:
+        """Remove a signal from the in-memory repository."""
+        repo = get_repository()
+        removed = repo.clear_signal(signal_id)
+        status = "removed" if removed else "not found"
+        if ctx:
+            await ctx.info(f"Signal '{signal_id}': {status}")
+        return {"signal_id": signal_id, "status": status}
+
+    @mcp.tool()
+    async def clear_all_signals(ctx: Context) -> dict[str, Any]:
+        """Clear all signals from the in-memory repository."""
+        repo = get_repository()
+        count = repo.clear_all()
+        if ctx:
+            await ctx.info(f"Cleared {count} signal(s) from repository")
+        return {"cleared_count": count}

--- a/src/mcp_tools/analysis_tools.py
+++ b/src/mcp_tools/analysis_tools.py
@@ -1,0 +1,941 @@
+"""MCP tools for signal analysis and spectral processing (ISO 13374 Block 2)."""
+
+import logging
+import json
+from pathlib import Path
+from typing import Any, Optional
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy import signal
+from scipy.fft import fft, fftfreq
+from scipy.signal import hilbert, butter, filtfilt, sosfiltfilt
+from scipy.stats import entropy
+from mcp.server.fastmcp import FastMCP, Context
+
+from ..config import DATA_DIR, MODELS_DIR
+from ..signal_loader import load_signal_data, get_metadata_path, SUPPORTED_EXTENSIONS
+from ..signal_repository import get_repository
+from ..models import (
+    FFTResult, SpectralPeak, EnvelopeResult, StatisticalResult, SignalInfo,
+    FeatureExtractionResult, PSDResult, STFTResult, EnvelopeSpectrumResult,
+    StoredSignalInfo
+)
+from ..spectral import (
+    compute_psd as _compute_psd,
+    compute_stft_spectrogram as _compute_stft,
+    compute_envelope_spectrum as _compute_envelope,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Helper functions (module-level, no MCP dependency)
+# ============================================================================
+
+
+def extract_time_domain_features(segment: np.ndarray) -> dict[str, float]:
+    """
+    Extract comprehensive time-domain features from a signal segment.
+
+    Args:
+        segment: 1D numpy array with signal segment
+
+    Returns:
+        Dictionary with 17 time-domain features
+    """
+    from scipy.stats import kurtosis, skew
+
+    # Basic statistics
+    mean_val = float(np.mean(segment))
+    std_val = float(np.std(segment))
+    var_val = float(np.var(segment))
+    mean_abs_val = float(np.mean(np.abs(segment)))
+
+    # RMS (Root Mean Square)
+    rms_val = float(np.sqrt(np.mean(segment**2)))
+
+    # Peak values
+    max_val = float(np.max(segment))
+    min_val = float(np.min(segment))
+    range_val = max_val - min_val
+
+    # Shape indicators
+    skewness_val = float(skew(segment))
+    kurtosis_val = float(kurtosis(segment, fisher=True))
+
+    # Avoid division by zero
+    if rms_val == 0:
+        rms_val = 1e-10
+    if mean_abs_val == 0:
+        mean_abs_val = 1e-10
+
+    # Dimensionless indicators
+    shape_factor_val = rms_val / mean_abs_val if mean_abs_val > 0 else 0.0
+    crest_factor_val = np.max(np.abs(segment)) / rms_val if rms_val > 0 else 0.0
+    impulse_factor_val = np.max(np.abs(segment)) / mean_abs_val if mean_abs_val > 0 else 0.0
+    clearance_factor_val = np.max(np.abs(segment)) / (np.mean(np.sqrt(np.abs(segment)))**2) if np.mean(np.sqrt(np.abs(segment))) > 0 else 0.0
+
+    # Energy and entropy
+    power_val = float(np.mean(segment**2))
+
+    # Entropy (probability distribution of signal amplitudes)
+    hist, _ = np.histogram(segment, bins=50, density=True)
+    hist = hist + 1e-10  # Avoid log(0)
+    entropy_val = float(entropy(hist))
+
+    # Zero crossing rate
+    zero_crossings = np.where(np.diff(np.sign(segment)))[0]
+    zero_crossing_rate_val = float(len(zero_crossings) / len(segment))
+
+    return {
+        'mean': mean_val,
+        'std': std_val,
+        'var': var_val,
+        'mean_abs': mean_abs_val,
+        'rms': rms_val,
+        'max': max_val,
+        'min': min_val,
+        'range': range_val,
+        'skewness': skewness_val,
+        'kurtosis': kurtosis_val,
+        'shape_factor': shape_factor_val,
+        'crest_factor': crest_factor_val,
+        'impulse_factor': impulse_factor_val,
+        'clearance_factor': clearance_factor_val,
+        'power': power_val,
+        'entropy': entropy_val,
+        'zero_crossing_rate': zero_crossing_rate_val
+    }
+
+
+def _resolve_sampling_rate(
+    signal_file: str,
+    sampling_rate: Optional[float],
+    strict: bool = True,
+) -> Optional[float]:
+    """
+    Resolve sampling rate for a signal file.
+
+    Priority: provided sampling_rate > metadata > error/None.
+
+    Args:
+        signal_file: Signal filename relative to DATA_DIR
+        sampling_rate: User-provided sampling rate (None = auto-detect)
+        strict: If True, raise on missing rate; if False, return None
+
+    Returns:
+        Resolved sampling rate, or None if strict=False and not found
+    """
+    if sampling_rate is not None:
+        return sampling_rate
+
+    metadata_path = get_metadata_path(signal_file)
+    if metadata_path.exists():
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+            rate = metadata.get("sampling_rate")
+            if rate is not None:
+                return rate
+
+    if strict:
+        raise ValueError(
+            f"No sampling rate found for {signal_file}. "
+            f"Please provide sampling_rate parameter or create "
+            f"{Path(signal_file).stem}_metadata.json with 'sampling_rate' field."
+        )
+    return None
+
+
+def _segment_and_extract_features(
+    signal_data: np.ndarray,
+    sampling_rate: float,
+    segment_duration: float,
+    overlap_ratio: float,
+) -> list[dict]:
+    """
+    Segment a signal and extract time-domain features from each segment.
+
+    Args:
+        signal_data: Raw signal array
+        sampling_rate: Sampling frequency in Hz
+        segment_duration: Duration of each segment in seconds
+        overlap_ratio: Overlap ratio between segments (0-1)
+
+    Returns:
+        List of feature dictionaries, one per segment
+    """
+    segment_length_samples = int(segment_duration * sampling_rate)
+    hop_length = int(segment_length_samples * (1 - overlap_ratio))
+    features_list = []
+
+    for start in range(0, len(signal_data) - segment_length_samples + 1, hop_length):
+        segment = signal_data[start:start + segment_length_samples]
+        features = extract_time_domain_features(segment)
+        features_list.append(features)
+
+    return features_list
+
+
+async def load_and_validate_metadata(
+    ctx: Context,
+    filename: str,
+    provided_sampling_rate: Optional[float],
+    default_sampling_rate: float,
+    provided_segment_duration: Optional[float],
+    default_segment_duration: float
+) -> tuple[float, float]:
+    """
+    Load metadata and validate/confirm analysis parameters with user.
+
+    Critical parameter validation strategy:
+    1. SAMPLING RATE:
+       - Check metadata file first
+       - If metadata exists: use it, notify user
+       - If no metadata AND user provided: use user value, warn no verification
+       - If no metadata AND no user input: CRITICAL WARNING, ask user to confirm
+
+    2. SEGMENT DURATION:
+       - Always notify user of value being used
+       - Suggest they can modify if needed
+
+    Args:
+        ctx: MCP context for user communication
+        filename: Signal filename
+        provided_sampling_rate: Sampling rate provided by user (None if using default)
+        default_sampling_rate: Default sampling rate (e.g., 1000.0)
+        provided_segment_duration: Segment duration provided by user (None if using default)
+        default_segment_duration: Default segment duration (e.g., 1.0)
+
+    Returns:
+        Tuple of (validated_sampling_rate, validated_segment_duration)
+    """
+    filepath = DATA_DIR / filename
+    metadata_file = filepath.parent / (filepath.stem + "_metadata.json")
+
+    # Initialize with provided or default values
+    sampling_rate = provided_sampling_rate if provided_sampling_rate is not None else default_sampling_rate
+    segment_duration = provided_segment_duration if provided_segment_duration is not None else default_segment_duration
+
+    # Check if user explicitly provided values (not using defaults)
+    user_provided_sampling_rate = (provided_sampling_rate is not None and provided_sampling_rate != default_sampling_rate)
+    user_provided_segment_duration = (provided_segment_duration is not None and provided_segment_duration != default_segment_duration)
+
+    # STEP 1: Validate SAMPLING RATE (CRITICAL)
+    metadata_found = False
+    if metadata_file.exists():
+        import json
+        with open(metadata_file, 'r') as f:
+            metadata = json.load(f)
+            if 'sampling_rate' in metadata:
+                metadata_sampling_rate = metadata['sampling_rate']
+                metadata_found = True
+
+                if user_provided_sampling_rate and abs(sampling_rate - metadata_sampling_rate) > 0.1:
+                    # User provided DIFFERENT value than metadata
+                    await ctx.info(f"⚠️  CONFLICT: User provided {sampling_rate} Hz, but metadata says {metadata_sampling_rate} Hz")
+                    await ctx.info(f"   Using METADATA value: {metadata_sampling_rate} Hz (more reliable)")
+                    sampling_rate = metadata_sampling_rate
+                else:
+                    # Metadata found, use it
+                    await ctx.info(f"✅ Metadata found: sampling_rate = {metadata_sampling_rate} Hz")
+                    sampling_rate = metadata_sampling_rate
+
+    # CRITICAL: No metadata found
+    if not metadata_found:
+        if user_provided_sampling_rate:
+            # User provided value, no metadata to verify
+            await ctx.info(f"📌 Using user-provided sampling_rate = {sampling_rate} Hz")
+            await ctx.info(f"   ⚠️  No metadata file to verify - cannot confirm correctness")
+        else:
+            # NO metadata, NO user input - CRITICAL!
+            await ctx.info(f"")
+            await ctx.info(f"❌ CRITICAL: No metadata found and no sampling_rate provided!")
+            await ctx.info(f"")
+            await ctx.info(f"   File: {filename}")
+            await ctx.info(f"   Expected metadata: {metadata_file.name}")
+            await ctx.info(f"")
+            await ctx.info(f"   Sampling rate is CRITICAL for frequency analysis accuracy.")
+            await ctx.info(f"   Using default {sampling_rate} Hz may give COMPLETELY WRONG results!")
+            await ctx.info(f"")
+            await ctx.info(f"⚠️  PLEASE CONFIRM:")
+            await ctx.info(f"   • Do you know the sampling rate for '{filename}'?")
+            await ctx.info(f"   • If YES: Please provide sampling_rate parameter and re-run")
+            await ctx.info(f"   • If NO: Results will be UNRELIABLE - interpretation requires caution")
+            await ctx.info(f"")
+            await ctx.info(f"⚠️  PROCEEDING WITH DEFAULT {sampling_rate} Hz (likely incorrect!)")
+            await ctx.info(f"")
+
+    # STEP 2: Validate SEGMENT DURATION (important but less critical)
+    if user_provided_segment_duration:
+        await ctx.info(f"📊 Using segment_duration = {segment_duration}s (user-provided)")
+    else:
+        await ctx.info(f"📊 Using segment_duration = {segment_duration}s (default)")
+        await ctx.info(f"   💡 You can modify by providing segment_duration parameter")
+
+    # Calculate signal info
+    try:
+        signal_data = load_signal_data(filename)
+        if signal_data is None:
+            raise ValueError(f"Could not load signal data from: {filename}")
+        signal_duration_sec = len(signal_data) / sampling_rate
+        await ctx.info(f"")
+        await ctx.info(f"📏 Signal info: {len(signal_data)} samples, {signal_duration_sec:.2f}s duration at {sampling_rate} Hz")
+
+        if segment_duration is not None and segment_duration < signal_duration_sec:
+            await ctx.info(f"   Analyzing {segment_duration}s segment from {signal_duration_sec:.2f}s total")
+        else:
+            await ctx.info(f"   Analyzing full signal")
+        await ctx.info(f"")
+    except Exception as e:
+        logger.warning(f"Could not load signal for info: {e}")
+
+    return sampling_rate, segment_duration
+
+
+# ============================================================================
+# Tool registration
+# ============================================================================
+
+
+def register(mcp: FastMCP) -> None:
+    """Register signal-analysis MCP tools on *mcp*."""
+
+    # -- lazy import; only needed inside tool bodies that call extract_segment
+    from ..signal_loader import extract_segment
+    from mcp.server.session import ServerSession
+
+    # ================================================================
+    # TOOLS - FFT ANALYSIS
+    # ================================================================
+
+    @mcp.tool()
+    async def analyze_fft(
+        ctx: Context,
+        filename: str,
+        sampling_rate: Optional[float] = None,
+        max_frequency: Optional[float] = None,
+        segment_duration: Optional[float] = None,
+        random_seed: Optional[int] = None
+    ) -> FFTResult:
+        """
+        Perform FFT (Fast Fourier Transform) analysis on a signal.
+
+        FFT analysis converts the signal from time domain to frequency domain,
+        allowing identification of harmonic components and faults that manifest
+        at specific frequencies.
+
+        By default, analyzes a RANDOM 1.0-second segment from the signal for efficiency.
+        Set segment_duration=None to analyze the entire signal.
+
+        **CRITICAL - LLM Inference Policy:**
+        - **NEVER infer fault type from filename** (e.g., "OuterRaceFault_1.csv" does NOT mean outer race fault exists)
+        - **NEVER assume signal characteristics from filename** (e.g., "baseline" does NOT mean healthy)
+        - Treat ALL filenames as opaque identifiers
+        - Base analysis ONLY on frequency spectrum data returned by this tool
+        - If filename suggests a characteristic but data shows otherwise, report the data findings
+
+        **CRITICAL - Parameter Validation:**
+        - Sampling rate is auto-detected from metadata if available
+        - If no metadata: user MUST provide sampling_rate or results will be UNRELIABLE
+        - Segment duration defaults to 1.0s but can be customized
+        - User will be notified of all assumptions before analysis proceeds
+
+        Args:
+            ctx: MCP context for user communication
+            filename: Name of the file containing the signal
+            sampling_rate: Sampling frequency in Hz (auto-detect from metadata if None)
+            max_frequency: Maximum frequency to analyze (default: Nyquist frequency)
+            segment_duration: Duration in seconds to analyze (default: 1.0s random segment).
+                             Set to None to analyze full signal.
+            random_seed: Random seed for reproducible segment selection (default: None = random)
+
+        Returns:
+            FFTResult with frequencies, magnitudes and dominant peak
+        """
+        # Validate and load metadata with user confirmation
+        sampling_rate, segment_duration = await load_and_validate_metadata(
+            ctx=ctx,
+            filename=filename,
+            provided_sampling_rate=sampling_rate,
+            default_sampling_rate=1000.0,
+            provided_segment_duration=segment_duration,
+            default_segment_duration=1.0
+        )
+
+        # Load data
+        signal_data = load_signal_data(filename)
+
+        if signal_data is None:
+            raise ValueError(f"Unable to load signal from {filename}")
+
+        # Extract segment if requested
+        full_signal_length = len(signal_data)
+        signal_duration_sec = full_signal_length / sampling_rate
+
+        if segment_duration is not None and segment_duration < signal_duration_sec:
+            signal_data = extract_segment(signal_data, segment_duration, sampling_rate, seed=random_seed)
+            logger.info(f"Analyzing {segment_duration}s random segment from {signal_duration_sec:.1f}s signal")
+        else:
+            logger.info(f"Analyzing full signal ({signal_duration_sec:.1f}s, {full_signal_length} samples)")
+
+        # Number of samples
+        N = len(signal_data)
+
+        # Apply Hamming window to reduce spectral leakage
+        window = np.hamming(N)
+        signal_windowed = signal_data * window
+
+        # Calculate FFT
+        fft_values = fft(signal_windowed)
+        frequencies = fftfreq(N, 1/sampling_rate)
+
+        # Take only positive frequencies (excluding DC component at index 0)
+        positive_freq_idx = frequencies > 0
+        frequencies = frequencies[positive_freq_idx]
+
+        # Correct normalization for single-sided spectrum:
+        # - Multiply by 2 (energy from negative frequencies)
+        # - Divide by N (FFT normalization)
+        # Note: DC component (freq=0) should not be multiplied by 2, but we exclude it with frequencies > 0
+        magnitudes = 2.0 * np.abs(fft_values[positive_freq_idx]) / N
+
+        # Apply maximum frequency limit if specified
+        if max_frequency is not None:
+            freq_limit_idx = frequencies <= max_frequency
+            frequencies = frequencies[freq_limit_idx]
+            magnitudes = magnitudes[freq_limit_idx]
+
+        # Find dominant peak
+        peak_idx = np.argmax(magnitudes)
+        peak_frequency = float(frequencies[peak_idx])
+        peak_magnitude = float(magnitudes[peak_idx])
+
+        # Calculate frequency resolution
+        frequency_resolution = sampling_rate / N
+
+        # Build compact summary: top N peaks + stats (no full arrays)
+        top_n = 20
+        max_mag = float(np.max(magnitudes)) if len(magnitudes) > 0 else 1e-12
+        order = np.argsort(magnitudes)[::-1]
+        n_peaks = min(top_n, len(order))
+        top_idx = np.sort(order[:n_peaks])  # sort back by frequency
+
+        top_peaks = []
+        for i in top_idx:
+            mag_val = float(magnitudes[i])
+            mag_db = float(20 * np.log10(max(mag_val, 1e-12) / max(max_mag, 1e-12)))
+            top_peaks.append(SpectralPeak(
+                frequency_hz=round(float(frequencies[i]), 3),
+                magnitude=round(mag_val, 6),
+                magnitude_db=round(mag_db, 2)
+            ))
+
+        rms_spectral = float(np.sqrt(np.mean(magnitudes**2)))
+
+        return FFTResult(
+            top_peaks=top_peaks,
+            peak_frequency=peak_frequency,
+            peak_magnitude=peak_magnitude,
+            rms_spectral=round(rms_spectral, 6),
+            total_bins=len(frequencies),
+            freq_range_hz=[round(float(frequencies[0]), 3), round(float(frequencies[-1]), 3)] if len(frequencies) > 0 else [0, 0],
+            sampling_rate=sampling_rate,
+            num_samples=N,
+            frequency_resolution=frequency_resolution
+        )
+
+    # ================================================================
+    # TOOLS - ENVELOPE ANALYSIS
+    # ================================================================
+
+    @mcp.tool()
+    async def analyze_envelope(
+        ctx: Context,
+        filename: str,
+        sampling_rate: Optional[float] = None,
+        filter_low: float = 500.0,
+        filter_high: float = 2000.0,
+        num_peaks: int = 5,
+        segment_duration: Optional[float] = None,
+        random_seed: Optional[int] = None
+    ) -> EnvelopeResult:
+        """
+        Perform Envelope Analysis to detect bearing faults.
+
+        Envelope analysis is particularly effective for detecting faults in ball/roller bearings.
+        The signal is high-pass filtered, then the envelope is calculated via Hilbert transform,
+        and finally the envelope spectrum is analyzed.
+
+        By default, analyzes a RANDOM 1.0-second segment from the signal for efficiency.
+        Set segment_duration=None to analyze the entire signal.
+
+        Returns ONLY peak information and diagnosis text (no full arrays) to avoid context overflow.
+
+        **CRITICAL - LLM Inference Policy:**
+        - **NEVER infer fault type from filename** (e.g., "OuterRaceFault_1.csv" does NOT mean outer race fault exists)
+        - **NEVER assume signal characteristics from filename** (e.g., "baseline" does NOT mean healthy)
+        - Treat ALL filenames as opaque identifiers
+        - Base diagnosis ONLY on frequency-domain evidence (peaks matching BPFO/BPFI/BSF/FTF)
+        - If filename suggests a fault but analysis shows no evidence, report "No fault detected despite filename"
+
+        **CRITICAL - Parameter Validation:**
+        - Sampling rate is auto-detected from metadata if available
+        - If no metadata: user MUST provide sampling_rate or results will be UNRELIABLE
+        - Segment duration defaults to 1.0s but can be customized
+        - User will be notified of all assumptions before analysis proceeds
+
+        Args:
+            ctx: MCP context for user communication
+            filename: Name of the file containing the signal
+            sampling_rate: Sampling frequency in Hz (auto-detect from metadata if None)
+            filter_low: Low frequency of bandpass filter in Hz (default: 500 Hz)
+            filter_high: High frequency of bandpass filter in Hz (default: 2000 Hz)
+            num_peaks: Number of main peaks to identify (default: 5)
+            segment_duration: Duration in seconds to analyze (default: 1.0s random segment).
+                             Set to None to analyze full signal.
+            random_seed: Random seed for reproducible segment selection (default: None = random)
+
+        Returns:
+            EnvelopeResult with peak information and diagnosis (optimized for chat display)
+        """
+        # Validate and load metadata with user confirmation
+        sampling_rate, segment_duration = await load_and_validate_metadata(
+            ctx=ctx,
+            filename=filename,
+            provided_sampling_rate=sampling_rate,
+            default_sampling_rate=1000.0,
+            provided_segment_duration=segment_duration,
+            default_segment_duration=1.0
+        )
+
+        # Load data
+        signal_data = load_signal_data(filename)
+
+        if signal_data is None:
+            raise ValueError(f"Unable to load signal from {filename}")
+
+        # Extract segment if requested
+        full_signal_length = len(signal_data)
+        signal_duration_sec = full_signal_length / sampling_rate
+
+        if segment_duration is not None and segment_duration < signal_duration_sec:
+            signal_data = extract_segment(signal_data, segment_duration, sampling_rate, seed=random_seed)
+            logger.info(f"Analyzing {segment_duration}s random segment from {signal_duration_sec:.1f}s signal")
+        else:
+            logger.info(f"Analyzing full signal ({signal_duration_sec:.1f}s, {full_signal_length} samples)")
+
+        # Design Butterworth bandpass filter using SOS (numerically stable)
+        nyquist = sampling_rate / 2
+        low = filter_low / nyquist
+        high = filter_high / nyquist
+
+        sos = butter(4, [low, high], btype='band', output='sos')
+
+        # Apply filter
+        filtered_signal = sosfiltfilt(sos, signal_data)
+
+        # Calculate envelope using Hilbert transform
+        analytic_signal = hilbert(filtered_signal)
+        envelope = np.abs(analytic_signal)
+
+        # Calculate envelope spectrum
+        N = len(envelope)
+        envelope_fft = fft(envelope)
+        envelope_frequencies = fftfreq(N, 1/sampling_rate)
+
+        # Take only positive frequencies
+        positive_idx = envelope_frequencies > 0
+        envelope_frequencies = envelope_frequencies[positive_idx]
+        envelope_magnitudes = np.abs(envelope_fft[positive_idx])
+
+        # Find main peaks using scipy.signal.find_peaks (same method as HTML reports)
+        from scipy.signal import find_peaks
+
+        # Convert to dB for prominence calculation
+        max_magnitude = np.max(envelope_magnitudes)
+        envelope_magnitudes_db = 20 * np.log10(np.maximum(envelope_magnitudes / max_magnitude, 1e-10))
+
+        # Find peaks with minimum prominence (at least 2 dB above surroundings)
+        # and minimum distance (avoid adjacent FFT bins of same peak)
+        freq_resolution = sampling_rate / N
+        min_distance_samples = max(1, int(1.0 / freq_resolution))  # At least 1 Hz spacing
+
+        peak_indices, _ = find_peaks(
+            envelope_magnitudes_db,
+            distance=min_distance_samples,
+            prominence=2  # At least 2 dB prominence
+        )
+
+        # Sort by magnitude and keep top num_peaks
+        if len(peak_indices) > num_peaks:
+            sorted_indices = np.argsort(envelope_magnitudes[peak_indices])[::-1]
+            peak_indices = peak_indices[sorted_indices[:num_peaks]]
+        elif len(peak_indices) == 0:
+            # Fallback: if no peaks found with find_peaks, use simple sorting
+            peak_indices = np.argsort(envelope_magnitudes)[-num_peaks:][::-1]
+
+        peak_frequencies = envelope_frequencies[peak_indices].tolist()
+        peak_magnitudes = envelope_magnitudes[peak_indices].tolist()
+
+        # Create diagnosis text
+        diagnosis_lines = [
+            f"Envelope Analysis Results:",
+            f"Filter band: {filter_low}-{filter_high} Hz",
+            f"",
+            f"Top {num_peaks} peaks in envelope spectrum:"
+        ]
+
+        for i, (freq, mag) in enumerate(zip(peak_frequencies, peak_magnitudes), 1):
+            diagnosis_lines.append(f"  {i}. {freq:7.2f} Hz  (magnitude: {mag:.2e})")
+
+        diagnosis_lines.extend([
+            "",
+            "Bearing frequency reference (example @ 1500 RPM):",
+            "  • BPFO (outer race): ~81.13 Hz",
+            "  • BPFI (inner race): ~118.88 Hz",
+            "  • BSF (ball spin):   ~63.91 Hz",
+            "  • FTF (cage):        ~14.84 Hz",
+            "",
+            "⚠️ Compare peaks above with actual bearing frequencies for your system.",
+            "💡 Use plot_envelope(...) for visual analysis and harmonic identification."
+        ])
+
+        diagnosis = "\n".join(diagnosis_lines)
+
+        # Small preview (first 100 points for hint/context)
+        preview_size = min(100, len(envelope_frequencies))
+
+        return EnvelopeResult(
+            num_samples=len(envelope),
+            sampling_rate=sampling_rate,
+            filter_band=(filter_low, filter_high),
+            peak_frequencies=peak_frequencies,
+            peak_magnitudes=peak_magnitudes,
+            diagnosis=diagnosis,
+            spectrum_preview_freq=envelope_frequencies[:preview_size].tolist(),
+            spectrum_preview_mag=envelope_magnitudes[:preview_size].tolist()
+        )
+
+    # ================================================================
+    # TOOLS - STATISTICAL ANALYSIS
+    # ================================================================
+
+    @mcp.tool()
+    def analyze_statistics(filename: str) -> StatisticalResult:
+        """
+        Calculate statistical parameters of the signal for diagnostics.
+
+        Statistical parameters are key indicators for diagnostics:
+        - RMS: Effective value, correlated to signal energy
+        - Crest Factor: Indicates presence of impulses (high = possible faults)
+        - Kurtosis: Measures impulsiveness (excess kurtosis; >0 = non-Gaussian, >3 = strong impulses)
+        - Peak-to-Peak: Signal range
+
+        **CRITICAL - LLM Inference Policy:**
+        - **NEVER infer fault type from filename** (e.g., "OuterRaceFault_1.csv" does NOT mean outer race fault exists)
+        - **NEVER assume signal characteristics from filename** (e.g., "baseline" does NOT mean healthy)
+        - Treat ALL filenames as opaque identifiers
+        - Statistical parameters (RMS/CF/Kurtosis) are indicators ONLY - NOT definitive diagnostics
+        - High kurtosis indicates "possible fault" - NOT "confirmed fault"
+        - Must be combined with frequency-domain evidence for diagnosis
+
+        Args:
+            filename: Name of the file containing the signal
+
+        Returns:
+            StatisticalResult with all statistical parameters
+        """
+        # Load data
+        signal_data = load_signal_data(filename)
+
+        if signal_data is None:
+            raise ValueError(f"Unable to load signal from {filename}")
+
+        # Calculate statistical parameters
+        rms = float(np.sqrt(np.mean(signal_data**2)))
+        peak = float(np.max(np.abs(signal_data)))
+        peak_to_peak = float(np.max(signal_data) - np.min(signal_data))
+        mean_val = float(np.mean(signal_data))
+        std_dev = float(np.std(signal_data))
+
+        # Crest Factor
+        crest_factor = peak / rms if rms > 0 else 0.0
+
+        # Kurtosis (using scipy)
+        from scipy.stats import kurtosis, skew
+        kurtosis_val = float(kurtosis(signal_data, fisher=True))  # Fisher=True for excess kurtosis
+        skewness_val = float(skew(signal_data))
+
+        # Auto-detect signal units based on RMS magnitude
+        # Heuristic: acceleration signals typically have RMS > 0.5 g
+        # velocity signals typically have RMS < 100 mm/s (usually 1-50 mm/s range)
+        if rms > 0.5:
+            detected_unit = "g (acceleration)"
+            unit_note = "⚠️ Signal detected as ACCELERATION in 'g' units. For ISO 20816-3 evaluation, use evaluate_iso_20816() which converts to velocity (mm/s)."
+        else:
+            detected_unit = "mm/s (velocity) or g (low-amplitude acceleration)"
+            unit_note = "💡 Signal has low amplitude. If this is acceleration in 'g', values are very low. If velocity in 'mm/s', this is typical for healthy machines."
+
+        return StatisticalResult(
+            rms=rms,
+            peak_to_peak=peak_to_peak,
+            peak=peak,
+            crest_factor=crest_factor,
+            kurtosis=kurtosis_val,
+            skewness=skewness_val,
+            mean=mean_val,
+            std_dev=std_dev,
+            detected_unit=detected_unit,
+            unit_note=unit_note
+        )
+
+    # ================================================================
+    # TOOLS - FEATURE EXTRACTION
+    # ================================================================
+
+    @mcp.tool()
+    async def extract_features_from_signal(
+        signal_file: str,
+        sampling_rate: Optional[float] = None,
+        segment_duration: float = 0.1,
+        overlap_ratio: float = 0.5,
+        ctx: Context = None
+    ) -> FeatureExtractionResult:
+        """
+        Extract time-domain features from signal using sliding window segmentation.
+
+        Segments the signal into overlapping windows and extracts 17 statistical features
+        from each segment. Features include: mean, std, RMS, kurtosis, crest factor, entropy, etc.
+
+        Args:
+            signal_file: Name of the CSV file in data/signals/
+            sampling_rate: Sampling frequency in Hz (auto-detect from metadata if None)
+            segment_duration: Duration of each segment in seconds (default: 0.1)
+            overlap_ratio: Overlap between segments, 0-1 (default: 0.5 = 50%)
+            ctx: MCP context for progress/logging
+
+        Returns:
+            FeatureExtractionResult with features matrix and metadata
+
+        Example:
+            extract_features_from_signal(
+                "healthy_motor.csv",
+                sampling_rate=10000,
+                segment_duration=0.2,
+                overlap_ratio=0.5
+            )
+        """
+        if ctx:
+            await ctx.info(f"Extracting features from {signal_file}...")
+
+        # Auto-detect sampling rate from metadata if not provided
+        if sampling_rate is None:
+            metadata_path = get_metadata_path(signal_file)
+            if metadata_path.exists():
+                with open(metadata_path) as f:
+                    metadata = json.load(f)
+                    sampling_rate = metadata.get("sampling_rate", 10000.0)
+                    if ctx:
+                        await ctx.info(f"Auto-detected sampling rate from metadata: {sampling_rate} Hz")
+            else:
+                sampling_rate = 10000.0  # fallback default
+                if ctx:
+                    await ctx.info(f"No metadata found, using default sampling rate: {sampling_rate} Hz")
+        else:
+            if ctx:
+                await ctx.info(f"Using specified sampling rate: {sampling_rate} Hz")
+
+        # Load signal
+        filepath = DATA_DIR / signal_file
+        if not filepath.exists():
+            raise FileNotFoundError(f"File not found: {signal_file}")
+
+        signal_data = load_signal_data(signal_file)
+        if signal_data is None:
+            raise ValueError(f"Could not load signal data from: {signal_file}")
+
+        # Calculate segment parameters
+        segment_length_samples = int(segment_duration * sampling_rate)
+        hop_length = int(segment_length_samples * (1 - overlap_ratio))
+
+        # Extract segments
+        segments = []
+        num_samples = len(signal_data)
+
+        for start in range(0, num_samples - segment_length_samples + 1, hop_length):
+            end = start + segment_length_samples
+            segment = signal_data[start:end]
+            segments.append(segment)
+
+        if ctx:
+            await ctx.info(f"Created {len(segments)} segments from signal")
+
+        # Extract features from each segment
+        features_list = []
+        for segment in segments:
+            features = extract_time_domain_features(segment)
+            features_list.append(features)
+
+        # Convert to DataFrame for easier handling
+        features_df = pd.DataFrame(features_list)
+        feature_names = list(features_df.columns)
+
+        # Save features to file
+        features_file = DATA_DIR / f"features_{signal_file}"
+        features_df.to_csv(features_file, index=False)
+
+        if ctx:
+            await ctx.info(f"Features saved to {features_file.name}")
+            await ctx.info(f"Feature matrix shape: {features_df.shape}")
+
+        return FeatureExtractionResult(
+            num_segments=len(segments),
+            segment_length_samples=segment_length_samples,
+            segment_duration_s=segment_duration,
+            overlap_ratio=overlap_ratio,
+            features_shape=list(features_df.shape),
+            feature_names=feature_names,
+            features_preview=[features_list[i] for i in range(min(5, len(features_list)))]
+        )
+
+    # ================================================================
+    # TOOLS - SPECTRAL ANALYSIS (Phase 1 — signal_id based)
+    # ================================================================
+
+    @mcp.tool()
+    async def compute_power_spectral_density(
+        ctx: Context,
+        signal_id: str,
+        nperseg: int = 256,
+        noverlap: int = 128,
+        window: str = "hann",
+    ) -> PSDResult:
+        """Compute Power Spectral Density (Welch method) for a stored signal.
+
+        Requires signal loaded via load_signal() first.
+
+        Args:
+            signal_id: ID of the stored signal.
+            nperseg: Samples per FFT segment (default 256).
+            noverlap: Overlap between segments (default 128).
+            window: Window function (default 'hann').
+        """
+        repo = get_repository()
+        signal_data = repo.get_signal(signal_id)
+        info = repo.get_signal_info(signal_id)
+        fs = info.get("sampling_rate")
+        if fs is None:
+            raise ValueError(f"No sampling_rate for signal '{signal_id}'. Re-load with sampling_rate parameter.")
+
+        if ctx:
+            await ctx.info(f"Computing PSD for '{signal_id}' ({info['num_samples']} samples, {fs} Hz)")
+
+        result = _compute_psd(signal_data, fs, nperseg=nperseg, noverlap=noverlap, window=window)
+
+        return PSDResult(
+            signal_id=signal_id,
+            num_samples=info["num_samples"],
+            sampling_rate=fs,
+            nperseg=nperseg,
+            noverlap=noverlap,
+            window=window,
+            top_peaks=[SpectralPeak(**p) for p in result["top_peaks"]],
+            total_power=result["total_power"],
+            freq_range_hz=result["freq_range_hz"],
+            frequency_resolution=result["frequency_resolution"],
+        )
+
+    @mcp.tool()
+    async def compute_spectrogram_stft(
+        ctx: Context,
+        signal_id: str,
+        nperseg: int = 256,
+        noverlap: int = 128,
+        window: str = "hann",
+    ) -> STFTResult:
+        """Compute STFT spectrogram for a stored signal.
+
+        Returns time-frequency summary (no full 2D array). Use for detecting
+        time-varying frequency content (transient faults, speed changes).
+
+        Args:
+            signal_id: ID of the stored signal.
+            nperseg: Samples per STFT segment (default 256).
+            noverlap: Overlap between segments (default 128).
+            window: Window function (default 'hann').
+        """
+        repo = get_repository()
+        signal_data = repo.get_signal(signal_id)
+        info = repo.get_signal_info(signal_id)
+        fs = info.get("sampling_rate")
+        if fs is None:
+            raise ValueError(f"No sampling_rate for signal '{signal_id}'.")
+
+        if ctx:
+            await ctx.info(f"Computing STFT for '{signal_id}'")
+
+        result = _compute_stft(signal_data, fs, nperseg=nperseg, noverlap=noverlap, window=window)
+
+        return STFTResult(
+            signal_id=signal_id,
+            num_samples=info["num_samples"],
+            sampling_rate=fs,
+            nperseg=nperseg,
+            noverlap=noverlap,
+            window=window,
+            num_time_bins=result["num_time_bins"],
+            num_freq_bins=result["num_freq_bins"],
+            freq_range_hz=result["freq_range_hz"],
+            time_range_s=result["time_range_s"],
+            max_power_freq_hz=result["max_power_freq_hz"],
+            max_power_time_s=result["max_power_time_s"],
+            energy_per_band=result["energy_per_band"],
+        )
+
+    @mcp.tool()
+    async def compute_envelope_spectrum_tool(
+        ctx: Context,
+        signal_id: str,
+        filter_low: float = 500.0,
+        filter_high: float = 5000.0,
+        method: str = "hilbert",
+    ) -> EnvelopeSpectrumResult:
+        """Compute envelope spectrum for a stored signal (signal_id pattern).
+
+        Use for bearing fault detection. The envelope spectrum reveals
+        modulation patterns caused by bearing defects.
+
+        Args:
+            signal_id: ID of the stored signal.
+            filter_low: Bandpass filter low frequency (Hz).
+            filter_high: Bandpass filter high frequency (Hz).
+            method: Envelope method (default 'hilbert').
+        """
+        repo = get_repository()
+        signal_data = repo.get_signal(signal_id)
+        info = repo.get_signal_info(signal_id)
+        fs = info.get("sampling_rate")
+        if fs is None:
+            raise ValueError(f"No sampling_rate for signal '{signal_id}'.")
+
+        if ctx:
+            await ctx.info(f"Computing envelope spectrum for '{signal_id}' ({filter_low}-{filter_high} Hz)")
+
+        result = _compute_envelope(
+            signal_data, fs,
+            frequency_range=(filter_low, filter_high),
+            method=method,
+        )
+
+        return EnvelopeSpectrumResult(
+            signal_id=signal_id,
+            num_samples=result["num_envelope_samples"],
+            sampling_rate=fs,
+            method=method,
+            frequency_range=(filter_low, filter_high),
+            top_peaks=[SpectralPeak(**p) for p in result["top_peaks"]],
+            diagnosis=result["diagnosis"],
+        )

--- a/src/mcp_tools/diagnostics_tools.py
+++ b/src/mcp_tools/diagnostics_tools.py
@@ -1,0 +1,1861 @@
+"""MCP tools for diagnostics, anomaly detection, and documentation (ISO 13374 Blocks 3-4)."""
+
+import logging
+import json
+import pickle
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+from scipy import signal
+from scipy.fft import fft, fftfreq
+from scipy.signal import hilbert, butter, sosfiltfilt
+from sklearn.preprocessing import StandardScaler
+from sklearn.decomposition import PCA
+from sklearn.svm import OneClassSVM
+from sklearn.neighbors import LocalOutlierFactor
+from mcp.server.fastmcp import FastMCP, Context
+
+from ..config import DATA_DIR, MODELS_DIR, RESOURCES_DIR, REPORTS_DIR, CACHE_DIR
+from ..signal_loader import load_signal_data, get_metadata_path, extract_segment, SUPPORTED_EXTENSIONS
+from ..signal_repository import get_repository
+from ..models import (
+    ISO20816Result, AnomalyModelResult, AnomalyPredictionResult,
+    BearingFaultCheckResult, BearingFaultsSummary, VibrationSeverityResult,
+    DiagnosisResult, StoredSignalInfo
+)
+from ..report_generator import save_iso_report, REPORTS_DIR as REPORTS_DIR_PATH
+from ..document_reader import (
+    calculate_bearing_frequencies,
+    extract_machine_specs,
+    extract_bearing_designation,
+    extract_rpm_values,
+    extract_power_ratings,
+    extract_text_from_pdf,
+)
+from ..spectral import (
+    compute_psd as _compute_psd,
+    compute_stft_spectrogram as _compute_stft,
+    compute_envelope_spectrum as _compute_envelope,
+)
+from ..bearing_catalog import (
+    lookup_bearing as _lookup_bearing,
+    compute_fault_frequencies as _compute_fault_freqs,
+    list_catalog_bearings as _list_catalog,
+)
+from ..bearing_analyzer import (
+    check_bearing_fault_peak as _check_fault_peak,
+    check_all_bearing_faults as _check_all_faults,
+    lookup_bearing_and_compute as _lookup_and_compute,
+)
+from ..iso10816 import assess_vibration_severity as _assess_severity
+from ..diagnosis_pipeline import diagnose_vibration as _diagnose_vibration
+
+from .analysis_tools import extract_time_domain_features
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (module-level, outside register)
+# ---------------------------------------------------------------------------
+
+def _resolve_sampling_rate(
+    signal_file: str,
+    sampling_rate: Optional[float],
+    strict: bool = True,
+) -> Optional[float]:
+    """
+    Resolve sampling rate for a signal file.
+
+    Priority: provided sampling_rate > metadata > error/None.
+
+    Args:
+        signal_file: Signal filename relative to DATA_DIR
+        sampling_rate: User-provided sampling rate (None = auto-detect)
+        strict: If True, raise on missing rate; if False, return None
+
+    Returns:
+        Resolved sampling rate, or None if strict=False and not found
+    """
+    if sampling_rate is not None:
+        return sampling_rate
+
+    metadata_path = get_metadata_path(signal_file)
+    if metadata_path.exists():
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+            rate = metadata.get("sampling_rate")
+            if rate is not None:
+                return rate
+
+    if strict:
+        raise ValueError(
+            f"No sampling rate found for {signal_file}. "
+            f"Please provide sampling_rate parameter or create "
+            f"{Path(signal_file).stem}_metadata.json with 'sampling_rate' field."
+        )
+    return None
+
+
+def _segment_and_extract_features(
+    signal_data: np.ndarray,
+    sampling_rate: float,
+    segment_duration: float,
+    overlap_ratio: float,
+) -> list[dict]:
+    """
+    Segment a signal and extract time-domain features from each segment.
+
+    Args:
+        signal_data: Raw signal array
+        sampling_rate: Sampling frequency in Hz
+        segment_duration: Duration of each segment in seconds
+        overlap_ratio: Overlap ratio between segments (0-1)
+
+    Returns:
+        List of feature dictionaries, one per segment
+    """
+    segment_length_samples = int(segment_duration * sampling_rate)
+    hop_length = int(segment_length_samples * (1 - overlap_ratio))
+    features_list = []
+
+    for start in range(0, len(signal_data) - segment_length_samples + 1, hop_length):
+        segment = signal_data[start:start + segment_length_samples]
+        features = extract_time_domain_features(segment)
+        features_list.append(features)
+
+    return features_list
+
+
+async def _extract_features_from_files(
+    signal_files: list[str],
+    sampling_rate: Optional[float],
+    segment_duration: float,
+    overlap_ratio: float,
+    strict: bool = True,
+    ctx: Context = None,
+) -> tuple[list[dict], list[float]]:
+    """
+    Load signals, resolve sampling rates, segment, and extract features.
+
+    Args:
+        signal_files: List of signal filenames relative to DATA_DIR
+        sampling_rate: User-provided sampling rate (None = auto-detect per file)
+        segment_duration: Segment duration in seconds
+        overlap_ratio: Overlap ratio (0-1)
+        strict: If True, raise on missing files/rates; if False, skip them
+        ctx: MCP context for logging
+
+    Returns:
+        Tuple of (all_features_list, detected_rates)
+    """
+    all_features = []
+    detected_rates = []
+
+    for signal_file in signal_files:
+        filepath = DATA_DIR / signal_file
+        if not filepath.exists():
+            if strict:
+                raise FileNotFoundError(f"File not found: {signal_file}")
+            else:
+                if ctx:
+                    await ctx.warning(f"File not found: {signal_file}, skipping")
+                continue
+
+        file_rate = _resolve_sampling_rate(signal_file, sampling_rate, strict=strict)
+        if file_rate is None:
+            if ctx:
+                await ctx.warning(f"No sampling rate for {signal_file}, skipping")
+            continue
+
+        if ctx and sampling_rate is None:
+            await ctx.info(f"  {signal_file}: detected {file_rate} Hz from metadata")
+
+        detected_rates.append(file_rate)
+
+        signal_data = load_signal_data(signal_file)
+        if signal_data is None:
+            if strict:
+                raise ValueError(f"Could not load signal data from: {signal_file}")
+            else:
+                if ctx:
+                    await ctx.warning(f"Could not load {signal_file}, skipping")
+                continue
+
+        features = _segment_and_extract_features(signal_data, file_rate, segment_duration, overlap_ratio)
+        all_features.extend(features)
+
+    return all_features, detected_rates
+
+
+async def _extract_and_transform_validation_features(
+    signal_files: list[str],
+    sampling_rate: Optional[float],
+    segment_duration: float,
+    overlap_ratio: float,
+    scaler,
+    pca,
+    strict: bool = False,
+    ctx: Context = None,
+) -> Optional[np.ndarray]:
+    """
+    Extract features from validation files and apply scaler + PCA transform.
+
+    Args:
+        signal_files: List of signal filenames relative to DATA_DIR
+        sampling_rate: User-provided sampling rate (None = auto-detect)
+        segment_duration: Segment duration in seconds
+        overlap_ratio: Overlap ratio (0-1)
+        scaler: Fitted StandardScaler
+        pca: Fitted PCA transformer
+        strict: If True, raise on errors; if False, skip problematic files
+        ctx: MCP context for logging
+
+    Returns:
+        PCA-transformed feature matrix, or None if no features extracted
+    """
+    features_list, _ = await _extract_features_from_files(
+        signal_files, sampling_rate, segment_duration, overlap_ratio,
+        strict=strict, ctx=ctx
+    )
+
+    if not features_list:
+        return None
+
+    features_df = pd.DataFrame(features_list)
+    features_scaled = scaler.transform(features_df.values)
+    features_pca = pca.transform(features_scaled)
+    return features_pca
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+def register(mcp: FastMCP) -> None:
+    """Register diagnostics, anomaly-detection, and documentation tools on *mcp*."""
+
+    # Import ServerSession for type hints used in some signatures
+    from mcp.server.session import ServerSession
+
+    # ------------------------------------------------------------------
+    # ISO 20816 evaluation
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    async def evaluate_iso_20816(
+        ctx: Context,
+        signal_file: str,
+        sampling_rate: float = 10000.0,
+        machine_group: int = 2,  # CHANGED: Default 2 (medium) - most common industrial case
+        support_type: str = "rigid",  # Default rigid - most common for horizontal machines
+        operating_speed_rpm: Optional[float] = None,
+        signal_unit: Optional[str] = None  # NEW: 'g' for acceleration, 'mm/s' for velocity, None for auto-detect
+    ) -> ISO20816Result:
+        """
+        Evaluate vibration severity according to ISO 20816-3 standard.
+
+        ISO 20816-3 defines vibration severity zones for rotating machinery based on
+        broadband RMS velocity measurements on non-rotating parts (bearings, housings).
+
+        **CRITICAL - LLM Inference Policy:**
+        - **NEVER infer fault type or severity from filename** (e.g., "OuterRaceFault_1.csv" does NOT mean outer race fault)
+        - **NEVER assume baseline/healthy from filename** (e.g., "baseline" does NOT guarantee Zone A)
+        - Treat ALL filenames as opaque identifiers
+        - Report ONLY the ISO zone returned by measurement, regardless of filename
+        - If filename suggests "baseline" but measurement shows Zone C/D, report Zone C/D
+
+        **DEFAULTS** (use if user doesn't specify):
+        - machine_group = 2 (medium-sized machines, most common)
+        - support_type = "rigid" (horizontal machines on foundations)
+
+        **Machine Group Selection Guide** (ask user if unsure):
+        - Group 1: Large machines (power >300 kW OR shaft height H >= 315 mm)
+          Examples: Large turbines, generators, compressors, large pumps
+        - Group 2: Medium machines (15-300 kW OR 160mm <= H < 315mm) [DEFAULT]
+          Examples: Industrial motors, fans, pumps, gearboxes
+
+        **Support Type Selection Guide** (ask user if unsure):
+        - "rigid": Machine on stiff foundation, horizontal orientation [DEFAULT]
+          Rule: Lowest natural frequency > 1.25 x main excitation frequency
+          Examples: Motors/pumps on concrete, horizontal compressors
+        - "flexible": Machine on soft supports, vertical, or large turbine-generator sets
+          Examples: Vertical pumps, machines on springs, large turbogenerators
+
+        **When to ask user**:
+        - If power/dimensions unknown -> use defaults (Group 2, rigid)
+        - If clearly large turbine (>10 MW) -> suggest Group 1, flexible
+        - If vertical machine -> suggest flexible
+        - If user provides machine specs -> use guide above
+
+        Evaluation Zones:
+        - Zone A (Green): New machine condition - excellent
+        - Zone B (Yellow): Acceptable for long-term unrestricted operation
+        - Zone C (Orange): Unsatisfactory - limited operation, plan maintenance
+        - Zone D (Red): Sufficient severity to cause damage - immediate action
+
+        Args:
+            signal_file: Name of the CSV file in data/signals/
+            sampling_rate: Sampling frequency in Hz (default: 10000)
+            machine_group: Machine group 1 (large) or 2 (medium) (default: 2 - medium)
+            support_type: 'rigid' or 'flexible' (default: 'rigid')
+            operating_speed_rpm: Operating speed in RPM (optional, for frequency range selection)
+            signal_unit: Signal unit - 'g' or 'm/s2' (acceleration) or 'mm/s' or 'm/s' (velocity).
+
+                         **PRIORITY ORDER FOR UNIT DETECTION:**
+                         1. Check metadata file for 'signal_unit' field (recommended)
+                         2. Use this parameter if explicitly provided
+                         3. If neither exists: LLM will ask user to confirm based on RMS hypothesis
+                         4. Default assumption: 'g' (most common for vibration sensors)
+
+                         **IMPORTANT**: Wrong unit completely invalidates ISO 20816-3 results!
+                         Best practice: Add 'signal_unit' field to metadata JSON files.
+
+        Returns:
+            ISO20816Result with evaluation zone, severity level, and recommendations
+
+        Example:
+            await evaluate_iso_20816(
+                ctx,
+                "motor_vibration.csv",
+                sampling_rate=10000,
+                machine_group=2,
+                support_type="rigid",
+                operating_speed_rpm=1500,
+                signal_unit="g"  # Explicitly specify: 'g' or 'mm/s'
+            )
+        """
+        from ..iso10816 import assess_severity_raw
+
+        # Load signal
+        filepath = DATA_DIR / signal_file
+        if not filepath.exists():
+            raise FileNotFoundError(f"File not found: {signal_file}")
+
+        signal_data = load_signal_data(signal_file)
+        if signal_data is None:
+            raise ValueError(f"Could not load signal data from: {signal_file}")
+
+        # Try to read metadata JSON (single read for sampling_rate + signal_unit)
+        metadata_file = filepath.parent / (filepath.stem + "_metadata.json")
+        metadata_found = False
+        metadata = {}
+        user_provided_sampling_rate = (sampling_rate != 10000.0)  # Check if user changed default
+
+        if metadata_file.exists():
+            with open(metadata_file, 'r') as f:
+                metadata = json.load(f)
+                if 'sampling_rate' in metadata:
+                    old_sampling_rate = sampling_rate
+                    sampling_rate = metadata['sampling_rate']
+                    metadata_found = True
+                    if ctx:
+                        await ctx.info(f"Found metadata: sampling_rate = {sampling_rate} Hz")
+                        if user_provided_sampling_rate and old_sampling_rate != sampling_rate:
+                            await ctx.info(f"   (Overriding user-provided {old_sampling_rate} Hz with metadata value)")
+
+        # CRITICAL: If no metadata and user didn't provide sampling_rate, ASK!
+        if not metadata_found and not user_provided_sampling_rate:
+            if ctx:
+                await ctx.info(f"CRITICAL: No metadata found and no sampling_rate provided!")
+                await ctx.info(f"   Sampling rate is REQUIRED for accurate ISO 20816-3 evaluation.")
+                await ctx.info(f"   Using default {sampling_rate} Hz may give INCORRECT results.")
+                await ctx.info(f"")
+                await ctx.info(f"PLEASE CONFIRM:")
+                await ctx.info(f"   - Do you know the sampling rate of '{signal_file}'?")
+                await ctx.info(f"   - If YES: Re-run with correct sampling_rate parameter")
+                await ctx.info(f"   - If NO: Results may be unreliable - use with caution")
+                await ctx.info(f"")
+                await ctx.info(f"PROCEEDING WITH DEFAULT {sampling_rate} Hz (may be incorrect!)")
+        elif not metadata_found and user_provided_sampling_rate:
+            if ctx:
+                await ctx.info(f"Using user-provided sampling_rate = {sampling_rate} Hz (no metadata verification)")
+
+        # Notify about machine parameters
+        if ctx:
+            await ctx.info(f"Machine parameters: Group {machine_group} ({'Large' if machine_group == 1 else 'Medium'}), Support '{support_type}'")
+            await ctx.info(f"   If incorrect, provide machine_group and support_type parameters")
+
+        # ========================================================================
+        # SIGNAL UNIT DETECTION WITH HYPOTHESIS FLOW
+        # ========================================================================
+        rms_raw = np.sqrt(np.mean(signal_data**2))
+        detected_unit = None
+
+        # STEP 1: Check metadata for signal_unit
+        if metadata_found and 'signal_unit' in metadata:
+            detected_unit = metadata['signal_unit'].lower()
+            if ctx:
+                await ctx.info(f"")
+                await ctx.info(f"SIGNAL UNIT from metadata: '{metadata['signal_unit']}'")
+
+        # STEP 2: User explicitly provided signal_unit parameter
+        if signal_unit is not None:
+            detected_unit = signal_unit.lower()
+            if ctx:
+                await ctx.info(f"")
+                await ctx.info(f"SIGNAL UNIT from user parameter: '{signal_unit}'")
+
+        # STEP 3: No metadata, no user input -> ASK USER with hypothesis
+        if detected_unit is None:
+            if rms_raw > 0.5:
+                hypothesis = 'g'
+                hypothesis_reason = f"RMS={rms_raw:.2f} > 0.5 (typical for acceleration)"
+            else:
+                hypothesis = 'mm/s'
+                hypothesis_reason = f"RMS={rms_raw:.2f} < 0.5 (typical for velocity)"
+
+            if ctx:
+                await ctx.info(f"")
+                await ctx.info(f"SIGNAL UNIT UNKNOWN - ASKING USER FOR CONFIRMATION")
+                await ctx.info(f"")
+                await ctx.info(f"HYPOTHESIS: Signal appears to be in '{hypothesis}' units")
+                await ctx.info(f"   Reasoning: {hypothesis_reason}")
+                await ctx.info(f"")
+                await ctx.info(f"PLEASE CONFIRM SIGNAL UNITS:")
+                await ctx.info(f"   - Is the signal in 'g' (acceleration) or 'm/s2' (acceleration)?")
+                await ctx.info(f"   - Or is it already in 'mm/s' (velocity)?")
+                await ctx.info(f"")
+                await ctx.info(f"HOW TO SPECIFY:")
+                await ctx.info(f"   1. Add 'signal_unit' field to metadata file: {metadata_file.name}")
+                await ctx.info(f"      Example: {{'signal_unit': 'g', ...}}")
+                await ctx.info(f"   2. OR provide signal_unit parameter when calling this tool")
+                await ctx.info(f"      Example: signal_unit='g' or signal_unit='mm/s'")
+                await ctx.info(f"")
+                await ctx.info(f"DEFAULT ASSUMPTION: Using '{hypothesis}' (most common for vibration sensors)")
+                await ctx.info(f"   If this is incorrect, results will be INVALID!")
+
+            detected_unit = hypothesis
+
+        # Validate detected unit
+        if detected_unit not in ['g', 'm/s\u00b2', 'mm/s', 'm/s']:
+            if ctx:
+                await ctx.info(f"ERROR: Invalid signal_unit '{detected_unit}'")
+                await ctx.info(f"   Valid values: 'g', 'm/s\u00b2' (acceleration) or 'mm/s', 'm/s' (velocity)")
+            raise ValueError(f"Invalid signal_unit: '{detected_unit}'. Must be 'g', 'm/s\u00b2', 'mm/s', or 'm/s'")
+
+        # Notify about unit conversion
+        if detected_unit in ['g', 'm/s\u00b2']:
+            if ctx:
+                await ctx.info(f"")
+                await ctx.info(f"UNIT CONVERSION: Acceleration ({detected_unit}) -> Velocity (mm/s)")
+                await ctx.info(f"   ISO 20816-3 requires velocity measurements")
+                await ctx.info(f"   Performing frequency-domain integration...")
+
+        # ========================================================================
+        # DELEGATE MATH to iso10816.assess_severity_raw (single source of truth)
+        # ========================================================================
+        result = assess_severity_raw(
+            signal=signal_data,
+            fs=sampling_rate,
+            machine_group=machine_group,
+            support_type=support_type,
+            signal_unit=detected_unit,
+            operating_speed_rpm=operating_speed_rpm,
+        )
+
+        # Post-computation ctx messages
+        if ctx:
+            if result["unit_conversion_performed"]:
+                await ctx.info(f"Conversion complete: {rms_raw:.2f} {detected_unit} -> {result['rms_velocity_mm_s']:.2f} mm/s RMS")
+            elif detected_unit == 'mm/s':
+                await ctx.info(f"Signal already in velocity (mm/s) - no conversion needed")
+
+        # Build zone description with conversion notice
+        zone_desc = result["zone_description"]
+        if result["unit_conversion_performed"]:
+            zone_desc = f"SIGNAL CONVERTED: Acceleration ({detected_unit}) -> Velocity (mm/s). {zone_desc}"
+
+        return ISO20816Result(
+            rms_velocity=result["rms_velocity_mm_s"],
+            machine_group=machine_group,
+            support_type=support_type.lower(),
+            zone=result["zone"],
+            zone_description=zone_desc,
+            severity_level=result["severity_level"],
+            color_code=result["color_code"],
+            boundary_ab=result["boundaries"]["AB"],
+            boundary_bc=result["boundaries"]["BC"],
+            boundary_cd=result["boundaries"]["CD"],
+            frequency_range=result["frequency_range"],
+            operating_speed_rpm=operating_speed_rpm
+        )
+
+    # ------------------------------------------------------------------
+    # ISO 20816 chart
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    async def plot_iso_20816_chart(
+        filename: str,
+        sampling_rate: float,
+        machine_group: int = 1,
+        support_type: str = "rigid",
+        operating_speed_rpm: Optional[float] = None,
+        ctx: Context | None = None
+    ) -> str:
+        """
+        Generate visual chart showing ISO 20816-3 zone position for the analyzed signal.
+
+        Creates an interactive HTML plot with:
+        - Horizontal bar chart showing zones A/B/C/D with boundaries
+        - Marker indicating actual RMS velocity position
+        - Color-coded zones (green/yellow/orange/red)
+        - Zone descriptions
+
+        Args:
+            filename: Name of the signal file
+            sampling_rate: Sampling frequency (Hz)
+            machine_group: 1 (large >300kW) or 2 (medium 15-300kW)
+            support_type: 'rigid' or 'flexible'
+            operating_speed_rpm: Operating speed in RPM (optional)
+            ctx: MCP context
+
+        Returns:
+            Path to generated HTML file with ISO chart
+        """
+        if ctx:
+            await ctx.info(f"Evaluating ISO 20816-3 for {filename}...")
+
+        # First, perform ISO evaluation
+        iso_result = await evaluate_iso_20816(
+            ctx=ctx,
+            signal_file=filename,
+            sampling_rate=sampling_rate,
+            machine_group=machine_group,
+            support_type=support_type,
+            operating_speed_rpm=operating_speed_rpm
+        )
+
+        # Create figure
+        fig = go.Figure()
+
+        # Zone boundaries
+        boundaries = [0, iso_result.boundary_ab, iso_result.boundary_bc, iso_result.boundary_cd, iso_result.boundary_cd * 1.3]
+        zone_names = ["Zone A<br>(Good)", "Zone B<br>(Acceptable)", "Zone C<br>(Unsatisfactory)", "Zone D<br>(Unacceptable)"]
+        zone_colors = ["#28a745", "#ffc107", "#fd7e14", "#dc3545"]  # green, yellow, orange, red
+
+        # Add horizontal bars for each zone
+        for i in range(4):
+            fig.add_trace(go.Bar(
+                y=[f"ISO 20816-3<br>Group {machine_group}<br>{support_type.title()}"],
+                x=[boundaries[i+1] - boundaries[i]],
+                base=boundaries[i],
+                orientation='h',
+                name=zone_names[i],
+                marker=dict(color=zone_colors[i], opacity=0.7),
+                text=[zone_names[i]],
+                textposition='inside',
+                hovertemplate=f"{zone_names[i]}<br>Range: {boundaries[i]:.2f} - {boundaries[i+1]:.2f} mm/s<extra></extra>"
+            ))
+
+        # Add marker for actual value
+        fig.add_trace(go.Scatter(
+            x=[iso_result.rms_velocity],
+            y=[f"ISO 20816-3<br>Group {machine_group}<br>{support_type.title()}"],
+            mode='markers+text',
+            name='Measured RMS',
+            marker=dict(
+                symbol='diamond',
+                size=20,
+                color='black',
+                line=dict(width=2, color='white')
+            ),
+            text=[f'<b>{iso_result.rms_velocity:.2f} mm/s</b>'],
+            textposition="top center",
+            textfont=dict(size=14, color='black'),
+            hovertemplate=f"Measured: {iso_result.rms_velocity:.2f} mm/s<br>Zone: {iso_result.zone}<br>{iso_result.severity_level}<extra></extra>"
+        ))
+
+        # Layout
+        max_x = boundaries[-1]
+        fig.update_layout(
+            title=dict(
+                text=f"ISO 20816-3 Evaluation: {filename}<br>" +
+                     f"<span style='font-size:14px'>RMS Velocity: {iso_result.rms_velocity:.2f} mm/s | " +
+                     f"Zone <b>{iso_result.zone}</b> ({iso_result.severity_level})</span>",
+                x=0.5,
+                xanchor='center'
+            ),
+            xaxis=dict(
+                title="RMS Velocity (mm/s)",
+                range=[0, max_x],
+                showgrid=True,
+                gridcolor='lightgray'
+            ),
+            yaxis=dict(
+                title="",
+                showticklabels=True
+            ),
+            barmode='stack',
+            height=400,
+            width=1000,
+            template='plotly_white',
+            showlegend=True,
+            legend=dict(
+                orientation="h",
+                yanchor="bottom",
+                y=1.02,
+                xanchor="center",
+                x=0.5
+            ),
+            annotations=[
+                dict(
+                    text=f"Zone Boundaries: A/B={iso_result.boundary_ab:.1f} | B/C={iso_result.boundary_bc:.1f} | C/D={iso_result.boundary_cd:.1f} mm/s",
+                    xref="paper", yref="paper",
+                    x=0.5, y=-0.15,
+                    showarrow=False,
+                    font=dict(size=11, color="gray")
+                )
+            ]
+        )
+
+        # Save HTML to reports directory
+        safe_name = Path(filename).stem.replace('/', '_').replace('\\', '_')
+        output_file = REPORTS_DIR / f"plot_iso_{safe_name}.html"
+        fig.write_html(str(output_file))
+
+        if ctx:
+            await ctx.info(f"ISO chart saved to {output_file.name}")
+            await ctx.info(f"To view report metadata: list_html_reports() or get_report_info()")
+
+        return f"ISO 20816-3 chart saved to: {output_file}\nUse list_html_reports() to see all reports, or open file in browser"
+
+    # ------------------------------------------------------------------
+    # ML anomaly detection – training
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    async def train_anomaly_model(
+        healthy_signal_files: list[str],
+        sampling_rate: Optional[float] = None,
+        segment_duration: float = 0.1,
+        overlap_ratio: float = 0.5,
+        model_type: str = "OneClassSVM",
+        pca_variance: float = 0.95,
+        fault_signal_files: Optional[list[str]] = None,
+        healthy_validation_files: Optional[list[str]] = None,
+        model_name: str = "anomaly_model",
+        ctx: Context = None
+    ) -> AnomalyModelResult:
+        """
+        Train ML-based anomaly detection model on healthy data (UNSUPERVISED/SEMI-SUPERVISED).
+
+        Complete pipeline:
+        1. Extract features from healthy signals (segmentation + time-domain features)
+        2. Standardize features (StandardScaler - fitted on training data only)
+        3. Dimensionality reduction (PCA with specified variance explained)
+        4. Train novelty detection model (OneClassSVM or LocalOutlierFactor) on HEALTHY DATA ONLY
+        5. Optional hyperparameter tuning using validation data (semi-supervised)
+        6. Save model, scaler, and PCA transformer
+
+        **Training Mode:**
+        - UNSUPERVISED: Train only on healthy data with automatic hyperparameters
+        - SEMI-SUPERVISED: Train on healthy data, tune hyperparameters using validation set (healthy + fault)
+
+        **Note:** This is NOT supervised learning. OneClassSVM/LOF are trained ONLY on healthy data.
+        Fault data (if provided) is used ONLY for hyperparameter tuning after training.
+
+        **Validation Strategy:**
+        - If healthy_validation_files provided: Use those explicitly (no split)
+        - If healthy_validation_files NOT provided: Automatic 80/20 split of training data
+        - If fault_signal_files provided: Enable semi-supervised mode (hyperparameter tuning)
+
+        Args:
+            healthy_signal_files: List of CSV files with healthy machine data (for training)
+            sampling_rate: Sampling frequency in Hz (auto-detect from metadata if None)
+            segment_duration: Segment duration in seconds (default: 0.1)
+            overlap_ratio: Overlap ratio 0-1 (default: 0.5)
+            model_type: 'OneClassSVM' or 'LocalOutlierFactor' (default: 'OneClassSVM')
+            pca_variance: Cumulative variance to explain with PCA (default: 0.95)
+            fault_signal_files: Optional list of fault signals for HYPERPARAMETER TUNING (semi-supervised)
+            healthy_validation_files: Optional list of healthy signals for validation (specificity check).
+                                      If not provided, 20% of training data will be used.
+            model_name: Name for saved model files (default: 'anomaly_model')
+            ctx: MCP context for progress/logging
+
+        Returns:
+            AnomalyModelResult with model paths and performance metrics
+        """
+        if ctx:
+            await ctx.info(f"Training {model_type} model on {len(healthy_signal_files)} healthy signals...")
+
+        # Step 1: Extract features from all healthy signals
+        all_features, detected_rates = await _extract_features_from_files(
+            healthy_signal_files, sampling_rate, segment_duration, overlap_ratio,
+            strict=True, ctx=ctx
+        )
+
+        features_df = pd.DataFrame(all_features)
+        X_train = features_df.values
+
+        if ctx:
+            await ctx.info(f"Extracted {X_train.shape[0]} feature vectors from healthy data")
+            await ctx.info(f"Original feature dimension: {X_train.shape[1]}")
+
+        # Step 2: Standardize features
+        scaler = StandardScaler()
+        X_scaled = scaler.fit_transform(X_train)
+
+        # Step 3: PCA for dimensionality reduction
+        pca = PCA(n_components=pca_variance)
+        X_pca = pca.fit_transform(X_scaled)
+
+        if ctx:
+            await ctx.info(f"PCA components: {pca.n_components_}")
+            await ctx.info(f"Variance explained: {pca.explained_variance_ratio_.sum():.3f}")
+
+        # Step 4: Train anomaly detection model
+        # Strategy: Train on healthy data only (unsupervised), then use validation for hyperparameter tuning
+
+        if model_type == "OneClassSVM":
+            if fault_signal_files:
+                # SEMI-SUPERVISED MODE: Train on healthy, tune hyperparameters with validation (healthy + fault)
+                if ctx:
+                    await ctx.info("Training in SEMI-SUPERVISED mode")
+                    await ctx.info("- Training: Healthy data only (unsupervised)")
+                    await ctx.info("- Hyperparameter tuning: Using validation set (healthy + fault)")
+                    await ctx.info("Evaluating hyperparameter grid...")
+
+                # Prepare validation features for fault signals
+                X_fault = await _extract_and_transform_validation_features(
+                    fault_signal_files, sampling_rate, segment_duration, overlap_ratio,
+                    scaler, pca, strict=False, ctx=ctx
+                )
+
+                # Prepare validation features for healthy signals
+                X_healthy_val = None
+                if healthy_validation_files:
+                    X_healthy_val = await _extract_and_transform_validation_features(
+                        healthy_validation_files, sampling_rate, segment_duration, overlap_ratio,
+                        scaler, pca, strict=False, ctx=ctx
+                    )
+
+                # Hyperparameter grid
+                param_grid = {
+                    'nu': [0.01, 0.05, 0.1, 0.2],
+                    'gamma': ['scale', 'auto', 0.001, 0.01, 0.1],
+                    'kernel': ['rbf']
+                }
+
+                # Manual hyperparameter search with validation scoring
+                best_score = -np.inf
+                best_params = None
+                best_model = None
+
+                for nu in param_grid['nu']:
+                    for gamma in param_grid['gamma']:
+                        # Train on HEALTHY DATA ONLY
+                        model_candidate = OneClassSVM(kernel='rbf', nu=nu, gamma=gamma)
+                        model_candidate.fit(X_pca)  # Only healthy training data
+
+                        # Evaluate on validation set (healthy + fault)
+                        validation_score = 0.0
+                        validation_count = 0
+
+                        # Score healthy validation (should predict +1)
+                        if X_healthy_val is not None:
+                            healthy_predictions = model_candidate.predict(X_healthy_val)
+                            healthy_accuracy = np.mean(healthy_predictions == 1)
+                            validation_score += healthy_accuracy
+                            validation_count += 1
+
+                        # Score fault validation (should predict -1)
+                        if X_fault is not None:
+                            fault_predictions = model_candidate.predict(X_fault)
+                            fault_accuracy = np.mean(fault_predictions == -1)
+                            validation_score += fault_accuracy
+                            validation_count += 1
+
+                        # Balanced accuracy across healthy + fault
+                        if validation_count > 0:
+                            validation_score /= validation_count
+
+                        if validation_score > best_score:
+                            best_score = validation_score
+                            best_params = {'kernel': 'rbf', 'nu': nu, 'gamma': gamma}
+                            best_model = model_candidate
+
+                model = best_model
+
+                if ctx:
+                    await ctx.info(f"Best hyperparameters: nu={best_params['nu']}, gamma={best_params['gamma']}")
+                    await ctx.info(f"Validation balanced accuracy: {best_score:.3f}")
+
+            else:
+                # UNSUPERVISED MODE: No fault data -> Use automatic parameters
+                if ctx:
+                    await ctx.info("Training in UNSUPERVISED mode (novelty detection)")
+                    await ctx.info("Using automatic parameters: nu='auto', gamma='scale'")
+
+                # Auto-calculate nu based on expected outlier fraction (rule of thumb: 5%)
+                nu_auto = min(0.1, max(0.01, 1.0 / np.sqrt(len(X_pca))))
+
+                model = OneClassSVM(
+                    kernel='rbf',
+                    nu=nu_auto,  # Adaptive based on sample size
+                    gamma='scale'  # Automatic scaling based on features
+                )
+                model.fit(X_pca)
+
+                best_params = {
+                    'kernel': 'rbf',
+                    'nu': float(nu_auto),
+                    'gamma': 'scale',
+                    'mode': 'unsupervised_auto'
+                }
+
+                if ctx:
+                    await ctx.info(f"Auto-calculated nu={nu_auto:.4f} based on sample size")
+
+        elif model_type == "LocalOutlierFactor":
+            if fault_signal_files:
+                # SEMI-SUPERVISED MODE with LOF
+                if ctx:
+                    await ctx.info("Training LOF in SEMI-SUPERVISED mode")
+                    await ctx.info("- Training: Healthy data only (unsupervised)")
+                    await ctx.info("- Hyperparameter tuning: Using validation set")
+
+                # Prepare validation features for fault signals
+                X_fault = await _extract_and_transform_validation_features(
+                    fault_signal_files, sampling_rate, segment_duration, overlap_ratio,
+                    scaler, pca, strict=False, ctx=ctx
+                )
+
+                # Prepare healthy validation features
+                X_healthy_val = None
+                if healthy_validation_files:
+                    X_healthy_val = await _extract_and_transform_validation_features(
+                        healthy_validation_files, sampling_rate, segment_duration, overlap_ratio,
+                        scaler, pca, strict=False, ctx=ctx
+                    )
+
+                # Hyperparameter search for LOF
+                best_score = -np.inf
+                best_params = None
+                best_model = None
+
+                for n_neighbors in [10, 20, 30, 50]:
+                    for contamination in [0.05, 0.1, 0.15, 0.2]:
+                        model_candidate = LocalOutlierFactor(
+                            n_neighbors=n_neighbors,
+                            contamination=contamination,
+                            novelty=True
+                        )
+                        model_candidate.fit(X_pca)  # Only healthy training data
+
+                        # Evaluate on validation set
+                        validation_score = 0.0
+                        validation_count = 0
+
+                        # Score healthy validation
+                        if X_healthy_val is not None:
+                            healthy_predictions = model_candidate.predict(X_healthy_val)
+                            healthy_accuracy = np.mean(healthy_predictions == 1)
+                            validation_score += healthy_accuracy
+                            validation_count += 1
+
+                        # Score fault validation
+                        if X_fault is not None:
+                            fault_predictions = model_candidate.predict(X_fault)
+                            fault_accuracy = np.mean(fault_predictions == -1)
+                            validation_score += fault_accuracy
+                            validation_count += 1
+
+                        # Balanced accuracy
+                        if validation_count > 0:
+                            validation_score /= validation_count
+
+                        if validation_score > best_score:
+                            best_score = validation_score
+                            best_params = {'n_neighbors': n_neighbors, 'contamination': contamination}
+                            best_model = model_candidate
+
+                model = best_model
+
+                if ctx:
+                    await ctx.info(f"Best parameters: n_neighbors={best_params['n_neighbors']}, contamination={best_params['contamination']}")
+
+            else:
+                # UNSUPERVISED MODE: Auto parameters
+                if ctx:
+                    await ctx.info("Training LOF in UNSUPERVISED mode")
+                    await ctx.info("Using automatic parameters based on sample size")
+
+                # Auto-calculate n_neighbors (rule of thumb: sqrt(n) or ~5% of samples)
+                n_auto = max(10, min(50, int(np.sqrt(len(X_pca)))))
+                contamination_auto = 0.1  # Conservative 10% outlier assumption
+
+                model = LocalOutlierFactor(
+                    n_neighbors=n_auto,
+                    contamination=contamination_auto,
+                    novelty=True
+                )
+                model.fit(X_pca)
+
+                best_params = {
+                    'n_neighbors': int(n_auto),
+                    'contamination': contamination_auto,
+                    'mode': 'unsupervised_auto'
+                }
+
+                if ctx:
+                    await ctx.info(f"Auto-calculated n_neighbors={n_auto}")
+
+        else:
+            raise ValueError(f"Unknown model_type: {model_type}. Use 'OneClassSVM' or 'LocalOutlierFactor'")
+
+        # Step 5: Optional validation on healthy + fault data
+        validation_accuracy = None
+        validation_details = None
+        validation_metrics = None
+
+        if fault_signal_files or healthy_validation_files:
+            # Part A: Validate on HEALTHY data
+            # Two options:
+            # 1. User provides explicit healthy_validation_files -> Use those
+            # 2. User doesn't provide -> Auto-split training data 80/20
+
+            if healthy_validation_files:
+                # Option 1: User provided explicit healthy validation files
+                if ctx:
+                    await ctx.info(f"Using {len(healthy_validation_files)} explicitly provided healthy validation files")
+
+                # Extract and transform features from validation files
+                X_pca_healthy_val = await _extract_and_transform_validation_features(
+                    healthy_validation_files, sampling_rate, segment_duration, overlap_ratio,
+                    scaler, pca, strict=True, ctx=ctx
+                )
+
+                if X_pca_healthy_val is not None:
+                    healthy_predictions = model.predict(X_pca_healthy_val)
+                    healthy_correct = np.sum(healthy_predictions == 1)
+                    healthy_total = len(healthy_predictions)
+                    healthy_accuracy = healthy_correct / healthy_total
+
+                    if ctx:
+                        await ctx.info(f"Healthy validation: {healthy_correct}/{healthy_total} correctly classified ({healthy_accuracy*100:.1f}%)")
+                else:
+                    healthy_correct = 0
+                    healthy_total = 0
+                    healthy_accuracy = 0.0
+
+            else:
+                # Option 2: Auto-split training data 80/20
+                if ctx:
+                    await ctx.info("No healthy validation files provided - using 80/20 split of training data")
+
+                split_idx = int(0.8 * len(X_pca))
+                X_pca_train = X_pca[:split_idx]
+                X_pca_healthy_val = X_pca[split_idx:]
+
+                # Retrain model on 80% split for proper validation
+                if model_type == "OneClassSVM":
+                    model_retrained = OneClassSVM(
+                        kernel=best_params.get('kernel', 'rbf'),
+                        nu=best_params['nu'],
+                        gamma=best_params['gamma']
+                    )
+                    model_retrained.fit(X_pca_train)
+                    model = model_retrained  # Use retrained model
+
+                    if ctx:
+                        await ctx.info("Model retrained on 80% of data for validation")
+
+                # Validate on 20% split
+                healthy_predictions = model.predict(X_pca_healthy_val)
+                healthy_correct = np.sum(healthy_predictions == 1)
+                healthy_total = len(healthy_predictions)
+                healthy_accuracy = healthy_correct / healthy_total
+
+                if ctx:
+                    await ctx.info(f"Healthy validation: {healthy_correct}/{healthy_total} correctly classified ({healthy_accuracy*100:.1f}%)")
+
+            # Part B: Validate on FAULT data
+            X_fault_pca = await _extract_and_transform_validation_features(
+                fault_signal_files, sampling_rate, segment_duration, overlap_ratio,
+                scaler, pca, strict=True, ctx=ctx
+            )
+
+            if X_fault_pca is not None:
+                # Predict (should be -1 for anomalies)
+                fault_predictions = model.predict(X_fault_pca)
+
+                # Calculate fault detection rate
+                anomaly_detected = np.sum(fault_predictions == -1)
+                fault_total = len(fault_predictions)
+                fault_accuracy = anomaly_detected / fault_total
+
+                # Calculate overall balanced accuracy
+                # Overall accuracy = (healthy_correct + fault_correct) / (healthy_total + fault_total)
+                total_correct = healthy_correct + anomaly_detected
+                total_samples = healthy_total + fault_total
+                validation_accuracy = float(total_correct / total_samples) if total_samples > 0 else 0.0
+
+                validation_details = (
+                    f"Healthy: {healthy_correct}/{healthy_total} correct ({healthy_accuracy*100:.1f}%), "
+                    f"Fault: {anomaly_detected}/{fault_total} detected ({fault_accuracy*100:.1f}%)"
+                )
+
+                validation_metrics = {
+                    'healthy_correct': int(healthy_correct),
+                    'healthy_total': int(healthy_total),
+                    'healthy_accuracy': float(healthy_accuracy),
+                    'fault_detected': int(anomaly_detected),
+                    'fault_total': int(fault_total),
+                    'fault_accuracy': float(fault_accuracy),
+                    'overall_accuracy': float(validation_accuracy)
+                }
+
+                if ctx:
+                    await ctx.info(f"Fault validation: {anomaly_detected}/{fault_total} detected as anomalies ({fault_accuracy*100:.1f}%)")
+                    await ctx.info(f"Overall validation accuracy: {validation_accuracy*100:.1f}%")
+
+        # Step 6: Save model, scaler, and PCA
+        MODELS_DIR.mkdir(parents=True, exist_ok=True)
+
+        model_path = MODELS_DIR / f"{model_name}_model.pkl"
+        scaler_path = MODELS_DIR / f"{model_name}_scaler.pkl"
+        pca_path = MODELS_DIR / f"{model_name}_pca.pkl"
+
+        with open(model_path, 'wb') as f:
+            pickle.dump(model, f)
+        with open(scaler_path, 'wb') as f:
+            pickle.dump(scaler, f)
+        with open(pca_path, 'wb') as f:
+            pickle.dump(pca, f)
+
+        # Save metadata
+        metadata = {
+            'model_type': model_type,
+            'training_mode': 'supervised' if fault_signal_files else 'unsupervised',
+            'feature_names': list(features_df.columns),
+            'num_features_original': X_train.shape[1],
+            'num_features_pca': X_pca.shape[1],
+            'pca_variance': float(pca.explained_variance_ratio_.sum()),
+            'best_params': best_params,
+            'sampling_rate': sampling_rate if sampling_rate is not None else 'per_file',
+            'sampling_rates_detected': detected_rates if sampling_rate is None else None,
+            'segment_duration': segment_duration,
+            'overlap_ratio': overlap_ratio,
+            'multi_rate_training': sampling_rate is None,
+            'validation_with_faults': fault_signal_files is not None,
+            'num_validation_files': len(fault_signal_files) if fault_signal_files else 0
+        }
+
+        metadata_path = MODELS_DIR / f"{model_name}_metadata.json"
+        with open(metadata_path, 'w') as f:
+            json.dump(metadata, f, indent=2)
+
+        if ctx:
+            await ctx.info(f"Model saved to {model_path}")
+            await ctx.info(f"Scaler saved to {scaler_path}")
+            await ctx.info(f"PCA saved to {pca_path}")
+
+        return AnomalyModelResult(
+            model_type=model_type,
+            num_training_samples=X_train.shape[0],
+            num_features_original=X_train.shape[1],
+            num_features_pca=X_pca.shape[1],
+            variance_explained=float(pca.explained_variance_ratio_.sum()),
+            model_params=best_params,
+            model_path=str(model_path),
+            scaler_path=str(scaler_path),
+            pca_path=str(pca_path),
+            validation_accuracy=validation_accuracy,
+            validation_details=validation_details,
+            validation_metrics=validation_metrics
+        )
+
+    # ------------------------------------------------------------------
+    # ML anomaly detection – prediction
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    async def predict_anomalies(
+        signal_file: str,
+        model_name: str = "anomaly_model",
+        ctx: Context = None
+    ) -> AnomalyPredictionResult:
+        """
+        Predict anomalies in new signal using trained model.
+
+        Applies the complete pipeline:
+        1. Segment signal
+        2. Extract features
+        3. Apply scaler (from training)
+        4. Apply PCA (from training)
+        5. Predict with trained model
+        6. Calculate anomaly ratio and overall health
+
+        Args:
+            signal_file: Name of CSV file to analyze
+            model_name: Name of trained model (default: 'anomaly_model')
+            ctx: MCP context for progress/logging
+
+        Returns:
+            AnomalyPredictionResult with predictions and health assessment
+        """
+        if ctx:
+            await ctx.info(f"Predicting anomalies in {signal_file}...")
+
+        # Load model, scaler, PCA
+        model_path = MODELS_DIR / f"{model_name}_model.pkl"
+        scaler_path = MODELS_DIR / f"{model_name}_scaler.pkl"
+        pca_path = MODELS_DIR / f"{model_name}_pca.pkl"
+        metadata_path = MODELS_DIR / f"{model_name}_metadata.json"
+
+        if not model_path.exists():
+            raise FileNotFoundError(f"Model not found: {model_path}. Train model first.")
+
+        with open(model_path, 'rb') as f:
+            model = pickle.load(f)
+        with open(scaler_path, 'rb') as f:
+            scaler = pickle.load(f)
+        with open(pca_path, 'rb') as f:
+            pca = pickle.load(f)
+        with open(metadata_path, 'r') as f:
+            metadata = json.load(f)
+
+        # Load signal
+        filepath = DATA_DIR / signal_file
+        if not filepath.exists():
+            raise FileNotFoundError(f"File not found: {signal_file}")
+
+        signal_data = load_signal_data(signal_file)
+        if signal_data is None:
+            raise ValueError(f"Could not load signal data from: {signal_file}")
+
+        # Extract features
+        sampling_rate_val = metadata['sampling_rate']
+        if isinstance(sampling_rate_val, str):
+            # Model was trained with per-file metadata detection; read from signal metadata
+            meta_path = get_metadata_path(signal_file)
+            if meta_path.exists():
+                with open(meta_path, 'r') as f:
+                    signal_meta = json.load(f)
+                sampling_rate_val = float(signal_meta.get('sampling_rate', 10000.0))
+            else:
+                raise ValueError(
+                    f"Model was trained with per-file sampling rates but no metadata found for {signal_file}. "
+                    "Please provide a _metadata.json file alongside the signal CSV."
+                )
+        sampling_rate_val = float(sampling_rate_val)
+        segment_duration = metadata['segment_duration']
+        overlap_ratio = metadata['overlap_ratio']
+
+        segment_length_samples = int(segment_duration * sampling_rate_val)
+        hop_length = int(segment_length_samples * (1 - overlap_ratio))
+
+        features_list = []
+        for start in range(0, len(signal_data) - segment_length_samples + 1, hop_length):
+            segment = signal_data[start:start + segment_length_samples]
+            features = extract_time_domain_features(segment)
+            features_list.append(features)
+
+        X_test = pd.DataFrame(features_list).values
+
+        # Apply preprocessing
+        X_scaled = scaler.transform(X_test)
+        X_pca = pca.transform(X_scaled)
+
+        # Predict
+        predictions = model.predict(X_pca)
+
+        # Get anomaly scores if available
+        anomaly_scores = None
+        if hasattr(model, 'decision_function'):
+            anomaly_scores = model.decision_function(X_pca).tolist()
+
+        # Calculate statistics
+        anomaly_count = int(np.sum(predictions == -1))
+        anomaly_ratio = float(anomaly_count / len(predictions))
+
+        # Assess overall health
+        if anomaly_ratio < 0.1:
+            overall_health = "Healthy"
+            confidence = "High"
+        elif anomaly_ratio < 0.3:
+            overall_health = "Suspicious"
+            confidence = "Medium"
+        else:
+            overall_health = "Faulty"
+            confidence = "High"
+
+        if ctx:
+            await ctx.info(f"Analyzed {len(predictions)} segments")
+            await ctx.info(f"Anomalies detected: {anomaly_count} ({anomaly_ratio*100:.1f}%)")
+            await ctx.info(f"Health status: {overall_health}")
+
+        return AnomalyPredictionResult(
+            num_segments=len(predictions),
+            anomaly_count=anomaly_count,
+            anomaly_ratio=anomaly_ratio,
+            predictions=predictions.tolist(),
+            anomaly_scores=anomaly_scores,
+            overall_health=overall_health,
+            confidence=confidence
+        )
+
+    # ------------------------------------------------------------------
+    # Machine documentation tools
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    async def list_machine_manuals(ctx: Context | None = None) -> list[dict[str, Any]]:
+        """
+        List all available machine manuals in resources/machine_manuals/.
+
+        Returns list of PDFs and text files with filename, size, and modification date.
+        Use this to see what manuals are available before extracting specs.
+
+        **IMPORTANT - LLM Usage Guidelines:**
+        - This tool returns ONLY the list of available files
+        - DO NOT make assumptions about manual content without reading it
+        - DO NOT infer specifications without using extract_manual_specs() or read_manual_excerpt()
+        - ALWAYS use the returned filenames exactly as-is when calling other tools
+        - If user asks about manual content, use read_manual_excerpt() or extract_manual_specs()
+
+        Returns:
+            List of dictionaries with manual information
+
+        Example:
+            >>> manuals = list_machine_manuals()
+            >>> print(f"Found {len(manuals)} manuals")
+            >>> for m in manuals:
+            ...     print(f"- {m['filename']}: {m['size_mb']:.2f} MB")
+        """
+        manuals_dir = RESOURCES_DIR / "machine_manuals"
+        manuals = []
+
+        # Support both PDF and TXT files
+        for manual_file in list(manuals_dir.glob("*.pdf")) + list(manuals_dir.glob("*.txt")):
+            stat = manual_file.stat()
+            manuals.append({
+                "filename": manual_file.name,
+                "size_mb": stat.st_size / (1024 * 1024),
+                "modified": stat.st_mtime,
+                "path": str(manual_file.relative_to(RESOURCES_DIR))
+            })
+
+        if ctx:
+            await ctx.info(f"Found {len(manuals)} machine manuals in resources/machine_manuals/")
+
+
+        return sorted(manuals, key=lambda x: x['filename'])
+
+    @mcp.tool()
+    async def extract_manual_specs(
+        manual_filename: str,
+        use_cache: bool = True,
+        ctx: Context | None = None
+    ) -> dict[str, Any]:
+        """
+        Extract machine specifications from equipment manual PDF.
+
+        Automatically extracts:
+        - Bearing designations (e.g., SKF 6205, FAG NU2205)
+        - Operating speeds (RPM values)
+        - Power ratings (kW, HP, MW)
+        - Text excerpt for LLM context
+
+        Results are cached for fast repeated access.
+
+        **IMPORTANT - LLM Usage Guidelines:**
+        - This tool returns ONLY data extracted from the manual text
+        - DO NOT add information not present in the extraction results
+        - DO NOT make assumptions about missing specifications
+        - If a specification is not in the results, tell the user it was not found
+        - ALWAYS base your response exclusively on the returned dictionary
+        - If user needs more detail, suggest using read_manual_excerpt() to read full text
+        - DO NOT invent bearing geometries, frequencies, or other technical data
+
+        **WORKFLOW for missing bearing geometry:**
+        1. Check if bearing geometry is in extraction results (rare in manuals)
+        2. If not found, use search_bearing_catalog(bearing_designation) tool
+        3. If bearing not in catalog, ask user to provide:
+           - All geometric parameters (num_balls, ball_diameter_mm, pitch_diameter_mm, contact_angle_deg)
+           - OR upload manufacturer catalog to bearing_catalogs/ directory
+
+        Args:
+            manual_filename: PDF filename in resources/machine_manuals/
+            use_cache: Use cached extraction if available (default: True)
+            ctx: MCP context
+
+        Returns:
+            Dictionary with extracted specifications and text excerpt
+
+        Example:
+            >>> specs = extract_manual_specs("pump_XYZ_manual.pdf")
+            >>> print(f"Bearings: {specs['bearings']}")
+            >>> print(f"RPM: {specs['rpm_values']}")
+            >>> print(f"Power: {specs['power_ratings']}")
+        """
+        if ctx:
+            await ctx.info(f"Extracting specifications from: {manual_filename}")
+
+        manual_path = RESOURCES_DIR / "machine_manuals" / manual_filename
+
+        if not manual_path.exists():
+            raise FileNotFoundError(
+                f"Manual not found: {manual_filename}\n"
+                f"Available manuals: {[f.name for f in (RESOURCES_DIR / 'machine_manuals').glob('*.pdf')]}"
+            )
+
+        # Extract specs (with caching)
+        specs = extract_machine_specs(manual_path, use_cache=use_cache)
+
+        if ctx:
+            await ctx.info(f"Found {len(specs['bearings'])} bearing designations")
+            await ctx.info(f"Found {len(specs['rpm_values'])} RPM values")
+            if specs['bearings']:
+                await ctx.info(f"Bearings: {', '.join(specs['bearings'][:5])}")
+
+        return specs
+
+    @mcp.tool()
+    async def calculate_bearing_characteristic_frequencies(
+        num_balls: int,
+        ball_diameter_mm: float,
+        pitch_diameter_mm: float,
+        contact_angle_deg: float = 0.0,
+        shaft_speed_rpm: float = 1500.0,
+        ctx: Context | None = None
+    ) -> dict[str, float]:
+        """
+        Calculate bearing characteristic frequencies from geometry.
+
+        Uses formulas from ISO 15243:2017 and SKF bearing handbook.
+        Essential for bearing fault diagnosis when you know bearing geometry
+        but don't have pre-calculated frequencies.
+
+        **IMPORTANT - LLM Usage Guidelines:**
+        - This tool REQUIRES exact bearing geometry parameters
+        - DO NOT guess or estimate bearing geometry if not provided
+        - DO NOT use "typical" or "standard" values without user confirmation
+        - If geometry is unknown, tell user to:
+          1. Check manual using read_manual_excerpt()
+          2. Look up bearing in manufacturer catalog (e.g., SKF, FAG, NSK)
+          3. Use lookup_bearing_in_catalog() if bearing designation is known
+          4. Measure the bearing physically if necessary
+        - ONLY calculate with geometry explicitly provided by user or found in manual
+        - DO NOT make assumptions about contact angle (use 0 deg if unknown and inform user)
+
+        Args:
+            num_balls: Number of rolling elements (Z)
+            ball_diameter_mm: Ball/roller diameter (Bd) in mm
+            pitch_diameter_mm: Pitch circle diameter (Pd) in mm
+            contact_angle_deg: Contact angle (alpha) in degrees (0 deg for deep groove ball bearings)
+            shaft_speed_rpm: Shaft rotation speed in RPM
+            ctx: MCP context
+
+        Returns:
+            Dictionary with BPFO, BPFI, BSF, FTF in Hz
+
+        Example:
+            >>> # For SKF 6205 bearing at 1797 RPM
+            >>> freqs = calculate_bearing_characteristic_frequencies(
+            ...     num_balls=9,
+            ...     ball_diameter_mm=7.94,
+            ...     pitch_diameter_mm=34.55,
+            ...     contact_angle_deg=0.0,
+            ...     shaft_speed_rpm=1797
+            ... )
+            >>> print(f"BPFO: {freqs['BPFO']:.2f} Hz")
+            BPFO: 81.13 Hz
+
+        Common bearing geometries:
+        - Deep groove ball bearings: contact_angle = 0 deg
+        - Angular contact bearings: contact_angle = 15-40 deg
+        - Cylindrical roller bearings: contact_angle = 0 deg
+        """
+        if ctx:
+            await ctx.info(f"Calculating bearing frequencies for {num_balls} balls at {shaft_speed_rpm} RPM")
+
+        freqs = calculate_bearing_frequencies(
+            num_balls=num_balls,
+            ball_diameter_mm=ball_diameter_mm,
+            pitch_diameter_mm=pitch_diameter_mm,
+            contact_angle_deg=contact_angle_deg,
+            shaft_speed_rpm=shaft_speed_rpm
+        )
+
+        if ctx:
+            await ctx.info(f"BPFO (outer race): {freqs['BPFO']:.2f} Hz")
+            await ctx.info(f"BPFI (inner race): {freqs['BPFI']:.2f} Hz")
+            await ctx.info(f"BSF (ball spin): {freqs['BSF']:.2f} Hz")
+            await ctx.info(f"FTF (cage): {freqs['FTF']:.2f} Hz")
+
+        return freqs
+
+    @mcp.tool()
+    async def read_manual_excerpt(
+        manual_filename: str,
+        max_pages: int = 10,
+        ctx: Context | None = None
+    ) -> str:
+        """
+        Read text excerpt from machine manual (PDF or TXT).
+
+        Useful for providing context to LLM for questions about
+        specific machine parameters, maintenance procedures, etc.
+
+        **Token Warning**: Reading many pages can consume significant tokens.
+        Start with max_pages=10 and increase if needed.
+
+        **IMPORTANT - LLM Usage Guidelines:**
+        - This tool returns ONLY the text extracted from the manual
+        - Base your answers EXCLUSIVELY on the returned text
+        - DO NOT add information not present in the extracted text
+        - If information is not found in the text, clearly state "Not found in manual"
+        - DO NOT make assumptions or fill gaps with general knowledge
+        - If user needs more pages, suggest increasing max_pages parameter
+        - ALWAYS cite the manual when answering: "According to the manual..."
+
+        Args:
+            manual_filename: Manual filename in resources/machine_manuals/ (PDF or TXT)
+            max_pages: Maximum number of pages to extract (default: 10, ignored for TXT files)
+            ctx: MCP context
+
+        Returns:
+            Extracted text from manual
+
+        Example:
+            >>> text = read_manual_excerpt("pump_manual.pdf", max_pages=5)
+            >>> # LLM can now answer: "What bearings are recommended for this pump?"
+        """
+        if ctx:
+            await ctx.info(f"Reading from: {manual_filename}")
+
+        manual_path = RESOURCES_DIR / "machine_manuals" / manual_filename
+
+        if not manual_path.exists():
+            raise FileNotFoundError(f"Manual not found: {manual_filename}")
+
+        # Read based on file type
+        if manual_path.suffix.lower() == '.txt':
+            with open(manual_path, 'r', encoding='utf-8') as f:
+                text = f.read()
+            if ctx:
+                await ctx.info(f"Extracted {len(text)} characters from text file")
+        else:
+            text = extract_text_from_pdf(manual_path, max_pages=max_pages)
+            if ctx:
+                await ctx.info(f"Extracted {len(text)} characters from {max_pages} pages")
+
+        return text
+
+    @mcp.tool()
+    async def search_bearing_catalog(
+        bearing_designation: str,
+        ctx: Context | None = None
+    ) -> dict[str, Any]:
+        """
+        Search for bearing specifications in local bearing catalogs.
+
+        This is a FALLBACK tool. LLM should use this ONLY when:
+        1. Bearing designation found in machine manual
+        2. Bearing geometry NOT found in machine manual
+        3. Need geometry to calculate characteristic frequencies
+
+        **IMPORTANT - LLM Usage Guidelines:**
+        - Use this tool ONLY after checking machine manual first
+        - DO NOT use this as primary source - manual takes precedence
+        - If bearing not found here, ask user for specifications
+        - DO NOT guess or estimate if bearing not in catalog
+        - This catalog contains ~20 common ISO bearings (6200-6210, 6300-6310 series)
+        - For uncommon bearings, tell user: "Bearing {X} not in catalog. Please provide geometry or upload manufacturer catalog to bearing_catalogs/"
+
+        Search order:
+        1. JSON catalog (common_bearings_catalog.json) - 20 common bearings
+        2. In-memory fallback (legacy 6205, 6206)
+        3. Returns None if not found
+
+        Args:
+            bearing_designation: Bearing designation (e.g., "6205", "SKF 6205-2RS", "FAG 6206")
+            ctx: MCP context
+
+        Returns:
+            Dictionary with bearing specifications if found, None otherwise
+
+        Example:
+            >>> specs = search_bearing_catalog("SKF 6205-2RS")
+            >>> print(f"Balls: {specs['num_balls']}, Diameter: {specs['ball_diameter_mm']} mm")
+            Balls: 9, Diameter: 7.94 mm
+        """
+        if ctx:
+            await ctx.info(f"Searching catalog for bearing: {bearing_designation}")
+
+        try:
+            from ..document_reader import lookup_bearing_in_catalog
+
+            bearing_specs = lookup_bearing_in_catalog(bearing_designation)
+
+            if bearing_specs:
+                if ctx:
+                    await ctx.info(f"Found {bearing_specs['designation']} in catalog (source: {bearing_specs.get('source', 'unknown')})")
+                    await ctx.info(f"  Type: {bearing_specs.get('type', 'N/A')}")
+                    await ctx.info(f"  Balls: {bearing_specs['num_balls']}, Ball diameter: {bearing_specs['ball_diameter_mm']} mm")
+                    await ctx.info(f"  Pitch diameter: {bearing_specs['pitch_diameter_mm']} mm")
+                return bearing_specs
+            else:
+                if ctx:
+                    await ctx.warning(f"Bearing {bearing_designation} not found in catalog")
+                    await ctx.warning("  LLM should ask user for bearing geometry or suggest uploading manufacturer catalog")
+                return {
+                    "error": f"Bearing {bearing_designation} not found in catalog",
+                    "suggestion": "Ask user for bearing geometry (num_balls, ball_diameter_mm, pitch_diameter_mm, contact_angle_deg) or upload manufacturer catalog PDF to resources/bearing_catalogs/",
+                    "catalog_contains": "Common ISO bearings: 6200-6210, 6300-6310 series"
+                }
+
+        except Exception as e:
+            logger.error(f"Error searching bearing catalog: {e}")
+            if ctx:
+                await ctx.error(f"Error searching catalog: {str(e)}")
+            return {
+                "error": str(e),
+                "suggestion": "Check that bearing_catalogs directory exists and contains common_bearings_catalog.json"
+            }
+
+    # ------------------------------------------------------------------
+    # Document search (RAG)
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    async def search_documentation(
+        query: str,
+        top_k: int = 5,
+        force_reindex: bool = False,
+        ctx: Context | None = None
+    ) -> dict[str, Any]:
+        """
+        Semantic search across all machine manuals and bearing catalogs.
+
+        Uses vector retrieval (RAG) to find the most relevant passages from
+        PDFs, text files, and JSON catalogs in resources/.
+
+        Backends (chosen automatically):
+          - FAISS + sentence-transformers  (pip install predictive-maintenance-mcp[vector-search])
+          - TF-IDF keyword search          (default, zero extra deps)
+
+        The index is built lazily on first call and cached on disk.  It is
+        automatically rebuilt when source files change.
+
+        Args:
+            query: Natural-language question or keywords
+                   (e.g. "bearing 6205 geometry", "maintenance interval pump")
+            top_k: Number of passages to return (default: 5)
+            force_reindex: Rebuild the index even if cache is fresh (default: False)
+            ctx: MCP context
+
+        Returns:
+            Dictionary with ranked results, each containing text passage, source
+            file, relevance score, and chunk index.
+        """
+        from ..rag import get_or_build_index, backend_name
+
+        if ctx:
+            await ctx.info(f"Searching documentation for: {query!r} (backend: {backend_name()})")
+
+        idx = get_or_build_index(force_rebuild=force_reindex)
+
+        if idx.num_chunks == 0:
+            return {
+                "results": [],
+                "backend": backend_name(),
+                "note": "No documents indexed. Add PDFs or TXT files to resources/machine_manuals/ or resources/bearing_catalogs/."
+            }
+
+        results = idx.query(query, top_k=top_k)
+
+        if ctx:
+            await ctx.info(f"Found {len(results)} relevant passages from {len(set(r['source'] for r in results))} documents")
+
+        return {
+            "query": query,
+            "num_results": len(results),
+            "total_chunks_indexed": idx.num_chunks,
+            "backend": backend_name(),
+            "results": results,
+        }
+
+    # ------------------------------------------------------------------
+    # Bearing diagnostics (Phase 1 -- signal_id based)
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    async def check_bearing_fault_peak_tool(
+        ctx: Context,
+        signal_id: str,
+        bearing_id: str,
+        fault_type: str,
+        rpm: float,
+        tolerance_pct: float = 5.0,
+    ) -> BearingFaultCheckResult:
+        """Check for a specific bearing fault frequency in a stored signal.
+
+        Args:
+            signal_id: ID of the stored signal.
+            bearing_id: Bearing designation (e.g. '6205').
+            fault_type: Which fault to check: 'BPFO', 'BPFI', 'BSF', or 'FTF'.
+            rpm: Shaft speed in RPM.
+            tolerance_pct: Frequency matching tolerance (default 5%).
+        """
+        repo = get_repository()
+        signal_data = repo.get_signal(signal_id)
+        info = repo.get_signal_info(signal_id)
+        fs = info.get("sampling_rate")
+        if fs is None:
+            raise ValueError(f"No sampling_rate for signal '{signal_id}'.")
+
+        # Look up expected frequency
+        freq_data = _compute_fault_freqs(bearing_id, rpm)
+        if freq_data is None:
+            raise ValueError(f"Bearing '{bearing_id}' not found in catalog.")
+
+        fault_type_upper = fault_type.upper()
+        if fault_type_upper not in freq_data:
+            raise ValueError(f"Invalid fault_type '{fault_type}'. Use BPFO, BPFI, BSF, or FTF.")
+
+        expected = freq_data[fault_type_upper]
+
+        if ctx:
+            await ctx.info(f"Checking {fault_type_upper} at {expected:.2f} Hz for bearing {bearing_id}")
+
+        result = _check_fault_peak(
+            signal=signal_data,
+            fs=fs,
+            expected_freq=expected,
+            fault_type=fault_type_upper,
+            bearing_id=bearing_id,
+            signal_id=signal_id,
+            tolerance_pct=tolerance_pct,
+        )
+
+        return BearingFaultCheckResult(**result)
+
+    @mcp.tool()
+    async def check_bearing_faults_direct(
+        ctx: Context,
+        signal_id: str,
+        bearing_id: str,
+        rpm: float,
+        tolerance_pct: float = 5.0,
+    ) -> BearingFaultsSummary:
+        """Run all bearing fault checks (BPFO, BPFI, BSF, FTF) on a stored signal.
+
+        Args:
+            signal_id: ID of the stored signal.
+            bearing_id: Bearing designation (e.g. '6205').
+            rpm: Shaft speed in RPM.
+            tolerance_pct: Frequency matching tolerance (default 5%).
+        """
+        repo = get_repository()
+        signal_data = repo.get_signal(signal_id)
+        info = repo.get_signal_info(signal_id)
+        fs = info.get("sampling_rate")
+        if fs is None:
+            raise ValueError(f"No sampling_rate for signal '{signal_id}'.")
+
+        if ctx:
+            await ctx.info(f"Running all bearing fault checks for {bearing_id} at {rpm} RPM")
+
+        result = _check_all_faults(
+            signal=signal_data,
+            fs=fs,
+            bearing_id=bearing_id,
+            rpm=rpm,
+            signal_id=signal_id,
+            tolerance_pct=tolerance_pct,
+        )
+
+        return BearingFaultsSummary(
+            signal_id=result["signal_id"],
+            bearing_id=result["bearing_id"],
+            rpm=result["rpm"],
+            shaft_frequency_hz=result["shaft_frequency_hz"],
+            bearing_frequencies=result["bearing_frequencies"],
+            fault_checks=[BearingFaultCheckResult(**c) for c in result["fault_checks"]],
+            overall_assessment=result["overall_assessment"],
+            most_likely_fault=result["most_likely_fault"],
+        )
+
+    @mcp.tool()
+    async def lookup_bearing_and_compute_tool(
+        ctx: Context,
+        bearing_type: str,
+        rpm: float,
+        signal_id: str,
+        tolerance_pct: float = 5.0,
+    ) -> BearingFaultsSummary:
+        """Look up bearing, compute fault frequencies, and check signal -- all in one call.
+
+        End-to-end bearing analysis: catalog lookup + frequency calculation +
+        envelope spectrum fault detection.
+
+        Args:
+            bearing_type: Bearing designation (e.g. 'SKF 6205-2RS', '6205').
+            rpm: Shaft speed in RPM.
+            signal_id: ID of the stored signal.
+            tolerance_pct: Frequency matching tolerance (default 5%).
+        """
+        repo = get_repository()
+        signal_data = repo.get_signal(signal_id)
+        info = repo.get_signal_info(signal_id)
+        fs = info.get("sampling_rate")
+        if fs is None:
+            raise ValueError(f"No sampling_rate for signal '{signal_id}'.")
+
+        if ctx:
+            await ctx.info(f"End-to-end bearing analysis: {bearing_type} at {rpm} RPM")
+
+        result = _lookup_and_compute(
+            signal=signal_data,
+            fs=fs,
+            bearing_type=bearing_type,
+            rpm=rpm,
+            signal_id=signal_id,
+            tolerance_pct=tolerance_pct,
+        )
+
+        return BearingFaultsSummary(
+            signal_id=result["signal_id"],
+            bearing_id=result["bearing_id"],
+            rpm=result["rpm"],
+            shaft_frequency_hz=result["shaft_frequency_hz"],
+            bearing_frequencies=result["bearing_frequencies"],
+            fault_checks=[BearingFaultCheckResult(**c) for c in result["fault_checks"]],
+            overall_assessment=result["overall_assessment"],
+            most_likely_fault=result["most_likely_fault"],
+        )
+
+    # ------------------------------------------------------------------
+    # ISO severity & diagnosis (Phase 1 -- signal_id based)
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    async def assess_vibration_severity(
+        ctx: Context,
+        signal_id: str,
+        machine_class: str = "II",
+        axis: str = "vertical",
+    ) -> VibrationSeverityResult:
+        """Assess vibration severity per ISO 10816/20816 for a stored signal.
+
+        Uses the signal_id pattern (load once, reference by ID).
+        Signal unit is read from metadata; defaults to 'g' if unknown.
+
+        Args:
+            signal_id: ID of the stored signal.
+            machine_class: 'I' (small <15kW), 'II' (medium 15-300kW),
+                'III' (large rigid >300kW), 'IV' (large flexible).
+            axis: Measurement axis (informational).
+        """
+        repo = get_repository()
+        signal_data = repo.get_signal(signal_id)
+        info = repo.get_signal_info(signal_id)
+        fs = info.get("sampling_rate")
+        if fs is None:
+            raise ValueError(f"No sampling_rate for signal '{signal_id}'.")
+
+        signal_unit = info.get("signal_unit", "g")
+        if ctx:
+            await ctx.info(f"Assessing ISO severity for '{signal_id}' (class {machine_class}, unit: {signal_unit})")
+
+        result = _assess_severity(
+            signal=signal_data,
+            fs=fs,
+            machine_class=machine_class,
+            axis=axis,
+            signal_unit=signal_unit,
+        )
+        result["signal_id"] = signal_id
+
+        if ctx:
+            await ctx.info(f"Zone {result['zone']} ({result['severity_level']}): {result['rms_velocity_mm_s']:.2f} mm/s")
+
+        return VibrationSeverityResult(**result)
+
+    @mcp.tool()
+    async def diagnose_vibration_tool(
+        ctx: Context,
+        signal_id: str,
+        rpm: float,
+        bearing_id: Optional[str] = None,
+        machine_class: str = "II",
+    ) -> DiagnosisResult:
+        """Full integrated diagnosis: FFT + PSD + STFT + bearing faults + ISO severity.
+
+        Comprehensive vibration diagnostic pipeline. Loads signal from repository,
+        runs all analyses, and synthesizes results into an actionable report.
+
+        Args:
+            signal_id: ID of the stored signal.
+            rpm: Machine operating speed in RPM.
+            bearing_id: Bearing designation for fault detection (optional).
+            machine_class: ISO machine class (default 'II').
+        """
+        repo = get_repository()
+        signal_data = repo.get_signal(signal_id)
+        info = repo.get_signal_info(signal_id)
+        fs = info.get("sampling_rate")
+        if fs is None:
+            raise ValueError(f"No sampling_rate for signal '{signal_id}'.")
+
+        signal_unit = info.get("signal_unit", "g")
+        if ctx:
+            await ctx.info(f"Running full diagnosis for '{signal_id}' at {rpm} RPM")
+            if bearing_id:
+                await ctx.info(f"Bearing analysis: {bearing_id}")
+
+        result = _diagnose_vibration(
+            signal=signal_data,
+            fs=fs,
+            rpm=rpm,
+            signal_id=signal_id,
+            bearing_id=bearing_id,
+            machine_class=machine_class,
+            signal_unit=signal_unit,
+        )
+
+        # Convert nested dicts to Pydantic models
+        bearing_faults_model = None
+        if result["bearing_faults"]:
+            bf = result["bearing_faults"]
+            bearing_faults_model = BearingFaultsSummary(
+                signal_id=bf["signal_id"],
+                bearing_id=bf["bearing_id"],
+                rpm=bf["rpm"],
+                shaft_frequency_hz=bf["shaft_frequency_hz"],
+                bearing_frequencies=bf["bearing_frequencies"],
+                fault_checks=[BearingFaultCheckResult(**c) for c in bf["fault_checks"]],
+                overall_assessment=bf["overall_assessment"],
+                most_likely_fault=bf["most_likely_fault"],
+            )
+
+        iso_model = VibrationSeverityResult(**result["iso_severity"])
+
+        if ctx:
+            await ctx.info(f"Diagnosis complete: {result['confidence']} confidence")
+            await ctx.info(f"ISO Zone: {result['iso_severity']['zone']}")
+            for rec in result["recommendations"]:
+                await ctx.info(f"  -> {rec}")
+
+        return DiagnosisResult(
+            signal_id=result["signal_id"],
+            rpm=result["rpm"],
+            bearing_id=result["bearing_id"],
+            machine_class=result["machine_class"],
+            fft_summary=result["fft_summary"],
+            psd_summary=result["psd_summary"],
+            stft_summary=result["stft_summary"],
+            bearing_faults=bearing_faults_model,
+            iso_severity=iso_model,
+            anomaly_detection=result.get("anomaly_detection"),
+            overall_diagnosis=result["overall_diagnosis"],
+            confidence=result["confidence"],
+            recommendations=result["recommendations"],
+        )

--- a/src/mcp_tools/prompts.py
+++ b/src/mcp_tools/prompts.py
@@ -1,0 +1,619 @@
+"""MCP diagnostic prompts for guided analysis workflows."""
+
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+
+def register(mcp):
+    """Register diagnostic prompts on the MCP server."""
+
+    @mcp.prompt()
+    def diagnose_bearing(
+        signal_file: str,
+        sampling_rate: Optional[float] = None,
+        machine_group: int = 2,  # CHANGED: Default 2 (medium) - most common
+        support_type: str = "rigid",  # Default rigid - most common
+        operating_speed_rpm: Optional[float] = None,
+        bpfo: Optional[float] = None,
+        bpfi: Optional[float] = None,
+        bsf: Optional[float] = None,
+        ftf: Optional[float] = None
+    ) -> str:
+        """
+        Guided workflow for bearing diagnostics with ISO 20816-3 compliance.
+
+        Evidence-based policy:
+        - Envelope peaks at characteristic frequencies are PRIMARY indicators (strong evidence)
+        - Statistical indicators (CF>6, Kurtosis>10) are SECONDARY/confirmatory
+        - If envelope shows clear peaks at BPFO/BPFI/BSF/FTF (±5% tolerance) → bearing fault is STRONGLY indicated
+        - Additional high CF or Kurtosis reinforces the diagnosis but is not strictly required if envelope evidence is clear
+
+        **ISO 20816-3 Defaults** (use if user doesn't specify):
+        - machine_group = 2 (medium-sized machines, 15-300 kW, most common)
+        - support_type = "rigid" (horizontal machines on foundations)
+
+        Args:
+            signal_file: Name of the signal file to analyze
+            sampling_rate: Sampling frequency in Hz (if None, will check metadata or ask user)
+            machine_group: ISO machine group (1=large >300kW, 2=medium 15-300kW) (default: 2)
+            support_type: 'rigid' or 'flexible' (default: 'rigid' for horizontal machines)
+            operating_speed_rpm: Operating speed in RPM (required for interpreting results)
+            bpfo: Ball Pass Frequency Outer race (Hz) - if known
+            bpfi: Ball Pass Frequency Inner race (Hz) - if known
+            bsf: Ball Spin Frequency (Hz) - if known
+            ftf: Fundamental Train Frequency (Hz) - if known
+        """
+        # Build frequency reference string
+        freq_refs = []
+        if bpfo: freq_refs.append(f"BPFO={bpfo:.2f} Hz")
+        if bpfi: freq_refs.append(f"BPFI={bpfi:.2f} Hz")
+        if bsf: freq_refs.append(f"BSF={bsf:.2f} Hz")
+        if ftf: freq_refs.append(f"FTF={ftf:.2f} Hz")
+        freq_info = ", ".join(freq_refs) if freq_refs else "NOT PROVIDED - must request from user"
+
+        rpm_info = f", {operating_speed_rpm}" if operating_speed_rpm else ""
+        fs_info = f"{sampling_rate}" if sampling_rate else "UNKNOWN"
+
+        return f"""Perform evidence-based bearing diagnostic on "{signal_file}":
+
+    ⚠️  CRITICAL INFERENCE POLICY ⚠️
+    ═══════════════════════════════════════════════════════════════════════════════
+    **NEVER INFER FAULT TYPE OR CONDITION FROM FILENAME**
+
+    - Filename "{signal_file}" is an OPAQUE IDENTIFIER ONLY
+    - "OuterRaceFault" in filename ≠ outer race fault exists
+    - "baseline" in filename ≠ healthy signal
+    - "InnerRaceFault" in filename ≠ inner race fault exists
+
+    **BASE DIAGNOSIS EXCLUSIVELY ON:**
+    1. Envelope spectrum peaks matching BPFO/BPFI/BSF/FTF (±5% tolerance)
+    2. Statistical indicators (CF, Kurtosis) as SECONDARY confirmation
+    3. ISO 20816-3 zone measurement
+
+    **IF FILENAME CONTRADICTS ANALYSIS:**
+    Report: "Despite filename suggesting [X], analysis shows [Y]"
+    Example: "Despite 'OuterRaceFault' in filename, envelope analysis shows NO peaks at BPFO"
+
+    ═══════════════════════════════════════════════════════════════════════════════
+    STEP 0 — FILENAME RESOLUTION & MANDATORY PARAMETER CHECK
+    ═══════════════════════════════════════════════════════════════════════════════
+
+    1. Verify signal file existence:
+       Call list_available_signals() to get exact filename.
+       If "{signal_file}" not found or multiple matches exist, ASK USER to clarify.
+       Do NOT guess or auto-correct filenames.
+
+    2. Required parameters:
+       ✓ Signal file: {signal_file}
+       {'✓' if sampling_rate else '✗'} Sampling rate: {fs_info} Hz
+       {'✓' if operating_speed_rpm else '✗'} Operating speed: {operating_speed_rpm or 'NOT PROVIDED'} RPM
+       {'✓' if freq_refs else '✗'} Bearing characteristic frequencies: {freq_info}
+
+       CRITICAL RULE: If sampling_rate is UNKNOWN, check signal metadata JSON first.
+       If still missing OR if bearing frequencies (BPFO/BPFI/BSF/FTF) are NOT PROVIDED:
+       → STOP and ASK USER for these parameters before proceeding.
+       → Explain: "Cannot perform bearing diagnosis without [missing parameters]. Please provide: ..."
+
+       Example response when parameters are missing:
+       "I cannot proceed with the bearing diagnosis because the following required
+       parameters are missing:
+       - Bearing characteristic frequencies (BPFO, BPFI, BSF, FTF)
+       Please provide these values so I can complete the envelope analysis and
+       identify the fault type."
+
+       Do NOT use placeholder/default values. Do NOT proceed with incomplete data.
+       Do NOT attempt diagnosis without characteristic frequencies.
+
+    ═══════════════════════════════════════════════════════════════════════════════
+    STEP 1 — ISO 20816-3 (Severity Context)
+    ═══════════════════════════════════════════════════════════════════════════════
+
+    BEFORE calling evaluate_iso_20816, ASK USER to confirm machine parameters:
+
+    "For ISO 20816-3 evaluation, I need to know:
+    1. Machine group:
+       - Group 1 (large): >300 kW or shaft height ≥ 315 mm
+       - Group 2 (medium): 15-300 kW or shaft height 160-315 mm
+
+    2. Support type:
+       - Rigid: Foundation natural freq > 1.25× operating freq
+       - Flexible: All other cases (typical for large machines)
+
+    Based on your description, I'll assume:
+    - Machine group: {machine_group} (default for typical industrial equipment)
+    - Support type: {support_type} (most common)
+
+    Is this correct, or should I use different values?"
+
+    If user confirms or provides values, proceed with:
+    Call: evaluate_iso_20816("{signal_file}", {fs_info}, {machine_group}, "{support_type}"{rpm_info})
+    Report: RMS velocity and ISO zone (A/B/C/D) in 1-2 sentences.
+    Note: This provides overall severity but is NOT bearing-specific. Use for maintenance urgency only.
+
+    Optional visualization:
+    Call: generate_iso_report("{signal_file}", {machine_group}, "{support_type}"{rpm_info})
+    This saves an interactive HTML report to the reports/ directory showing:
+    - Color-coded ISO zone chart with marker on measured RMS velocity
+    - Time-domain signal plot
+    - Detailed severity assessment
+    The tool returns the file path. Tell user to open the returned HTML file path in their browser to view the interactive report.
+
+    ═══════════════════════════════════════════════════════════════════════════════
+    STEP 2 — Statistical Screening
+    ═══════════════════════════════════════════════════════════════════════════════
+
+    Call: analyze_statistics("{signal_file}")
+    Report: RMS, Crest Factor, Kurtosis (excess), Skewness in bullet points.
+
+    Interpretation flags (SECONDARY indicators):
+    • CF > 6 or Kurtosis > 10 → Strong impulsiveness (supports bearing fault hypothesis)
+    • CF 4-6 or Kurtosis 5-10 → Moderate impulsiveness (weak support)
+    • CF < 4 and Kurtosis < 5 → Low impulsiveness (but envelope may still show faults)
+
+    ⚠️ Do NOT diagnose from statistics alone. Proceed to envelope analysis.
+
+    ═══════════════════════════════════════════════════════════════════════════════
+    STEP 3 — FFT Spectrum (Contextual)
+    ═══════════════════════════════════════════════════════════════════════════════
+
+    Call: analyze_fft("{signal_file}", {fs_info})
+    Report dominant peaks in bullet points (top 5 only). Look for:
+    • Shaft speed (1× RPM = {operating_speed_rpm/60 if operating_speed_rpm else '?'} Hz) and harmonics
+    • Any elevated broadband noise
+
+    Optional visualization:
+    Call: generate_fft_report("{signal_file}", max_freq=5000, num_peaks=15)
+    This saves an interactive HTML report to the reports/ directory showing:
+    - FFT spectrum in dB scale with automatic peak detection
+    - Harmonic markers (if rotation frequency provided)
+    - Top frequency peaks table
+    The tool returns the file path. Tell user to open the returned HTML file path in their browser to view the interactive FFT analysis.
+
+    ═══════════════════════════════════════════════════════════════════════════════
+    STEP 4 — ENVELOPE ANALYSIS (PRIMARY DIAGNOSTIC EVIDENCE)
+    ═══════════════════════════════════════════════════════════════════════════════
+
+    Call: analyze_envelope("{signal_file}", {fs_info}, 500, 5000, num_peaks=10)
+
+    Expected frequencies (±5% tolerance):
+    {chr(10).join(f'  • {ref}' for ref in freq_refs) if freq_refs else '  (User must provide BPFO, BPFI, BSF, FTF)'}
+
+    Examine envelope spectrum peaks:
+    1. Check if ANY peak falls within ±5% of expected frequencies
+    2. Check for harmonics: 2×BPFO, 3×BPFO, 2×BPFI, etc.
+    3. List top 5-10 peaks with frequencies and magnitudes
+
+    Optional visualization:
+    Call: generate_envelope_report("{signal_file}",
+                                  bpfo={bpfo or 'None'},
+                                  bpfi={bpfi or 'None'},
+                                  bsf={bsf or 'None'},
+                                  ftf={ftf or 'None'},
+                                  filter_low=500,
+                                  filter_high=5000,
+                                  max_freq=500)
+    This saves an interactive HTML report to the reports/ directory showing:
+    - Filtered signal with envelope overlay (time domain)
+    - Envelope spectrum in dB scale with bearing frequency markers
+    - Automatic bearing fault detection with confidence levels
+    The tool returns the file path. Tell user to open the returned HTML file path in their browser to view the interactive envelope analysis with bearing fault markers.
+
+    ═══════════════════════════════════════════════════════════════════════════════
+    STEP 5 — DIAGNOSTIC DECISION (EVIDENCE-BASED)
+    ═══════════════════════════════════════════════════════════════════════════════
+
+    Decision tree:
+
+    A) IF envelope spectrum shows clear peak(s) at characteristic frequency (±5%):
+       → Bearing fault type is STRONGLY INDICATED
+
+       Classification by frequency:
+       • Peak at BPFO (±5%) → **Outer race fault**
+       • Peak at BPFI (±5%) → **Inner race fault**
+       • Peak at BSF (±5%) → **Rolling element (ball) fault**
+       • Peak at FTF (±5%) → **Cage fault**
+
+       Confidence level:
+       - High confidence: Peak + harmonics present AND (CF>6 OR Kurtosis>10)
+       - Moderate confidence: Peak present but weaker harmonics OR moderate stats (CF 4-6, Kurt 5-10)
+       - Note: Even without extreme statistics, clear envelope peaks ARE diagnostic
+
+    B) IF envelope shows ambiguous/borderline peaks:
+       → "Possible [fault type] - envelope peak near [frequency] but [state issue: weak magnitude, no harmonics, etc.]"
+       → Recommend: retake measurement, higher resolution, trending
+
+    C) IF no envelope peaks at characteristic frequencies:
+       → "No clear bearing fault signatures detected"
+       → IF stats are elevated: "High impulsiveness without bearing-specific frequencies suggests [other cause: impacts, looseness, etc.]"
+       → IF ISO zone C/D: "Elevated vibration without bearing signatures - check alignment, balance, structural issues"
+
+    ═══════════════════════════════════════════════════════════════════════════════
+    STEP 6 — RECOMMENDATIONS
+    ═══════════════════════════════════════════════════════════════════════════════
+
+    Based on diagnosis + ISO zone (ONLY use these recommendations - DO NOT invent others):
+    • Confirmed fault + Zone C/D → Immediate action: inspect bearing, plan replacement
+    • Confirmed fault + Zone B → Short-term action: schedule maintenance within 1-3 months, increase monitoring
+    • Confirmed fault + Zone A → Monitor closely: retest in 1-2 weeks, track progression
+    • No fault + Zone C/D → Investigate other causes: alignment, balance, looseness, foundation
+    • No fault + Zone A/B → Continue routine monitoring
+
+    CRITICAL: Do NOT suggest specific parameter values (e.g., filter frequencies, acquisition settings)
+    unless they appear in tool outputs. Do NOT invent troubleshooting steps beyond those listed above.
+
+    Always cite:
+    - Which envelope peaks were found (frequency, magnitude, harmonics)
+    - Statistical values (CF, Kurtosis) and how they support/contradict
+    - ISO zone and severity
+    - Specific tool outputs used
+
+    ═══════════════════════════════════════════════════════════════════════════════
+    OUTPUT FORMATTING (CRITICAL)
+    ═══════════════════════════════════════════════════════════════════════════════
+
+    Keep output CONCISE (≤300 words total):
+    • Use bullet points for all findings
+    • Provide brief summary first (2-3 sentences)
+    • Use generate_*_report() tools to create HTML reports (saved to reports/ directory)
+    • Tell user to open the HTML file path in browser for interactive visualizations
+    • If user needs more details, offer "Show detailed analysis?" continuation
+    • NEVER print large JSON/CSV data directly in text output
+    """
+
+
+    @mcp.prompt()
+    def diagnose_gear(
+        signal_file: str,
+        sampling_rate: Optional[float] = None,
+        num_teeth: Optional[int] = None,
+        rotation_speed_rpm: Optional[float] = None
+    ) -> str:
+        """
+        Evidence-based guided workflow for gear diagnostics with strict anti-speculation rules.
+
+        Args:
+            signal_file: Name of the signal file
+            sampling_rate: Sampling frequency in Hz (if None, will check metadata or ask user)
+            num_teeth: Number of gear teeth (REQUIRED for GMF calculation)
+            rotation_speed_rpm: Shaft rotation speed in RPM (REQUIRED for GMF and sideband identification)
+        """
+        fs_info = f"{sampling_rate}" if sampling_rate else "UNKNOWN"
+        teeth_info = f"{num_teeth}" if num_teeth else "NOT PROVIDED"
+        rpm_info = f"{rotation_speed_rpm}" if rotation_speed_rpm else "NOT PROVIDED"
+
+        return f"""Perform an evidence-based gear diagnostic on signal "{signal_file}":
+
+    ⚠️  CRITICAL INFERENCE POLICY ⚠️
+    ═══════════════════════════════════════════════════════════════════════════════
+    **NEVER INFER FAULT TYPE OR CONDITION FROM FILENAME**
+
+    - Filename "{signal_file}" is an OPAQUE IDENTIFIER ONLY
+    - "GearFault" in filename ≠ gear fault exists
+    - "baseline" in filename ≠ healthy signal
+    - "ToothDamage" in filename ≠ tooth damage exists
+
+    **BASE DIAGNOSIS EXCLUSIVELY ON:**
+    1. FFT spectrum showing GMF harmonics
+    2. Sidebands spaced by shaft rotation frequency (f_rot)
+    3. Statistical indicators (Kurtosis) as SECONDARY confirmation
+
+    **IF FILENAME CONTRADICTS ANALYSIS:**
+    Report: "Despite filename suggesting [X], analysis shows [Y]"
+    Example: "Despite 'GearFault' in filename, FFT analysis shows NO GMF harmonics or sidebands"
+
+    ═══════════════════════════════════════════════════════════════════════════════
+    STEP 0 — FILENAME RESOLUTION & MANDATORY PARAMETER CHECK
+    ═══════════════════════════════════════════════════════════════════════════════
+
+    1. Verify signal file existence:
+       Call list_available_signals() to get exact filename.
+       If "{signal_file}" not found or multiple matches exist, ASK USER to clarify.
+       Do NOT guess or auto-correct filenames.
+
+    2. Required parameters:
+       ✓ Signal file: {signal_file}
+       {'✓' if sampling_rate else '✗'} Sampling rate: {fs_info} Hz
+       {'✓' if num_teeth else '✗'} Number of teeth (Z): {teeth_info}
+       {'✓' if rotation_speed_rpm else '✗'} Rotation speed: {rpm_info} RPM
+
+       CRITICAL RULE: If sampling_rate is UNKNOWN, check signal metadata JSON first.
+       If still missing OR if num_teeth OR rotation_speed_rpm are NOT PROVIDED:
+       → STOP and ASK USER for these parameters before proceeding.
+       → Explain: "Cannot perform gear diagnosis without [missing parameters]. Please provide: ..."
+
+       Example response when parameters are missing:
+       "I cannot proceed with the gear diagnosis because the following required
+       parameters are missing:
+       - Number of gear teeth (Z): needed to calculate Gear Mesh Frequency (GMF)
+       - Rotation speed (RPM): needed to identify GMF and sidebands
+       Please provide these values so I can complete the spectral analysis and
+       identify gear faults."
+
+       Do NOT use placeholder/default values. Do NOT proceed with incomplete data.
+       Do NOT attempt diagnosis without num_teeth and rotation_speed_rpm.
+
+    GUARDRAILS (apply throughout):
+    - Do NOT infer faults from filename, path, or labels.
+    - A gear tooth fault (localized damage) requires BOTH:
+      • Clear Gear Mesh Frequency (GMF) harmonics AND
+      • Sidebands spaced by shaft rotation frequency (f_rot) around GMF or its harmonics
+      • (Optional but reinforcing) Elevated Kurtosis (>5) or modulation energy
+    - Without sidebands: DO NOT claim tooth damage; consider uniform wear only if GMF elevated but stable statistics.
+
+    STEP 1 — INPUT & CONTEXT
+    Once all parameters confirmed:
+    - f_rot = rotation_speed_rpm / 60 = {f"{rotation_speed_rpm/60:.2f}" if rotation_speed_rpm else "?"} Hz
+    - Theoretical GMF = f_rot × Z = {f"{rotation_speed_rpm/60 * num_teeth:.2f}" if (rotation_speed_rpm and num_teeth) else "?"} Hz
+
+    STEP 2 — STATISTICS (screening only)
+    Call: analyze_statistics("{signal_file}")
+    Report RMS, Crest Factor, Kurtosis in bullet points (brief).
+    Indicators:
+    - Elevated RMS: possible general load / imbalance
+    - High Kurtosis (>5): impulsive impacts (may correlate with chipped tooth)
+    - High Crest Factor (>4): impulsiveness
+    (Do NOT diagnose from stats alone.)
+
+    STEP 3 — SPECTRUM (frequency evidence)
+    Call: analyze_fft("{signal_file}", {fs_info})
+    Extract dominant peaks up to, e.g., 5× expected GMF. Identify:
+    - GMF and its harmonics: GMF, 2×GMF, 3×GMF
+    - Sidebands: GMF ± n·f_rot (n=1..3). Log their presence, spacing consistency, and relative amplitudes.
+    Report top 5 peaks only (brief).
+
+    Optional visualization:
+    Call: generate_fft_report("{signal_file}", max_freq=5000, num_peaks=15)
+    This saves an interactive HTML report to the reports/ directory showing FFT spectrum with automatic peak detection.
+    Tell user to open the returned HTML file path in their browser to view the interactive FFT analysis.
+
+    STEP 4 — OPTIONAL ENVELOPE (if strong modulation or impacts)
+    If stats suggest impulsiveness OR sideband pattern partial:
+    Call: analyze_envelope("{signal_file}", {fs_info}, 500, 5000)
+    to inspect modulation signature. (Not mandatory if FFT already conclusive.)
+
+    STEP 5 — CLASSIFICATION (apply confirmation rule)
+    Decision categories (choose exactly one):
+    - "Gear tooth fault CONFIRMED" → Requires: (GMF harmonics present) AND (≥1 clear sideband pair with spacing ≈ f_rot) AND (supporting stat: Kurtosis>5 or CF>4)
+    - "Possible localized tooth damage" → Partial sidebands OR ambiguous spacing; list missing evidence required for confirmation.
+    - "Uniform wear / increased load" → Elevated GMF amplitude WITHOUT sidebands, normal/low impulsiveness.
+
+    Each conclusion MUST cite: tools used (statistics, FFT, envelope), specific numeric peaks (frequencies & magnitudes), sideband spacing vs expected f_rot (difference in Hz), and any supporting statistical thresholds.
+
+    STEP 6 — RECOMMENDATIONS (brief bullet points)
+    Provide actionable items aligned with category:
+    - Confirmed fault: plan inspection, tooth visual check, lubrication review, short-term monitoring interval suggestion.
+    - Possible fault: higher-resolution spectrum, trend GMF amplitude.
+    - Uniform wear: continue monitoring; schedule routine inspection.
+
+    ═══════════════════════════════════════════════════════════════════════════════
+    OUTPUT FORMATTING (CRITICAL)
+    ═══════════════════════════════════════════════════════════════════════════════
+
+    Keep output CONCISE (≤300 words total):
+    • Use bullet points for all findings
+    • Provide brief summary first (2-3 sentences)
+    • Use generate_fft_report() tool to create HTML reports (saved to reports/ directory)
+    • Tell user to open the HTML file path in browser for interactive visualizations
+    • If user needs more details, offer "Show detailed analysis?" continuation
+    • NEVER print large JSON/CSV data directly in text output
+    """
+
+
+    @mcp.prompt()
+    def quick_diagnostic_report(signal_file: str) -> str:
+        """
+        Quick, evidence-aware screening report (non-definitive).
+
+        Args:
+            signal_file: Name of the signal file
+        """
+        return f"""Generate a concise screening report for "{signal_file}" using only observable evidence:
+
+    STEP 0 — FILENAME RESOLUTION
+    Call list_available_signals() to verify exact filename.
+    If "{signal_file}" not found or multiple matches, ASK USER to clarify.
+
+    Guardrails:
+    - Ignore filenames/paths as diagnostic evidence.
+    - Do NOT diagnose faults from statistics alone; use them for screening only.
+    - Use cautious language: "possible/consistent with" unless corroborated by multiple indicators.
+
+    1) Load & sanity checks
+    - Report number of samples, duration (s), min/max values (brief, 1 line).
+
+    2) Statistics (screening)
+    Call: analyze_statistics("{signal_file}")
+    Report: RMS, Crest Factor, Kurtosis, Skewness (bullet points only).
+    Flags (screening thresholds, not definitive):
+    - CF > 4 → impulsiveness present; CF > 6 → strong impulsiveness
+    - Kurtosis > 0 → non-Gaussian / impulsive content (excess kurtosis); > 3 → significant; > 6 → severe
+    Note: These flags alone are insufficient for fault identification.
+
+    3) Spectral snapshot
+    Call: analyze_fft("{signal_file}", 10000)
+    - Report peak frequency, magnitude (top 3 peaks only).
+    - If operating speed is known, relate peaks to 1×/2× RPM; otherwise, request it for deeper interpretation.
+
+    4) Next-step guidance (evidence-first)
+    - If strong impulsiveness (CF>6 or Kurtosis>6), suggest: "Use diagnose_bearing prompt for targeted bearing analysis"
+    - If tonal/harmonic pattern dominates, suggest: "Use diagnose_gear prompt if gear suspected"
+    - If broadband increase, suggest: ISO 20816-3 check with evaluate_iso_20816()
+
+    Output format (≤200 words):
+    - Screening summary with measured values (bullet points)
+    - No definitive fault labels
+    - List recommended targeted analyses and required missing parameters
+    """
+
+
+    @mcp.prompt()
+    def generate_iso_diagnostic_report(
+        signal_file: str,
+        sampling_rate: float = 10000.0,
+        machine_group: int = 1,
+        support_type: str = "rigid",
+        operating_speed_rpm: Optional[float] = None,
+        machine_name: str = "Machine",
+        measurement_location: str = "Bearing"
+    ) -> str:
+        """
+        Generate comprehensive diagnostic report with ISO 20816-3 compliance evaluation.
+
+        Creates a structured diagnostic report including:
+        - ISO 20816-3 vibration severity assessment
+        - Statistical indicators
+        - Spectral analysis
+        - Fault detection (bearing/gear)
+        - Maintenance recommendations
+
+        Args:
+            signal_file: Name of the signal file to analyze
+            sampling_rate: Sampling frequency in Hz
+            machine_group: ISO 20816 group (1=large >300kW, 2=medium 15-300kW)
+            support_type: 'rigid' or 'flexible'
+            operating_speed_rpm: Operating speed in RPM
+            machine_name: Machine identifier
+            measurement_location: Measurement point description
+        """
+        rpm_param = f", operating_speed_rpm={operating_speed_rpm}" if operating_speed_rpm else ""
+
+        return f"""Generate a comprehensive diagnostic report for {machine_name} - {measurement_location}
+
+    SIGNAL: {signal_file}
+    SAMPLING RATE: {sampling_rate} Hz
+    MACHINE GROUP: {machine_group} ({'Large >300kW' if machine_group == 1 else 'Medium 15-300kW'})
+    SUPPORT TYPE: {support_type.title()}
+    OPERATING SPEED: {operating_speed_rpm if operating_speed_rpm else 'Not specified'} RPM
+
+    ================================================================================
+    SECTION 1: ISO 20816-3 VIBRATION SEVERITY ASSESSMENT
+    ================================================================================
+
+    Execute: evaluate_iso_20816("{signal_file}", {sampling_rate}, {machine_group}, "{support_type}"{rpm_param})
+
+    Present results in this format:
+
+    ┌─────────────────────────────────────────────────────────────────────┐
+    │ ISO 20816-3 EVALUATION RESULT                                       │
+    ├─────────────────────────────────────────────────────────────────────┤
+    │ RMS Velocity (broadband):     [VALUE] mm/s                          │
+    │ Frequency Range:               [RANGE] Hz                           │
+    │ Evaluation Zone:               Zone [A/B/C/D]                       │
+    │ Severity Level:                [Good/Acceptable/Unsatisfactory/     │
+    │                                 Unacceptable]                        │
+    │ Color Code:                    🟢/🟡/🟠/🔴                          │
+    ├─────────────────────────────────────────────────────────────────────┤
+    │ ZONE BOUNDARIES (mm/s):                                             │
+    │   Zone A/B: [VALUE]  |  Zone B/C: [VALUE]  |  Zone C/D: [VALUE]    │
+    ├─────────────────────────────────────────────────────────────────────┤
+    │ INTERPRETATION:                                                     │
+    │ [Zone description from result]                                      │
+    └─────────────────────────────────────────────────────────────────────┘
+
+    ISO COMPLIANCE STATUS:
+    • If Zone A (Green): ✅ COMPLIANT - Machine in excellent condition
+    • If Zone B (Yellow): ⚠️  ACCEPTABLE - Continue normal operation, monitor
+    • If Zone C (Orange): ⚠️  NON-COMPLIANT - Plan maintenance within 1-3 months
+    • If Zone D (Red): 🚨 CRITICAL - Immediate action required, risk of damage
+
+    ================================================================================
+    SECTION 2: STATISTICAL INDICATORS
+    ================================================================================
+
+    Execute: analyze_statistics("{signal_file}")
+
+    Report the following parameters:
+
+    ┌─────────────────────────────────────────────────────────────────────┐
+    │ STATISTICAL ANALYSIS                                                │
+    ├─────────────────────────────────────────────────────────────────────┤
+    │ RMS:                  [VALUE] (Energy level)                        │
+    │ Peak:                 [VALUE] (Maximum amplitude)                   │
+    │ Peak-to-Peak:         [VALUE] (Total excursion)                     │
+    │ Crest Factor:         [VALUE] (Peak/RMS ratio)                      │
+    │ Kurtosis:             [VALUE] (Impulsiveness indicator)             │
+    │ Skewness:             [VALUE] (Asymmetry indicator)                 │
+    └─────────────────────────────────────────────────────────────────────┘
+
+    DIAGNOSTIC INDICATORS:
+    • Crest Factor > 4: ⚠️  Possible presence of impulses (bearing faults)
+    • Crest Factor > 6: 🚨 High probability of bearing defects
+    • Kurtosis > 0: ⚠️  Non-Gaussian / impulsive content (excess kurtosis, Fisher convention)
+    • Kurtosis > 3: ⚠️  Significant impulsive content (bearing damage likely)
+    • Kurtosis > 6: 🚨 Severe bearing damage (strong impulses)
+
+    ================================================================================
+    SECTION 3: SPECTRAL ANALYSIS
+    ================================================================================
+
+    Execute: analyze_fft("{signal_file}", {sampling_rate}, max_frequency=1000)
+
+    Identify:
+    • Peak frequency and magnitude
+    • Frequency resolution
+    • Energy distribution across spectrum
+
+    Execute: plot_spectrum("{signal_file}", {sampling_rate}, freq_range=[0, 1000], num_peaks=15)
+
+    Look for:
+    • Dominant frequencies (possible fault indicators)
+    • Harmonics pattern (multiples of rotation frequency)
+    • Sidebands (modulation indicators)
+    • Broadband noise level
+
+    ================================================================================
+    SECTION 4: BEARING FAULT DETECTION
+    ================================================================================
+
+    Execute: analyze_envelope("{signal_file}", {sampling_rate}, filter_low=500, filter_high=5000, num_peaks=10)
+
+    Execute: plot_envelope("{signal_file}", {sampling_rate}, filter_band=[500, 5000], freq_range=[0, 100])
+
+    Analyze envelope spectrum peaks and compare with:
+    • BPFO (Ball Pass Frequency - Outer race): Outer race defect
+    • BPFI (Ball Pass Frequency - Inner race): Inner race defect
+    • BSF (Ball Spin Frequency): Rolling element defect
+    • FTF (Fundamental Train Frequency): Cage defect
+
+    Note: Envelope peaks at harmonics of these frequencies indicate bearing damage
+
+    ================================================================================
+    SECTION 5: OVERALL ASSESSMENT AND RECOMMENDATIONS
+    ================================================================================
+
+    Based on all analyses, provide:
+
+    MACHINE CONDITION SUMMARY:
+    ├─ ISO 20816-3 Status: [Compliant/Non-compliant]
+    ├─ Vibration Severity: [Zone A/B/C/D - Color code]
+    ├─ Fault Indicators: [Present/Absent]
+    └─ Urgency Level: [Normal/Monitor/Plan Maintenance/Immediate Action]
+
+    IDENTIFIED ISSUES (if any):
+    • [List any detected faults based on statistical/spectral/envelope analysis]
+
+    RECOMMENDATIONS:
+    1. IMMEDIATE ACTIONS (if Zone D or critical indicators):
+       - [Specific actions needed]
+
+    2. SHORT-TERM (1-3 months, if Zone C):
+       - [Maintenance planning recommendations]
+
+    3. MONITORING (if Zone B):
+       - [Suggested monitoring frequency and parameters]
+
+    4. ROUTINE OPERATION (if Zone A):
+       - [Continue normal operation, periodic checks]
+
+    ADDITIONAL DIAGNOSTICS (if needed):
+    • Consider trending analysis for Zone B/C
+    • Perform time-domain analysis if high Crest Factor
+    • Check alignment if high 1× RPM component
+    • Inspect lubrication if broadband noise increase
+
+    ================================================================================
+    REPORT GENERATED: [Current date/time]
+    ANALYZED BY: ISO 20816-3 Diagnostic System
+    ================================================================================
+    """

--- a/src/mcp_tools/report_tools.py
+++ b/src/mcp_tools/report_tools.py
@@ -1,0 +1,1391 @@
+"""MCP tools for report generation and visualization (ISO 13374 Block 6)."""
+
+import logging
+import json
+import pickle
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+from scipy import signal
+from scipy.fft import fft, fftfreq
+from scipy.signal import hilbert, butter, sosfiltfilt
+from sklearn.preprocessing import StandardScaler
+from sklearn.decomposition import PCA
+from mcp.server.fastmcp import FastMCP, Context
+
+from ..config import DATA_DIR, MODELS_DIR, RESOURCES_DIR, REPORTS_DIR
+from ..signal_loader import load_signal_data, get_metadata_path, extract_segment, SUPPORTED_EXTENSIONS
+from ..report_generator import (
+    save_fft_report,
+    save_envelope_report,
+    save_iso_report,
+    read_report_metadata,
+    list_reports,
+    save_diagnostic_report_docx,
+    REPORTS_DIR as REPORTS_DIR_PATH,
+)
+from ..document_reader import calculate_bearing_frequencies
+
+logger = logging.getLogger(__name__)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register report generation and visualization tools with the MCP server."""
+
+    @mcp.tool()
+    async def generate_diagnostic_report_docx(
+        signal_file: str,
+        sections: dict[str, Any],
+        title: str | None = None,
+        ctx: Context | None = None,
+    ) -> dict[str, Any]:
+        """
+        Generate a structured Word (.docx) diagnostic report.
+
+        Requires: ``pip install predictive-maintenance-mcp[docx]``
+
+        ``sections`` is a dict whose keys define what to include (all optional):
+          - statistics:           dict  (RMS, Kurtosis, Crest Factor …)
+          - fft_peaks:            list  [{frequency, magnitude_db, note}, …]
+          - envelope_peaks:       list  [{frequency, magnitude_db, match}, …]
+          - bearing_frequencies:  dict  {BPFO, BPFI, BSF, FTF}
+          - iso:                  dict  (from evaluate_iso_20816 output)
+          - diagnosis:            str   (free-text diagnostic summary)
+
+        Args:
+            signal_file: Signal filename used for the report title / filename
+            sections: Content sections to include (see above)
+            title: Optional custom report title
+            ctx: MCP context
+
+        Returns:
+            Dictionary with file_path, file_name, and per-section summary.
+        """
+        if ctx:
+            await ctx.info(f"Generating DOCX diagnostic report for {signal_file}")
+
+        result = save_diagnostic_report_docx(signal_file, sections, title=title)
+
+        if ctx and "error" not in result:
+            await ctx.info(f"DOCX report saved: {result['file_name']}")
+
+        return result
+
+    @mcp.tool()
+    async def plot_signal(
+        signal_file: str,
+        sampling_rate: float = 10000.0,
+        time_range: Optional[list[float]] = None,
+        show_statistics: bool = True,
+        title: Optional[str] = None,
+        ctx: Context | None = None
+    ) -> str:
+        """
+        Generate interactive time-domain signal plot.
+
+        Creates an interactive HTML plot showing the signal in the time domain.
+        Useful for inspecting signal quality, identifying anomalies, and visualizing transients.
+
+        Args:
+            signal_file: Name of the CSV file in data/signals/
+            sampling_rate: Sampling frequency in Hz (default: 10000)
+            time_range: [start_time, end_time] in seconds to zoom on a portion (optional)
+            show_statistics: Show RMS, peak levels as horizontal lines (default: True)
+            title: Custom plot title (optional)
+            ctx: MCP context for progress/logging
+
+        Returns:
+            Path to generated HTML file
+
+        Example:
+            plot_signal(
+                "bearing_signal.csv",
+                sampling_rate=10000,
+                time_range=[0.1, 0.3],  # Zoom on 100-300 ms
+                show_statistics=True
+            )
+        """
+        if ctx:
+            await ctx.info(f"Generating time-domain plot for {signal_file}...")
+
+        # Read signal
+        filepath = DATA_DIR / signal_file
+        if not filepath.exists():
+            raise FileNotFoundError(f"File not found: {signal_file}")
+
+        signal_data = load_signal_data(signal_file)
+        if signal_data is None:
+            raise ValueError(f"Could not load signal data from: {signal_file}")
+
+        # Time array
+        n = len(signal_data)
+        time = np.arange(n) / sampling_rate
+
+        # Apply time range filter if specified
+        if time_range:
+            mask = (time >= time_range[0]) & (time <= time_range[1])
+            time_plot = time[mask]
+            signal_plot = signal_data[mask]
+        else:
+            time_plot = time
+            signal_plot = signal_data
+
+        # Calculate statistics
+        rms = np.sqrt(np.mean(signal_plot**2))
+        peak_pos = np.max(signal_plot)
+        peak_neg = np.min(signal_plot)
+        mean_val = np.mean(signal_plot)
+
+        # Create plot
+        fig = go.Figure()
+
+        # Main signal
+        fig.add_trace(go.Scatter(
+            x=time_plot,
+            y=signal_plot,
+            mode='lines',
+            name='Signal',
+            line=dict(color='blue', width=1),
+            hovertemplate='Time: %{x:.4f} s<br>Amplitude: %{y:.4f}<extra></extra>'
+        ))
+
+        # Add statistical reference lines if requested
+        if show_statistics:
+            # RMS lines
+            fig.add_trace(go.Scatter(
+                x=[time_plot[0], time_plot[-1]],
+                y=[rms, rms],
+                mode='lines',
+                name=f'RMS (+{rms:.4f})',
+                line=dict(color='green', width=2, dash='dash'),
+                hovertemplate=f'RMS: {rms:.4f}<extra></extra>'
+            ))
+
+            fig.add_trace(go.Scatter(
+                x=[time_plot[0], time_plot[-1]],
+                y=[-rms, -rms],
+                mode='lines',
+                name=f'RMS (−{rms:.4f})',
+                line=dict(color='green', width=2, dash='dash'),
+                showlegend=False,
+                hovertemplate=f'RMS: -{rms:.4f}<extra></extra>'
+            ))
+
+            # Peak lines
+            fig.add_trace(go.Scatter(
+                x=[time_plot[0], time_plot[-1]],
+                y=[peak_pos, peak_pos],
+                mode='lines',
+                name=f'Peak (+{peak_pos:.4f})',
+                line=dict(color='red', width=1, dash='dot'),
+                hovertemplate=f'Peak: {peak_pos:.4f}<extra></extra>'
+            ))
+
+            fig.add_trace(go.Scatter(
+                x=[time_plot[0], time_plot[-1]],
+                y=[peak_neg, peak_neg],
+                mode='lines',
+                name=f'Peak (−{abs(peak_neg):.4f})',
+                line=dict(color='red', width=1, dash='dot'),
+                hovertemplate=f'Peak: {peak_neg:.4f}<extra></extra>'
+            ))
+
+            # Mean line
+            if abs(mean_val) > 1e-6:  # Only show if mean is significant
+                fig.add_trace(go.Scatter(
+                    x=[time_plot[0], time_plot[-1]],
+                    y=[mean_val, mean_val],
+                    mode='lines',
+                    name=f'Mean ({mean_val:.4f})',
+                    line=dict(color='orange', width=1, dash='dashdot'),
+                    hovertemplate=f'Mean: {mean_val:.4f}<extra></extra>'
+                ))
+
+        # Layout
+        plot_title = title or f"Time-Domain Signal - {signal_file}"
+        duration = time_plot[-1] - time_plot[0]
+
+        fig.update_layout(
+            title=plot_title,
+            xaxis_title="Time (s)",
+            yaxis_title="Amplitude",
+            hovermode='x unified',
+            template='plotly_white',
+            width=1200,
+            height=600,
+            showlegend=True,
+            annotations=[
+                dict(
+                    text=f"Duration: {duration:.3f} s | Samples: {len(signal_plot)} | Fs: {sampling_rate} Hz",
+                    xref="paper", yref="paper",
+                    x=0.5, y=-0.15,
+                    showarrow=False,
+                    font=dict(size=10, color="gray")
+                )
+            ]
+        )
+
+        # Save HTML to reports directory
+        safe_name = Path(signal_file).stem.replace('/', '_').replace('\\', '_')
+        output_file = REPORTS_DIR / f"plot_signal_{safe_name}.html"
+        fig.write_html(str(output_file))
+
+        if ctx:
+            await ctx.info(f"Plot saved to {output_file.name}")
+            await ctx.info(f"To view report metadata: list_html_reports() or get_report_info()")
+
+        return f"Interactive plot saved to: {output_file}\nUse list_html_reports() to see all reports, or open file in browser"
+
+    @mcp.tool()
+    async def plot_spectrum(
+        signal_file: str,
+        sampling_rate: float = 10000.0,
+        freq_range: Optional[list[float]] = None,
+        num_peaks: int = 10,
+        min_peak_distance: float = 1.0,
+        rotation_freq: Optional[float] = None,
+        title: Optional[str] = None,
+        ctx: Context | None = None
+    ) -> str:
+        """
+        Generate interactive FFT spectrum plot with automatic peak detection.
+
+        Creates an interactive HTML plot showing the frequency spectrum up to Nyquist frequency (Fs/2).
+        Automatically identifies and labels the most significant peaks. If rotation frequency is provided,
+        identifies harmonics as 1x, 2x, 3x RPM.
+
+        Args:
+            signal_file: Name of the CSV file in data/signals/
+            sampling_rate: Sampling frequency in Hz (default: 10000)
+            freq_range: [min_freq, max_freq] to limit the plot range (default: [0, Fs/2])
+            num_peaks: Number of peaks to identify and label (default: 10)
+            min_peak_distance: Minimum distance between peaks in Hz (default: 1.0)
+            rotation_freq: Rotation frequency in Hz for RPM harmonic labeling (optional)
+            title: Custom plot title (optional)
+            ctx: MCP context for progress/logging
+
+        Returns:
+            Path to generated HTML file with peak information
+
+        Example:
+            plot_spectrum(
+                "bearing_signal.csv",
+                sampling_rate=10000,
+                rotation_freq=25.0,  # 1500 RPM = 25 Hz
+                num_peaks=15
+            )
+        """
+        if ctx:
+            await ctx.info(f"Generating spectrum plot for {signal_file}...")
+
+        # Read signal
+        filepath = DATA_DIR / signal_file
+        if not filepath.exists():
+            raise FileNotFoundError(f"File not found: {signal_file}")
+
+        signal_data = load_signal_data(signal_file)
+        if signal_data is None:
+            raise ValueError(f"Could not load signal data from: {signal_file}")
+
+        # Apply Hamming window to reduce spectral leakage
+        n = len(signal_data)
+        window = np.hamming(n)
+        signal_windowed = signal_data * window
+
+        # Compute FFT
+        freqs = fftfreq(n, d=1/sampling_rate)
+        fft_values = fft(signal_windowed)
+
+        # Keep only positive frequencies up to Nyquist (Fs/2)
+        nyquist = sampling_rate / 2.0
+        positive_freq_mask = (freqs > 0) & (freqs <= nyquist)
+        freqs = freqs[positive_freq_mask]
+
+        # Correct normalization for single-sided spectrum
+        amplitude = 2.0 * np.abs(fft_values[positive_freq_mask]) / n
+
+        # Convert to dB scale (normalized to maximum)
+        # Peak will be at 0 dB, everything else negative
+        max_amplitude = np.max(amplitude)
+        amplitude_db = 20 * np.log10(np.maximum(amplitude / max_amplitude, 1e-10))
+
+        # Default frequency range: 0 to Nyquist
+        if freq_range is None:
+            freq_range = [0, nyquist]
+
+        # Apply frequency range filter
+        mask = (freqs >= freq_range[0]) & (freqs <= freq_range[1])
+        freqs_plot = freqs[mask]
+        amplitude_plot = amplitude[mask]
+        amplitude_db_plot = amplitude_db[mask]
+
+        # Find peaks using scipy
+        from scipy.signal import find_peaks
+
+        # Convert min_peak_distance to number of samples
+        freq_resolution = sampling_rate / n
+        min_distance_samples = int(min_peak_distance / freq_resolution)
+
+        # Find peaks in the plot range
+        peak_indices, properties = find_peaks(
+            amplitude_db_plot,
+            distance=min_distance_samples,
+            prominence=2  # Only peaks with >2 dB prominence
+        )
+
+        # Sort by amplitude and keep top num_peaks
+        if len(peak_indices) > num_peaks:
+            sorted_indices = np.argsort(amplitude_db_plot[peak_indices])[::-1]
+            peak_indices = peak_indices[sorted_indices[:num_peaks]]
+
+        # Create plot
+        fig = go.Figure()
+
+        # Main spectrum in dB
+        fig.add_trace(go.Scatter(
+            x=freqs_plot,
+            y=amplitude_db_plot,
+            mode='lines',
+            name='Spectrum',
+            line=dict(color='blue', width=1),
+            hovertemplate='Frequency: %{x:.2f} Hz<br>Amplitude: %{y:.2f} dB<extra></extra>'
+        ))
+
+        # Mark detected peaks
+        for idx in peak_indices:
+            freq = freqs_plot[idx]
+            amp_db = amplitude_db_plot[idx]
+
+            # Generate label
+            if rotation_freq:
+                # Check if it's a harmonic of rotation frequency
+                harmonic_ratio = freq / rotation_freq
+                if abs(harmonic_ratio - round(harmonic_ratio)) < 0.1:  # Within 10% tolerance
+                    harmonic_num = int(round(harmonic_ratio))
+                    label = f"{harmonic_num}xRPM ({freq:.1f} Hz)"
+                else:
+                    label = f"{freq:.1f} Hz"
+            else:
+                label = f"{freq:.1f} Hz"
+
+            # Add marker
+            fig.add_trace(go.Scatter(
+                x=[freq],
+                y=[amp_db],
+                mode='markers+text',
+                name=label,
+                marker=dict(color='red', size=8, symbol='diamond'),
+                text=[label],
+                textposition="top center",
+                textfont=dict(size=9, color='red'),
+                hovertemplate=f'{label}<br>Amplitude: {amp_db:.2f} dB<extra></extra>'
+            ))
+
+        # Layout
+        plot_title = title or f"FFT Spectrum - {signal_file}"
+        fig.update_layout(
+            title=plot_title,
+            xaxis_title="Frequency (Hz)",
+            yaxis_title="Amplitude (dB re. max)",
+            hovermode='x unified',
+            template='plotly_white',
+            width=1200,
+            height=600,
+            showlegend=False,  # Hide legend since we have text labels
+            yaxis=dict(range=[-80, 5])  # From -80 dB to +5 dB (peak at 0 dB)
+        )
+
+        # Save HTML to reports directory
+        safe_name = Path(signal_file).stem.replace('/', '_').replace('\\', '_')
+        output_file = REPORTS_DIR / f"plot_spectrum_{safe_name}.html"
+        fig.write_html(str(output_file))
+
+        if ctx:
+            await ctx.info(f"Plot saved to {output_file.name}")
+            await ctx.info(f"Detected {len(peak_indices)} significant peaks")
+            await ctx.info(f"To view report metadata: list_html_reports() or get_report_info()")
+
+        return f"Interactive plot saved to: {output_file}\nUse list_html_reports() to see all reports, or open file in browser"
+
+    @mcp.tool()
+    async def plot_envelope(
+        signal_file: str,
+        sampling_rate: float = 10000.0,
+        filter_band: Optional[list[float]] = None,
+        freq_range: Optional[list[float]] = None,
+        highlight_freqs: Optional[list[float]] = None,
+        freq_labels: Optional[list[str]] = None,
+        title: Optional[str] = None,
+        ctx: Context | None = None
+    ) -> str:
+        """
+        Generate interactive envelope spectrum plot.
+
+        Creates an interactive HTML plot showing both the envelope spectrum and optionally
+        the filtered signal. Can highlight bearing/gear frequencies.
+
+        Args:
+            signal_file: Name of the CSV file in data/signals/
+            sampling_rate: Sampling frequency in Hz (default: 10000)
+            filter_band: [low_freq, high_freq] for bandpass filter (optional, default: [500, 5000])
+            freq_range: [min_freq, max_freq] to limit the envelope spectrum plot (optional)
+            highlight_freqs: List of frequencies (Hz) to mark (e.g., BPFO, BPFI) (optional)
+            freq_labels: Labels for highlighted frequencies (optional)
+            title: Custom plot title (optional)
+            ctx: MCP context for progress/logging
+
+        Returns:
+            Path to generated HTML file
+
+        Example:
+            plot_envelope(
+                "bearing_signal.csv",
+                sampling_rate=10000,
+                filter_band=[500, 5000],
+                freq_range=[0, 300],
+                highlight_freqs=[120.5, 241.0],
+                freq_labels=["BPFO", "2xBPFO"]
+            )
+        """
+        if ctx:
+            await ctx.info(f"Generating envelope plot for {signal_file}...")
+
+        # Read signal
+        filepath = DATA_DIR / signal_file
+        if not filepath.exists():
+            raise FileNotFoundError(f"File not found: {signal_file}")
+
+        signal_data = load_signal_data(signal_file)
+        if signal_data is None:
+            raise ValueError(f"Could not load signal data from: {signal_file}")
+
+        # Default filter band if not specified
+        if filter_band is None:
+            filter_band = [500, 5000]
+
+        # Validate filter band
+        nyquist = sampling_rate / 2
+        if filter_band[1] >= nyquist:
+            # Adjust upper frequency to be below Nyquist
+            filter_band[1] = nyquist * 0.95
+            if ctx:
+                await ctx.info(f"Adjusted filter upper limit to {filter_band[1]:.0f} Hz (< Nyquist)")
+
+        # Bandpass filter
+        low = filter_band[0] / nyquist
+        high = filter_band[1] / nyquist
+
+        # Ensure valid range
+        if low >= 1.0 or high >= 1.0 or low <= 0 or high <= 0:
+            raise ValueError(f"Invalid filter band [{filter_band[0]}, {filter_band[1]}] Hz for Fs={sampling_rate} Hz (Nyquist={nyquist} Hz)")
+
+        sos = butter(4, [low, high], btype='band', output='sos')
+        filtered_signal = sosfiltfilt(sos, signal_data)
+
+        # Envelope using Hilbert transform
+        analytic_signal = hilbert(filtered_signal)
+        envelope = np.abs(analytic_signal)
+
+        # Apply Hamming window to envelope before FFT
+        n = len(envelope)
+        window = np.hamming(n)
+        envelope_windowed = envelope * window
+
+        # FFT of envelope
+        freqs = fftfreq(n, d=1/sampling_rate)
+        fft_envelope = fft(envelope_windowed)
+
+        # Keep only positive frequencies (excluding DC at freq=0)
+        positive_freq_mask = freqs > 0
+        freqs = freqs[positive_freq_mask]
+
+        # Correct normalization for single-sided spectrum
+        amplitude = 2.0 * np.abs(fft_envelope[positive_freq_mask]) / n
+
+        # Convert to dB scale (normalized to maximum)
+        max_amplitude = np.max(amplitude)
+        amplitude_db = 20 * np.log10(np.maximum(amplitude / max_amplitude, 1e-10))
+
+        # Apply frequency range filter if specified
+        if freq_range:
+            mask = (freqs >= freq_range[0]) & (freqs <= freq_range[1])
+            freqs_plot = freqs[mask]
+            amplitude_plot = amplitude[mask]
+            amplitude_db_plot = amplitude_db[mask]
+        else:
+            freqs_plot = freqs
+            amplitude_plot = amplitude
+            amplitude_db_plot = amplitude_db
+
+        # Create subplots
+        fig = make_subplots(
+            rows=2, cols=1,
+            subplot_titles=(
+                f'Filtered Signal ({filter_band[0]}-{filter_band[1]} Hz)',
+                'Envelope Spectrum'
+            ),
+            vertical_spacing=0.12,
+            row_heights=[0.4, 0.6]
+        )
+
+        # Time array for signal plot
+        time = np.arange(len(filtered_signal)) / sampling_rate
+
+        # Plot 1: Filtered signal with envelope
+        fig.add_trace(
+            go.Scatter(
+                x=time,
+                y=filtered_signal,
+                mode='lines',
+                name='Filtered Signal',
+                line=dict(color='lightblue', width=1),
+                opacity=0.7
+            ),
+            row=1, col=1
+        )
+
+        fig.add_trace(
+            go.Scatter(
+                x=time,
+                y=envelope,
+                mode='lines',
+                name='Envelope',
+                line=dict(color='red', width=2)
+            ),
+            row=1, col=1
+        )
+
+        # Plot 2: Envelope spectrum in dB
+        fig.add_trace(
+            go.Scatter(
+                x=freqs_plot,
+                y=amplitude_db_plot,
+                mode='lines',
+                name='Envelope Spectrum',
+                line=dict(color='darkblue', width=1),
+                hovertemplate='Frequency: %{x:.2f} Hz<br>Amplitude: %{y:.2f} dB<extra></extra>'
+            ),
+            row=2, col=1
+        )
+
+        # Highlight specific frequencies in envelope spectrum
+        if highlight_freqs:
+            if not freq_labels:
+                freq_labels = [f"{f:.1f} Hz" for f in highlight_freqs]
+
+            for freq, label in zip(highlight_freqs, freq_labels):
+                # Find nearest frequency
+                idx = np.argmin(np.abs(freqs_plot - freq))
+
+                # Add vertical line
+                fig.add_vline(
+                    x=freq,
+                    line=dict(color='red', width=2, dash='dash'),
+                    annotation_text=label,
+                    annotation_position="top",
+                    row=2, col=1
+                )
+
+                # Add marker
+                fig.add_trace(
+                    go.Scatter(
+                        x=[freqs_plot[idx]],
+                        y=[amplitude_db_plot[idx]],
+                        mode='markers',
+                        name=label,
+                        marker=dict(color='red', size=10, symbol='diamond'),
+                        hovertemplate=f'{label}<br>Frequency: %{{x:.2f}} Hz<br>Amplitude: %{{y:.2f}} dB<extra></extra>',
+                        showlegend=True
+                    ),
+                    row=2, col=1
+                )
+
+        # Update axes
+        fig.update_xaxes(title_text="Time (s)", row=1, col=1)
+        fig.update_yaxes(title_text="Amplitude", row=1, col=1)
+        fig.update_xaxes(title_text="Frequency (Hz)", row=2, col=1)
+        fig.update_yaxes(title_text="Amplitude (dB re. max)", row=2, col=1)
+
+        # Set dB range for envelope spectrum (normalized to max)
+        fig.update_yaxes(range=[-80, 5], row=2, col=1)
+
+        # Layout
+        plot_title = title or f"Envelope Analysis - {signal_file}"
+        fig.update_layout(
+            title_text=plot_title,
+            hovermode='x unified',
+            template='plotly_white',
+            width=1200,
+            height=900,
+            showlegend=True
+        )
+
+        # Save HTML to reports directory
+        safe_name = Path(signal_file).stem.replace('/', '_').replace('\\', '_')
+        output_file = REPORTS_DIR / f"plot_envelope_{safe_name}.html"
+        fig.write_html(str(output_file))
+
+        if ctx:
+            await ctx.info(f"Plot saved to {output_file.name}")
+            await ctx.info(f"To view report metadata: list_html_reports() or get_report_info()")
+
+        return f"Interactive plot saved to: {output_file}\nUse list_html_reports() to see all reports, or open file in browser"
+
+    @mcp.tool()
+    async def generate_fft_report(
+        signal_file: str,
+        sampling_rate: Optional[float] = None,
+        max_freq: float = 5000.0,
+        num_peaks: int = 15,
+        rotation_freq: Optional[float] = None,
+        ctx: Context | None = None
+    ) -> dict[str, Any]:
+        """
+        Generate professional FFT spectrum report as HTML file.
+
+        **NEW PREFERRED METHOD**: Generates a professional HTML report file
+        instead of inline content. Saves to reports/ directory.
+
+        Args:
+            signal_file: Signal filename in data/signals/
+            sampling_rate: Sampling rate in Hz (auto-detect if None)
+            max_freq: Maximum frequency to display (Hz). Default 5000 Hz
+            num_peaks: Number of peaks to detect and label. Default 15
+            rotation_freq: Optional shaft rotation frequency for harmonic labels
+            ctx: MCP context
+
+        Returns:
+            Dictionary with file path, metadata, and summary (NO HTML content)
+
+        Example:
+            >>> result = generate_fft_report("real_train/baseline_1.csv")
+            >>> # User can open: result['file_path']
+        """
+        if ctx:
+            await ctx.info(f"Generating FFT report for {signal_file}...")
+
+        # Load signal
+        signal_data = load_signal_data(signal_file)
+        if signal_data is None:
+            raise ValueError(f"Unable to load signal from {signal_file}")
+
+        # Auto-detect sampling rate
+        if sampling_rate is None:
+            metadata_path = get_metadata_path(signal_file)
+            if metadata_path.exists():
+                with open(metadata_path) as f:
+                    metadata = json.load(f)
+                    sampling_rate = metadata.get("sampling_rate")
+
+            if sampling_rate is None:
+                raise ValueError("sampling_rate required (not found in metadata)")
+
+        # Perform FFT
+        N = len(signal_data)
+        window = np.hamming(N)
+        signal_windowed = signal_data * window
+
+        fft_values = fft(signal_windowed)
+        frequencies = fftfreq(N, 1/sampling_rate)
+
+        # Positive frequencies only
+        positive_idx = frequencies > 0
+        frequencies = frequencies[positive_idx]
+        magnitudes = 2.0 * np.abs(fft_values[positive_idx]) / N
+
+        # Generate and save report
+        result = save_fft_report(
+            signal_file=signal_file,
+            sampling_rate=sampling_rate,
+            frequencies=frequencies,
+            magnitudes=magnitudes,
+            signal_data=signal_data,
+            max_freq=max_freq,
+            num_peaks=num_peaks,
+            rotation_freq=rotation_freq
+        )
+
+        if ctx:
+            await ctx.info(result['message'])
+            await ctx.info(f"Report location: {result['file_path']}")
+
+        return result
+
+    @mcp.tool()
+    async def generate_envelope_report(
+        signal_file: str,
+        sampling_rate: Optional[float] = None,
+        filter_low: float = 500.0,
+        filter_high: float = 5000.0,
+        max_freq: float = 500.0,
+        num_peaks: int = 15,
+        bearing_freqs: Optional[dict[str, float]] = None,
+        ctx: Context | None = None
+    ) -> dict[str, Any]:
+        """
+        Generate professional envelope analysis report as HTML file.
+
+        **NEW PREFERRED METHOD**: Generates a professional HTML report file
+        instead of inline content. Saves to reports/ directory.
+
+        Args:
+            signal_file: Signal filename in data/signals/
+            sampling_rate: Sampling rate in Hz (auto-detect if None)
+            filter_low: Bandpass filter low cutoff (Hz). Default 500 Hz
+            filter_high: Bandpass filter high cutoff (Hz). Default 5000 Hz
+            max_freq: Max envelope spectrum frequency to display. Default 500 Hz
+            num_peaks: Number of peaks to detect. Default 15
+            bearing_freqs: Optional dict with BPFO, BPFI, BSF, FTF
+            ctx: MCP context
+
+        Returns:
+            Dictionary with file path, metadata, and summary (NO HTML content)
+
+        Example:
+            >>> result = generate_envelope_report(
+            ...     "real_train/OuterRaceFault_1.csv",
+            ...     bearing_freqs={"BPFO": 81.13, "BPFI": 118.88, "BSF": 63.91, "FTF": 14.84}
+            ... )
+        """
+        if ctx:
+            await ctx.info(f"Generating envelope analysis report for {signal_file}...")
+
+        # Load signal
+        signal_data = load_signal_data(signal_file)
+        if signal_data is None:
+            raise ValueError(f"Unable to load signal from {signal_file}")
+
+        # Auto-detect sampling rate and bearing freqs
+        if sampling_rate is None or bearing_freqs is None:
+            metadata_path = get_metadata_path(signal_file)
+            if metadata_path.exists():
+                with open(metadata_path) as f:
+                    metadata = json.load(f)
+                    if sampling_rate is None:
+                        sampling_rate = metadata.get("sampling_rate")
+                    if bearing_freqs is None:
+                        bearing_freqs = {
+                            "BPFO": metadata.get("BPFO"),
+                            "BPFI": metadata.get("BPFI"),
+                            "BSF": metadata.get("BSF"),
+                            "FTF": metadata.get("FTF")
+                        }
+
+            if sampling_rate is None:
+                raise ValueError("sampling_rate required")
+
+        # Bandpass filter
+        nyquist = sampling_rate / 2
+        sos = butter(4, [filter_low / nyquist, filter_high / nyquist], btype='band', output='sos')
+        filtered_signal = sosfiltfilt(sos, signal_data)
+
+        # Envelope via Hilbert
+        analytic_signal = hilbert(filtered_signal)
+        envelope = np.abs(analytic_signal)
+
+        # Envelope spectrum
+        N = len(envelope)
+        env_fft = fft(envelope)
+        env_frequencies = fftfreq(N, 1/sampling_rate)
+
+        positive_idx = env_frequencies > 0
+        env_frequencies = env_frequencies[positive_idx]
+        env_magnitudes = 2.0 * np.abs(env_fft[positive_idx]) / N
+
+        # Generate and save report
+        result = save_envelope_report(
+            signal_file=signal_file,
+            sampling_rate=sampling_rate,
+            filter_band=(filter_low, filter_high),
+            filtered_signal=filtered_signal,
+            envelope=envelope,
+            env_frequencies=env_frequencies,
+            env_magnitudes=env_magnitudes,
+            bearing_freqs=bearing_freqs,
+            max_freq=max_freq,
+            num_peaks=num_peaks
+        )
+
+        if ctx:
+            await ctx.info(result['message'])
+            await ctx.info(f"Report location: {result['file_path']}")
+            if result.get('bearing_matches'):
+                await ctx.info(f"Bearing frequency matches: {', '.join(result['bearing_matches'])}")
+
+        return result
+
+    @mcp.tool()
+    async def generate_iso_report(
+        signal_file: str,
+        sampling_rate: Optional[float] = None,
+        machine_group: int = 2,
+        support_type: str = "rigid",
+        operating_speed_rpm: Optional[float] = None,
+        ctx: Context | None = None
+    ) -> dict[str, Any]:
+        """
+        Generate professional ISO 20816-3 evaluation report as HTML file.
+
+        **NEW PREFERRED METHOD**: Generates a professional HTML report file
+        instead of inline content. Saves to reports/ directory.
+
+        Args:
+            signal_file: Signal filename in data/signals/
+            sampling_rate: Sampling rate in Hz (auto-detect if None)
+            machine_group: ISO machine group (1=large >300kW, 2=medium 15-300kW)
+            support_type: 'rigid' or 'flexible'
+            operating_speed_rpm: Operating speed in RPM (optional)
+            ctx: MCP context
+
+        Returns:
+            Dictionary with file path, metadata, and summary (NO HTML content)
+
+        Example:
+            >>> result = generate_iso_report(
+            ...     "real_train/baseline_1.csv",
+            ...     machine_group=2,
+            ...     support_type="rigid"
+            ... )
+        """
+        if ctx:
+            await ctx.info(f"Generating ISO 20816-3 report for {signal_file}...")
+
+        # Auto-detect sampling rate
+        if sampling_rate is None:
+            metadata_path = get_metadata_path(signal_file)
+            if metadata_path.exists():
+                with open(metadata_path) as f:
+                    sampling_rate = json.load(f).get("sampling_rate")
+
+            if sampling_rate is None:
+                raise ValueError("sampling_rate required")
+
+        # Import evaluate_iso_20816 from the monolith (will be refactored later)
+        from ..machinery_diagnostics_server import evaluate_iso_20816
+
+        # Perform ISO evaluation
+        iso_result = await evaluate_iso_20816(
+            ctx=ctx,
+            signal_file=signal_file,
+            sampling_rate=sampling_rate,
+            machine_group=machine_group,
+            support_type=support_type,
+            operating_speed_rpm=operating_speed_rpm
+        )
+
+        # Convert Pydantic model to dict
+        iso_dict = iso_result.model_dump()
+
+        # Generate and save report
+        result = save_iso_report(
+            signal_file=signal_file,
+            iso_result=iso_dict
+        )
+
+        if ctx:
+            await ctx.info(result['message'])
+            await ctx.info(f"Report location: {result['file_path']}")
+
+        return result
+
+    @mcp.tool()
+    def list_html_reports() -> list[dict[str, Any]]:
+        """
+        List all available HTML reports in reports/ directory.
+
+        Returns list of reports with metadata (file name, type, signal, size).
+        Does NOT return HTML content - only metadata to avoid token consumption.
+
+        Returns:
+            List of dicts with report information
+
+        Example:
+            >>> reports = list_html_reports()
+            >>> print(f"Found {len(reports)} reports")
+            >>> for r in reports:
+            ...     print(f"- {r['file_name']}: {r['report_type']} for {r['signal_file']}")
+        """
+        return list_reports()
+
+    @mcp.tool()
+    def get_report_info(file_name: str) -> dict[str, Any]:
+        """
+        Get metadata from HTML report without loading entire file.
+
+        Extracts metadata JSON from HTML report file. This allows LLM to
+        understand report content without consuming tokens for HTML.
+
+        Args:
+            file_name: Report filename in reports/ directory
+
+        Returns:
+            Dictionary with metadata (NO HTML content)
+
+        Example:
+            >>> info = get_report_info("fft_spectrum_baseline_1.html")
+            >>> print(f"Signal: {info['metadata']['signal_file']}")
+            >>> print(f"Peaks detected: {info['metadata']['num_peaks']}")
+        """
+        return read_report_metadata(file_name)
+
+    @mcp.tool()
+    async def generate_pca_visualization_report(
+        model_name: str,
+        test_signal_files: Optional[list[str]] = None,
+        true_labels: Optional[dict[str, str]] = None,
+        sampling_rate: Optional[float] = None,
+        segment_duration: float = 0.1,
+        overlap_ratio: float = 0.5,
+        ctx: Context | None = None
+    ) -> dict[str, Any]:
+        """
+        Generate PCA visualization HTML report showing training and test data in 2D PCA space.
+
+        Creates interactive scatter plot with:
+        - Training data (blue dots) - healthy baseline
+        - Test/prediction data (green = predicted healthy, red = predicted anomaly)
+        - PC1 vs PC2 axes with variance explained
+        - Hover information showing segment details and prediction status
+
+        **IMPORTANT**: Labels show MODEL PREDICTIONS, not ground truth. Use `true_labels`
+        parameter to provide actual labels for validation visualization.
+
+        **Strategy**: Same HTML report approach as FFT/Envelope/ISO reports.
+        Saved to reports/ directory for LLM to reference without consuming tokens.
+
+        Args:
+            model_name: Name of trained model (e.g., 'bearing_health_model')
+            test_signal_files: Optional list of signals to predict and visualize
+            true_labels: Optional dict mapping signal filenames to true labels.
+                        Format: {"baseline_3.csv": "healthy", "InnerRaceFault_vload_6.csv": "faulty"}
+                        When provided, legend shows both true and predicted labels for validation.
+            sampling_rate: Sampling rate (auto-detect from metadata if None)
+            segment_duration: Segment duration in seconds (default: 0.1s for ML)
+            overlap_ratio: Overlap ratio 0-1 (default: 0.5)
+            ctx: MCP context
+
+        Returns:
+            Dictionary with file path, metadata, and summary (includes validation metrics if true_labels provided)
+
+        Example (predictions only):
+            >>> generate_pca_visualization_report(
+            ...     model_name="bearing_health_model",
+            ...     test_signal_files=["real_test/baseline_3.csv", "real_test/InnerRaceFault_vload_6.csv"]
+            ... )
+
+        Example (with validation):
+            >>> generate_pca_visualization_report(
+            ...     model_name="bearing_health_model",
+            ...     test_signal_files=["real_test/baseline_3.csv", "real_test/InnerRaceFault_vload_6.csv"],
+            ...     true_labels={"baseline_3.csv": "healthy", "InnerRaceFault_vload_6.csv": "faulty"}
+            ... )
+        """
+        # Import extract_time_domain_features from the monolith (will be refactored later)
+        from ..machinery_diagnostics_server import extract_time_domain_features
+
+        if ctx:
+            await ctx.info(f"Generating PCA visualization for model '{model_name}'...")
+
+        # Load model, scaler, PCA
+        model_path = MODELS_DIR / f"{model_name}_model.pkl"
+        scaler_path = MODELS_DIR / f"{model_name}_scaler.pkl"
+        pca_path = MODELS_DIR / f"{model_name}_pca.pkl"
+        metadata_path = MODELS_DIR / f"{model_name}_metadata.json"
+
+        if not model_path.exists():
+            raise FileNotFoundError(f"Model not found: {model_path}")
+
+        with open(model_path, 'rb') as f:
+            model = pickle.load(f)
+        with open(scaler_path, 'rb') as f:
+            scaler = pickle.load(f)
+        with open(pca_path, 'rb') as f:
+            pca = pickle.load(f)
+        with open(metadata_path, 'r') as f:
+            model_metadata = json.load(f)
+
+        # Use model's sampling rate if not provided
+        if sampling_rate is None:
+            sampling_rate = model_metadata.get('sampling_rate', 10000.0)
+
+        # Collect training data (reconstruct from model metadata if available)
+        # For now, we'll just note that training data would be visualized
+        # In production, you'd save training features during train_anomaly_model
+
+        training_pca_data = []  # Placeholder - would load from saved training features
+
+        # Process test signals if provided
+        test_data_list = []
+
+        if test_signal_files:
+            for signal_file in test_signal_files:
+                filepath = DATA_DIR / signal_file
+                if not filepath.exists():
+                    logger.warning(f"File not found: {signal_file}, skipping...")
+                    continue
+
+                signal_data = load_signal_data(signal_file)
+                if signal_data is None:
+                    raise ValueError(f"Could not load signal data from: {signal_file}")
+
+                # Segment and extract features
+                segment_length_samples = int(segment_duration * sampling_rate)
+                hop_length = int(segment_length_samples * (1 - overlap_ratio))
+
+                features_list = []
+                for start in range(0, len(signal_data) - segment_length_samples + 1, hop_length):
+                    segment = signal_data[start:start + segment_length_samples]
+                    features = extract_time_domain_features(segment)
+                    features_list.append(features)
+
+                X_test = pd.DataFrame(features_list).values
+
+                # Apply preprocessing
+                X_scaled = scaler.transform(X_test)
+                X_pca = pca.transform(X_scaled)
+
+                # Predict
+                predictions = model.predict(X_pca)
+
+                test_data_list.append({
+                    'signal_file': signal_file,
+                    'pca_data': X_pca,
+                    'predictions': predictions
+                })
+
+        # Create Plotly figure
+        fig = go.Figure()
+
+        # Plot test data
+        for test_data in test_data_list:
+            X_pca = test_data['pca_data']
+            predictions = test_data['predictions']
+            signal_file = test_data['signal_file']
+
+            # Extract filename without path for label matching
+            file_basename = signal_file.split('/')[-1]
+
+            # Determine true label if provided
+            true_label = None
+            if true_labels and file_basename in true_labels:
+                true_label = true_labels[file_basename].lower()
+
+            # Separate healthy and anomalous predictions
+            healthy_idx = predictions == 1
+            anomaly_idx = predictions == -1
+
+            # Create legend labels
+            if true_label:
+                # Show both true and predicted labels for validation
+                healthy_legend = f'{signal_file} (True: {true_label}, Predicted: Healthy)'
+                anomaly_legend = f'{signal_file} (True: {true_label}, Predicted: Anomaly)'
+
+                # Update hover template to show both
+                healthy_hover = f'<b>{signal_file}</b><br>PC1: %{{x:.3f}}<br>PC2: %{{y:.3f}}<br>True Label: {true_label}<br>Predicted: Healthy<extra></extra>'
+                anomaly_hover = f'<b>{signal_file}</b><br>PC1: %{{x:.3f}}<br>PC2: %{{y:.3f}}<br>True Label: {true_label}<br>Predicted: ANOMALY<extra></extra>'
+            else:
+                # Show only predictions (no ground truth assumed)
+                healthy_legend = f'{signal_file} (Predicted: Healthy)'
+                anomaly_legend = f'{signal_file} (Predicted: Anomaly)'
+
+                # Hover template clarifies these are predictions
+                healthy_hover = f'<b>{signal_file}</b><br>PC1: %{{x:.3f}}<br>PC2: %{{y:.3f}}<br>Predicted: Healthy<extra></extra>'
+                anomaly_hover = f'<b>{signal_file}</b><br>PC1: %{{x:.3f}}<br>PC2: %{{y:.3f}}<br>Predicted: ANOMALY<extra></extra>'
+
+            if np.any(healthy_idx):
+                fig.add_trace(go.Scatter(
+                    x=X_pca[healthy_idx, 0],
+                    y=X_pca[healthy_idx, 1],
+                    mode='markers',
+                    name=healthy_legend,
+                    marker=dict(color='green', size=8, opacity=0.6),
+                    hovertemplate=healthy_hover
+                ))
+
+            if np.any(anomaly_idx):
+                fig.add_trace(go.Scatter(
+                    x=X_pca[anomaly_idx, 0],
+                    y=X_pca[anomaly_idx, 1],
+                    mode='markers',
+                    name=anomaly_legend,
+                    marker=dict(color='red', size=8, opacity=0.6, symbol='x'),
+                    hovertemplate=anomaly_hover
+                ))
+
+        # Layout
+        variance_explained = pca.explained_variance_ratio_
+        fig.update_layout(
+            title=f"PCA Visualization - {model_name}",
+            xaxis_title=f"PC1 ({variance_explained[0]*100:.1f}% variance)",
+            yaxis_title=f"PC2 ({variance_explained[1]*100:.1f}% variance)",
+            hovermode='closest',
+            template='plotly_white',
+            width=1000,
+            height=700,
+            showlegend=True
+        )
+
+        # Save HTML report
+        safe_name = model_name.replace("/", "_").replace("\\", "_")
+        output_file = REPORTS_DIR / f"pca_visualization_{safe_name}.html"
+        fig.write_html(str(output_file))
+
+        # Prepare metadata - convert all numpy types to Python natives
+        metadata = {
+            'report_type': 'pca_visualization',
+            'model_name': model_name,
+            'test_signals': test_signal_files or [],
+            'pca_components': int(pca.n_components_),
+            'variance_explained_pc1': float(variance_explained[0]),
+            'variance_explained_pc2': float(variance_explained[1]),
+            'total_variance_2d': float(variance_explained[0] + variance_explained[1]),
+            'segment_duration': float(segment_duration),
+            'sampling_rate': float(sampling_rate) if sampling_rate is not None else None,
+            'validation_mode': true_labels is not None
+        }
+
+        # Calculate summary statistics - convert numpy int to Python int
+        total_segments = int(sum(len(td['predictions']) for td in test_data_list))
+        total_anomalies = int(sum(np.sum(td['predictions'] == -1) for td in test_data_list))
+
+        summary = {
+            'total_segments': int(total_segments),
+            'total_anomalies': int(total_anomalies),
+            'anomaly_ratio': float(total_anomalies / total_segments) if total_segments > 0 else 0.0
+        }
+
+        # Calculate validation metrics if true labels provided
+        if true_labels:
+            correct_predictions = 0
+            total_with_labels = 0
+            per_file_accuracy = {}
+
+            for test_data in test_data_list:
+                signal_file = test_data['signal_file']
+                file_basename = signal_file.split('/')[-1]
+
+                if file_basename in true_labels:
+                    predictions = test_data['predictions']
+                    true_label = true_labels[file_basename].lower()
+
+                    # Determine expected predictions (1 = healthy, -1 = anomaly)
+                    expected_prediction = 1 if true_label in ['healthy', 'normal', 'baseline'] else -1
+
+                    # Count correct predictions
+                    file_correct = int(np.sum(predictions == expected_prediction))
+                    file_total = len(predictions)
+                    correct_predictions += file_correct
+                    total_with_labels += file_total
+
+                    per_file_accuracy[file_basename] = {
+                        'correct': file_correct,
+                        'total': file_total,
+                        'accuracy': float(file_correct / file_total) if file_total > 0 else 0.0,
+                        'true_label': true_label
+                    }
+
+            overall_accuracy = float(correct_predictions / total_with_labels) if total_with_labels > 0 else 0.0
+
+            summary['validation_metrics'] = {
+                'overall_accuracy': overall_accuracy,
+                'total_labeled_segments': total_with_labels,
+                'correct_predictions': correct_predictions,
+                'per_file_accuracy': per_file_accuracy
+            }
+
+            if ctx:
+                await ctx.info(f"Validation Mode: Overall accuracy = {overall_accuracy*100:.2f}%")
+                for fname, acc_info in per_file_accuracy.items():
+                    await ctx.info(f"  - {fname}: {acc_info['accuracy']*100:.1f}% ({acc_info['correct']}/{acc_info['total']})")
+
+        message = f"PCA visualization report saved: {output_file.name}"
+        if ctx:
+            await ctx.info(message)
+            await ctx.info(f"PC1+PC2 explain {metadata['total_variance_2d']*100:.1f}% of variance")
+            await ctx.info(f"Analyzed {total_segments} segments, {total_anomalies} anomalies detected")
+
+        return {
+            'file_path': str(output_file),
+            'file_name': output_file.name,
+            'message': message,
+            'metadata': metadata,
+            'summary': summary
+        }
+
+    @mcp.tool()
+    async def generate_feature_comparison_report(
+        signal_groups: dict[str, list[str]],
+        sampling_rate: Optional[float] = None,
+        segment_duration: float = 0.1,
+        overlap_ratio: float = 0.5,
+        features_to_plot: Optional[list[str]] = None,
+        ctx: Context | None = None
+    ) -> dict[str, Any]:
+        """
+        Generate feature comparison report with violin plots comparing time-domain features.
+
+        Creates interactive HTML report with violin plots showing distribution of 17
+        time-domain features across different signal groups (e.g., Healthy vs Faulty).
+
+        **Strategy**: Same HTML report approach as other reports. Useful for understanding
+        which features are most discriminative for fault detection.
+
+        Args:
+            signal_groups: Dictionary mapping group names to list of signal files.
+                          Example: {"Healthy": ["baseline_1.csv", "baseline_2.csv"],
+                                   "Faulty": ["InnerRaceFault_1.csv", "OuterRaceFault_1.csv"]}
+            sampling_rate: Sampling rate (auto-detect from metadata if None)
+            segment_duration: Segment duration in seconds (default: 0.1s for ML)
+            overlap_ratio: Overlap ratio 0-1 (default: 0.5)
+            features_to_plot: List of feature names to plot (default: all 17 features)
+            ctx: MCP context
+
+        Returns:
+            Dictionary with file path, metadata, and summary
+
+        Example:
+            >>> generate_feature_comparison_report(
+            ...     signal_groups={
+            ...         "Healthy": ["real_train/baseline_1.csv", "real_train/baseline_2.csv"],
+            ...         "Inner Fault": ["real_train/InnerRaceFault_vload_1.csv"],
+            ...         "Outer Fault": ["real_train/OuterRaceFault_1.csv"]
+            ...     }
+            ... )
+        """
+        # Import extract_time_domain_features from the monolith (will be refactored later)
+        from ..machinery_diagnostics_server import extract_time_domain_features
+
+        if ctx:
+            await ctx.info(f"Generating feature comparison report for {len(signal_groups)} groups...")
+
+        # All possible features
+        all_feature_names = [
+            'mean', 'std', 'var', 'mean_abs', 'rms', 'max', 'min', 'range',
+            'crest_factor', 'kurtosis', 'skewness', 'shape_factor', 'impulse_factor',
+            'clearance_factor', 'power', 'entropy', 'zero_crossing_rate'
+        ]
+
+        if features_to_plot is None:
+            features_to_plot = all_feature_names
+
+        # Extract features from all signal groups
+        group_features = {}
+
+        for group_name, signal_files in signal_groups.items():
+            all_features_for_group = []
+
+            for signal_file in signal_files:
+                filepath = DATA_DIR / signal_file
+                if not filepath.exists():
+                    logger.warning(f"File not found: {signal_file}, skipping...")
+                    continue
+
+                # Auto-detect sampling rate if not provided
+                if sampling_rate is None:
+                    metadata_path = get_metadata_path(signal_file)
+                    if metadata_path.exists():
+                        with open(metadata_path) as f:
+                            metadata = json.load(f)
+                            sampling_rate = metadata.get("sampling_rate", 10000.0)
+                    else:
+                        sampling_rate = 10000.0  # fallback
+
+                signal_data = load_signal_data(signal_file)
+                if signal_data is None:
+                    raise ValueError(f"Could not load signal data from: {signal_file}")
+
+                # Segment and extract features
+                segment_length_samples = int(segment_duration * sampling_rate)
+                hop_length = int(segment_length_samples * (1 - overlap_ratio))
+
+                for start in range(0, len(signal_data) - segment_length_samples + 1, hop_length):
+                    segment = signal_data[start:start + segment_length_samples]
+                    features = extract_time_domain_features(segment)
+                    all_features_for_group.append(features)
+
+            group_features[group_name] = pd.DataFrame(all_features_for_group)
+
+        # Create subplots - one violin plot per feature
+        num_features = len(features_to_plot)
+        rows = (num_features + 2) // 3  # 3 columns
+        cols = min(3, num_features)
+
+        fig = make_subplots(
+            rows=rows,
+            cols=cols,
+            subplot_titles=features_to_plot,
+            vertical_spacing=0.12,
+            horizontal_spacing=0.10
+        )
+
+        colors = ['blue', 'red', 'green', 'orange', 'purple', 'brown', 'pink']
+
+        for idx, feature in enumerate(features_to_plot):
+            row = idx // 3 + 1
+            col = idx % 3 + 1
+
+            for group_idx, (group_name, features_df) in enumerate(group_features.items()):
+                if feature not in features_df.columns:
+                    continue
+
+                fig.add_trace(
+                    go.Violin(
+                        y=features_df[feature],
+                        name=group_name,
+                        box_visible=True,
+                        meanline_visible=True,
+                        fillcolor=colors[group_idx % len(colors)],
+                        opacity=0.6,
+                        showlegend=(idx == 0),  # Show legend only once
+                        hovertemplate=f'<b>{group_name}</b><br>{feature}: %{{y:.4f}}<extra></extra>'
+                    ),
+                    row=row,
+                    col=col
+                )
+
+        # Update layout
+        fig.update_layout(
+            title="Time-Domain Feature Comparison (Violin Plots)",
+            height=400 * rows,
+            width=1400,
+            template='plotly_white',
+            showlegend=True,
+            legend=dict(
+                orientation="h",
+                yanchor="bottom",
+                y=1.02,
+                xanchor="center",
+                x=0.5
+            )
+        )
+
+        # Save HTML report
+        group_names_safe = "_vs_".join([name.replace(" ", "_") for name in signal_groups.keys()])
+        output_file = REPORTS_DIR / f"feature_comparison_{group_names_safe}.html"
+        fig.write_html(str(output_file))
+
+        # Prepare metadata
+        metadata = {
+            'report_type': 'feature_comparison',
+            'groups': {name: len(files) for name, files in signal_groups.items()},
+            'features_plotted': features_to_plot,
+            'segment_duration': segment_duration,
+            'sampling_rate': sampling_rate,
+            'segments_per_group': {name: len(df) for name, df in group_features.items()}
+        }
+
+        message = f"Feature comparison report saved: {output_file.name}"
+        if ctx:
+            await ctx.info(message)
+            await ctx.info(f"Compared {len(signal_groups)} groups across {len(features_to_plot)} features")
+
+        return {
+            'file_path': str(output_file),
+            'file_name': output_file.name,
+            'message': message,
+            'metadata': metadata
+        }

--- a/src/server.py
+++ b/src/server.py
@@ -1,0 +1,178 @@
+"""
+Predictive Maintenance MCP Server — Orchestrator.
+
+Thin entry point that creates the FastMCP instance and delegates tool
+registration to the mcp_tools sub-package (one module per ISO 13374 block).
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+from mcp.server.fastmcp import FastMCP
+
+from .config import DATA_DIR, MODELS_DIR, RESOURCES_DIR, REPORTS_DIR, CACHE_DIR
+from .mcp_tools import register_all
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# MCP server initialization
+# ---------------------------------------------------------------------------
+mcp = FastMCP(
+    "Predictive Maintenance",
+    instructions="""
+    MCP server for predictive maintenance and industrial machinery diagnostics.
+
+    Capabilities:
+    - Reading and managing vibration signals
+    - Spectral analysis (FFT with dB normalization)
+    - Envelope analysis for bearing fault detection
+    - Statistical analysis (RMS, Kurtosis, Crest Factor)
+    - ISO 20816-3 vibration severity evaluation
+    - Professional HTML report generation (saved to reports/ directory)
+    - Automatic peak detection and harmonic identification
+    - Guided diagnostic workflows (prompts)
+    - Document search (RAG) across machine manuals and bearing catalogs
+
+    Output efficiency:
+    - All spectral tools return COMPACT summaries (top peaks + stats), NOT full arrays
+    - Signal resources return metadata + statistics only, NOT raw samples
+    - Reports are saved as HTML files; only path + summary returned to chat
+    - Use generate_*_report() or plot_*() for full visual inspection
+    - NEVER attempt to display or return full-length arrays in chat
+
+    Report Generation System:
+    - All visualizations are generated as professional HTML files
+    - Reports are saved in reports/ directory with metadata
+    - LLM should inform user about report location and NOT display HTML content
+    - Use list_html_reports() to see available reports
+    - Use get_report_info() to get report info without consuming tokens
+
+    Documentation Search (RAG):
+    - Use search_documentation() to find relevant passages in manuals and catalogs
+    - Prefer search_documentation() over read_manual_excerpt() for targeted queries
+    - Use read_manual_excerpt() only when you need to read consecutive pages
+
+    Evidence-based inference policy (hard rules):
+    1) Do NOT infer fault type from filenames, paths, or user-provided labels. Treat filenames as opaque identifiers.
+    2) Do NOT make diagnostic claims based solely on statistical parameters (RMS/CF/Kurtosis). Use them for screening only.
+    3) Bearing fault identification (inner/outer/ball/cage) must be supported by frequency-domain evidence (envelope peaks at characteristic frequencies) and at least one additional indicator (e.g., high kurtosis or distinct harmonics). If this corroboration is missing, mark the result as "inconclusive" and recommend further analysis.
+    4) Use cautious language: say "possible" or "consistent with" when evidence is partial; say "confirmed" only if multiple independent analyses agree.
+    5) Always cite which analyses and thresholds support each conclusion. If data or parameters are missing, ask for them instead of guessing.
+    6) NEVER suggest parameters, thresholds, or recommendations not explicitly provided in tool outputs or prompt workflows. Do NOT invent frequency ranges, filter settings, or maintenance actions. Only use guidance from STEP 6 of diagnostic prompts.
+
+    Signal unit confirmation policy (CRITICAL - Hypothesis-based flow):
+    - When calling evaluate_iso_20816(), tool follows hypothesis-based unit detection:
+      1. Check metadata file for 'signal_unit' field (best practice)
+      2. Use user-provided signal_unit parameter if explicitly given
+      3. If neither exists: Tool generates RMS-based hypothesis and ASKS USER to confirm
+      4. Default assumption: 'g' (acceleration) if user doesn't know
+    - Tool will display hypothesis reasoning and request user confirmation
+    - ALWAYS inform user about the hypothesis and ask for confirmation
+    - If user confirms hypothesis is wrong, they must provide correct signal_unit parameter
+    - Wrong unit conversion (g vs mm/s) completely invalidates ISO 20816-3 results!
+    - Best practice: Recommend user adds 'signal_unit' field to metadata JSON files
+
+    Output formatting rules:
+    - Keep responses brief (<=300 words, bullet points)
+    - Inform user about generated HTML reports with file path
+    - DO NOT display HTML content in chat (wastes tokens)
+    - NEVER print large data directly
+    - Reports are professional, self-contained HTML files
+
+    Filename resolution policy:
+    - FIRST call list_available_signals() to verify exact filename
+    - Do NOT auto-correct or guess filenames
+    - If ambiguous, ask user to clarify
+
+    Workflow Prompts (use these for guided analysis):
+    - diagnose_bearing() - Complete bearing diagnostic workflow with evidence-based decision tree
+    - diagnose_gear() - Gear fault detection workflow
+    - quick_diagnostic_report() - Fast screening analysis (non-definitive)
+    """
+)
+
+# ---------------------------------------------------------------------------
+# Register all tools, resources, and prompts from ISO 13374 modules
+# ---------------------------------------------------------------------------
+register_all(mcp)
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle
+# ---------------------------------------------------------------------------
+def _setup_environment() -> None:
+    """Configure logging and create required directories."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        handlers=[logging.StreamHandler(sys.stderr)]
+    )
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    RESOURCES_DIR.mkdir(parents=True, exist_ok=True)
+    (RESOURCES_DIR / "machine_manuals").mkdir(parents=True, exist_ok=True)
+    (RESOURCES_DIR / "bearing_catalogs").mkdir(parents=True, exist_ok=True)
+    (RESOURCES_DIR / "datasheets").mkdir(parents=True, exist_ok=True)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def main():
+    """Run the MCP server.
+
+    CLI usage::
+
+        # Default: stdio transport (Claude Desktop, VS Code)
+        predictive-maintenance-mcp
+
+        # SSE transport for remote/enterprise clients
+        predictive-maintenance-mcp --transport sse --host 0.0.0.0 --port 8080
+
+        # Streamable-HTTP transport (MCP 2025-03-26 spec)
+        predictive-maintenance-mcp --transport streamable-http --port 8080
+
+    Environment variable overrides (useful in Docker)::
+
+        MCP_TRANSPORT=sse  MCP_HOST=0.0.0.0  MCP_PORT=8080
+    """
+    parser = argparse.ArgumentParser(
+        description="Predictive Maintenance MCP Server",
+    )
+    parser.add_argument(
+        "--transport", "-t",
+        choices=["stdio", "sse", "streamable-http"],
+        default=os.environ.get("MCP_TRANSPORT", "stdio"),
+        help="Transport protocol (default: stdio, env: MCP_TRANSPORT)",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("MCP_HOST", "127.0.0.1"),
+        help="Bind address for SSE/HTTP (default: 127.0.0.1, env: MCP_HOST)",
+    )
+    parser.add_argument(
+        "--port", "-p",
+        type=int,
+        default=int(os.environ.get("MCP_PORT", "8000")),
+        help="Port for SSE/HTTP transport (default: 8000, env: MCP_PORT)",
+    )
+    args = parser.parse_args()
+
+    _setup_environment()
+
+    mcp.settings.host = args.host
+    mcp.settings.port = args.port
+
+    logger.info("Starting Predictive Maintenance MCP Server...")
+    logger.info(f"Transport: {args.transport}")
+    logger.info(f"Data directory: {DATA_DIR}")
+    if args.transport != "stdio":
+        logger.info(f"Listening on {args.host}:{args.port}")
+
+    mcp.run(transport=args.transport)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Split `machinery_diagnostics_server.py` (5286 lines) into modular `mcp_tools/` package:
  - `acquisition_tools.py` (Block 1): signal loading, repository, resources
  - `analysis_tools.py` (Block 2): FFT, envelope, PSD, STFT, features
  - `diagnostics_tools.py` (Blocks 3-4): bearing, ISO, anomaly detection
  - `report_tools.py` (Block 6): plots, reports, HTML generation
  - `prompts.py`: 4 guided diagnostic workflows
- New `server.py` (178 lines) orchestrates all modules — verified 40/40 tools match
- Old monolith preserved for backward compat (to be removed in future)
- 3 tutorial Jupyter notebooks (PRD Phase 1.7 P0):
  - Getting Started, Bearing Diagnostics, Condition Monitoring

## Test plan

- [x] All 225 tests pass with zero regressions
- [x] New server verified: 40 MCP tools identical to old monolith
- [x] Both `from predictive_maintenance_mcp.server import mcp` and `from predictive_maintenance_mcp.machinery_diagnostics_server import mcp` work
- [ ] CI passes on all matrix combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)