### PR TITLE
fix(security): patch path traversal, scoring bug, race condition, and quality issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 60
+fail_under = 85
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",

--- a/src/diagnostics/bearing_analyzer.py
+++ b/src/diagnostics/bearing_analyzer.py
@@ -86,7 +86,7 @@ def check_bearing_fault_peak(
     if detected and len(harmonics) >= 2:
         confidence = "high"
     elif detected and len(harmonics) >= 1:
-        confidence = "high"
+        confidence = "moderate"
     elif detected:
         confidence = "moderate"
     elif len(harmonics) > 0:

--- a/src/mcp_tools/_utils.py
+++ b/src/mcp_tools/_utils.py
@@ -1,0 +1,160 @@
+"""Shared utilities for MCP tool modules."""
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from mcp.server.fastmcp import Context
+
+logger = logging.getLogger(__name__)
+
+
+def safe_resolve(base_dir: Path, user_input: str) -> Path:
+    """Resolve *user_input* under *base_dir* and verify containment.
+
+    Prevents path-traversal attacks (e.g. ``../../etc/passwd``).
+
+    Args:
+        base_dir: The directory the resolved path must stay inside.
+        user_input: User-supplied filename / relative path.
+
+    Returns:
+        The resolved, validated :class:`Path`.
+
+    Raises:
+        ValueError: If the resolved path escapes *base_dir*.
+    """
+    candidate = (base_dir / user_input).resolve()
+    allowed = base_dir.resolve()
+    if not str(candidate).startswith(str(allowed)):
+        raise ValueError(f"Invalid path — escapes base directory: {user_input}")
+    return candidate
+
+
+def sanitize_filename(name: str) -> str:
+    """Strip directory separators and dangerous characters from *name*.
+
+    Useful when constructing output filenames from user-provided strings.
+
+    Returns:
+        A safe filename component containing only ``[a-zA-Z0-9_.-]``.
+    """
+    stem = Path(name).name  # drop any directory components
+    return re.sub(r"[^a-zA-Z0-9_.\-]", "_", stem)
+
+
+async def load_and_validate_metadata(
+    ctx: Context,
+    filename: str,
+    data_dir: Path,
+    load_signal_data_fn,
+    provided_sampling_rate: Optional[float],
+    default_sampling_rate: float,
+    provided_segment_duration: Optional[float],
+    default_segment_duration: float,
+) -> tuple[float, float]:
+    """Load metadata and validate/confirm analysis parameters with user.
+
+    Critical parameter validation strategy:
+    1. SAMPLING RATE:
+       - Check metadata file first
+       - If metadata exists: use it, notify user
+       - If no metadata AND user provided: use user value, warn no verification
+       - If no metadata AND no user input: CRITICAL WARNING, ask user to confirm
+
+    2. SEGMENT DURATION:
+       - Always notify user of value being used
+       - Suggest they can modify if needed
+
+    Args:
+        ctx: MCP context for user communication.
+        filename: Signal filename.
+        data_dir: Base data directory.
+        load_signal_data_fn: Callable to load signal arrays.
+        provided_sampling_rate: Sampling rate provided by user (None if using default).
+        default_sampling_rate: Default sampling rate (e.g., 1000.0).
+        provided_segment_duration: Segment duration provided by user (None if using default).
+        default_segment_duration: Default segment duration (e.g., 1.0).
+
+    Returns:
+        Tuple of (validated_sampling_rate, validated_segment_duration).
+    """
+    filepath = data_dir / filename
+    metadata_file = filepath.parent / (filepath.stem + "_metadata.json")
+
+    # Initialize with provided or default values
+    sampling_rate = provided_sampling_rate if provided_sampling_rate is not None else default_sampling_rate
+    segment_duration = provided_segment_duration if provided_segment_duration is not None else default_segment_duration
+
+    # Check if user explicitly provided values (not using defaults)
+    user_provided_sampling_rate = (provided_sampling_rate is not None and provided_sampling_rate != default_sampling_rate)
+    user_provided_segment_duration = (provided_segment_duration is not None and provided_segment_duration != default_segment_duration)
+
+    # STEP 1: Validate SAMPLING RATE (CRITICAL)
+    metadata_found = False
+    if metadata_file.exists():
+        with open(metadata_file, 'r') as f:
+            metadata = json.load(f)
+            if 'sampling_rate' in metadata:
+                metadata_sampling_rate = metadata['sampling_rate']
+                metadata_found = True
+
+                if user_provided_sampling_rate and abs(sampling_rate - metadata_sampling_rate) > 0.1:
+                    await ctx.info(f"⚠️  CONFLICT: User provided {sampling_rate} Hz, but metadata says {metadata_sampling_rate} Hz")
+                    await ctx.info(f"   Using METADATA value: {metadata_sampling_rate} Hz (more reliable)")
+                    sampling_rate = metadata_sampling_rate
+                else:
+                    await ctx.info(f"✅ Metadata found: sampling_rate = {metadata_sampling_rate} Hz")
+                    sampling_rate = metadata_sampling_rate
+
+    # CRITICAL: No metadata found
+    if not metadata_found:
+        if user_provided_sampling_rate:
+            await ctx.info(f"📌 Using user-provided sampling_rate = {sampling_rate} Hz")
+            await ctx.info(f"   ⚠️  No metadata file to verify - cannot confirm correctness")
+        else:
+            await ctx.info(f"")
+            await ctx.info(f"❌ CRITICAL: No metadata found and no sampling_rate provided!")
+            await ctx.info(f"")
+            await ctx.info(f"   File: {filename}")
+            await ctx.info(f"   Expected metadata: {metadata_file.name}")
+            await ctx.info(f"")
+            await ctx.info(f"   Sampling rate is CRITICAL for frequency analysis accuracy.")
+            await ctx.info(f"   Using default {sampling_rate} Hz may give COMPLETELY WRONG results!")
+            await ctx.info(f"")
+            await ctx.info(f"⚠️  PLEASE CONFIRM:")
+            await ctx.info(f"   • Do you know the sampling rate for '{filename}'?")
+            await ctx.info(f"   • If YES: Please provide sampling_rate parameter and re-run")
+            await ctx.info(f"   • If NO: Results will be UNRELIABLE - interpretation requires caution")
+            await ctx.info(f"")
+            await ctx.info(f"⚠️  PROCEEDING WITH DEFAULT {sampling_rate} Hz (likely incorrect!)")
+            await ctx.info(f"")
+
+    # STEP 2: Validate SEGMENT DURATION (important but less critical)
+    if user_provided_segment_duration:
+        await ctx.info(f"📊 Using segment_duration = {segment_duration}s (user-provided)")
+    else:
+        await ctx.info(f"📊 Using segment_duration = {segment_duration}s (default)")
+        await ctx.info(f"   💡 You can modify by providing segment_duration parameter")
+
+    # Calculate signal info
+    try:
+        signal_data = load_signal_data_fn(filename)
+        if signal_data is None:
+            raise ValueError(f"Could not load signal data from: {filename}")
+        signal_duration_sec = len(signal_data) / sampling_rate
+        await ctx.info(f"")
+        await ctx.info(f"📏 Signal info: {len(signal_data)} samples, {signal_duration_sec:.2f}s duration at {sampling_rate} Hz")
+
+        if segment_duration is not None and segment_duration < signal_duration_sec:
+            await ctx.info(f"   Analyzing {segment_duration}s segment from {signal_duration_sec:.2f}s total")
+        else:
+            await ctx.info(f"   Analyzing full signal")
+        await ctx.info(f"")
+    except Exception as e:
+        logger.warning(f"Could not load signal for info: {e}")
+
+    return sampling_rate, segment_duration

--- a/src/mcp_tools/acquisition_tools.py
+++ b/src/mcp_tools/acquisition_tools.py
@@ -14,124 +14,9 @@ from ..signal_loader import load_signal_data, SUPPORTED_EXTENSIONS, get_metadata
 from ..signal_repository import get_repository
 from ..models import StoredSignalInfo, SignalInfo
 from ..document_reader import extract_text_from_pdf
+from ._utils import safe_resolve
 
 logger = logging.getLogger(__name__)
-
-
-async def load_and_validate_metadata(
-    ctx: Context,
-    filename: str,
-    provided_sampling_rate: Optional[float],
-    default_sampling_rate: float,
-    provided_segment_duration: Optional[float],
-    default_segment_duration: float
-) -> tuple[float, float]:
-    """
-    Load metadata and validate/confirm analysis parameters with user.
-
-    Critical parameter validation strategy:
-    1. SAMPLING RATE:
-       - Check metadata file first
-       - If metadata exists: use it, notify user
-       - If no metadata AND user provided: use user value, warn no verification
-       - If no metadata AND no user input: CRITICAL WARNING, ask user to confirm
-
-    2. SEGMENT DURATION:
-       - Always notify user of value being used
-       - Suggest they can modify if needed
-
-    Args:
-        ctx: MCP context for user communication
-        filename: Signal filename
-        provided_sampling_rate: Sampling rate provided by user (None if using default)
-        default_sampling_rate: Default sampling rate (e.g., 1000.0)
-        provided_segment_duration: Segment duration provided by user (None if using default)
-        default_segment_duration: Default segment duration (e.g., 1.0)
-
-    Returns:
-        Tuple of (validated_sampling_rate, validated_segment_duration)
-    """
-    filepath = DATA_DIR / filename
-    metadata_file = filepath.parent / (filepath.stem + "_metadata.json")
-
-    # Initialize with provided or default values
-    sampling_rate = provided_sampling_rate if provided_sampling_rate is not None else default_sampling_rate
-    segment_duration = provided_segment_duration if provided_segment_duration is not None else default_segment_duration
-
-    # Check if user explicitly provided values (not using defaults)
-    user_provided_sampling_rate = (provided_sampling_rate is not None and provided_sampling_rate != default_sampling_rate)
-    user_provided_segment_duration = (provided_segment_duration is not None and provided_segment_duration != default_segment_duration)
-
-    # STEP 1: Validate SAMPLING RATE (CRITICAL)
-    metadata_found = False
-    if metadata_file.exists():
-        import json
-        with open(metadata_file, 'r') as f:
-            metadata = json.load(f)
-            if 'sampling_rate' in metadata:
-                metadata_sampling_rate = metadata['sampling_rate']
-                metadata_found = True
-
-                if user_provided_sampling_rate and abs(sampling_rate - metadata_sampling_rate) > 0.1:
-                    # User provided DIFFERENT value than metadata
-                    await ctx.info(f"⚠️  CONFLICT: User provided {sampling_rate} Hz, but metadata says {metadata_sampling_rate} Hz")
-                    await ctx.info(f"   Using METADATA value: {metadata_sampling_rate} Hz (more reliable)")
-                    sampling_rate = metadata_sampling_rate
-                else:
-                    # Metadata found, use it
-                    await ctx.info(f"✅ Metadata found: sampling_rate = {metadata_sampling_rate} Hz")
-                    sampling_rate = metadata_sampling_rate
-
-    # CRITICAL: No metadata found
-    if not metadata_found:
-        if user_provided_sampling_rate:
-            # User provided value, no metadata to verify
-            await ctx.info(f"📌 Using user-provided sampling_rate = {sampling_rate} Hz")
-            await ctx.info(f"   ⚠️  No metadata file to verify - cannot confirm correctness")
-        else:
-            # NO metadata, NO user input - CRITICAL!
-            await ctx.info(f"")
-            await ctx.info(f"❌ CRITICAL: No metadata found and no sampling_rate provided!")
-            await ctx.info(f"")
-            await ctx.info(f"   File: {filename}")
-            await ctx.info(f"   Expected metadata: {metadata_file.name}")
-            await ctx.info(f"")
-            await ctx.info(f"   Sampling rate is CRITICAL for frequency analysis accuracy.")
-            await ctx.info(f"   Using default {sampling_rate} Hz may give COMPLETELY WRONG results!")
-            await ctx.info(f"")
-            await ctx.info(f"⚠️  PLEASE CONFIRM:")
-            await ctx.info(f"   • Do you know the sampling rate for '{filename}'?")
-            await ctx.info(f"   • If YES: Please provide sampling_rate parameter and re-run")
-            await ctx.info(f"   • If NO: Results will be UNRELIABLE - interpretation requires caution")
-            await ctx.info(f"")
-            await ctx.info(f"⚠️  PROCEEDING WITH DEFAULT {sampling_rate} Hz (likely incorrect!)")
-            await ctx.info(f"")
-
-    # STEP 2: Validate SEGMENT DURATION (important but less critical)
-    if user_provided_segment_duration:
-        await ctx.info(f"📊 Using segment_duration = {segment_duration}s (user-provided)")
-    else:
-        await ctx.info(f"📊 Using segment_duration = {segment_duration}s (default)")
-        await ctx.info(f"   💡 You can modify by providing segment_duration parameter")
-
-    # Calculate signal info
-    try:
-        signal_data = load_signal_data(filename)
-        if signal_data is None:
-            raise ValueError(f"Could not load signal data from: {filename}")
-        signal_duration_sec = len(signal_data) / sampling_rate
-        await ctx.info(f"")
-        await ctx.info(f"📏 Signal info: {len(signal_data)} samples, {signal_duration_sec:.2f}s duration at {sampling_rate} Hz")
-
-        if segment_duration is not None and segment_duration < signal_duration_sec:
-            await ctx.info(f"   Analyzing {segment_duration}s segment from {signal_duration_sec:.2f}s total")
-        else:
-            await ctx.info(f"   Analyzing full signal")
-        await ctx.info(f"")
-    except Exception as e:
-        logger.warning(f"Could not load signal for info: {e}")
-
-    return sampling_rate, segment_duration
 
 
 def register(mcp: FastMCP) -> None:
@@ -205,7 +90,7 @@ def register(mcp: FastMCP) -> None:
             JSON with signal metadata and basic statistics (no raw data)
         """
         try:
-            file_path = DATA_DIR / filename
+            file_path = safe_resolve(DATA_DIR, filename)
 
             if not file_path.exists():
                 return f'{{"error": "File {filename} not found"}}'
@@ -305,7 +190,7 @@ def register(mcp: FastMCP) -> None:
             "Read the pump manual and tell me what bearings are specified"
         """
         try:
-            manual_path = RESOURCES_DIR / "machine_manuals" / filename
+            manual_path = safe_resolve(RESOURCES_DIR / "machine_manuals", filename)
 
             if not manual_path.exists():
                 return json.dumps({
@@ -390,6 +275,7 @@ def register(mcp: FastMCP) -> None:
         duration: float = 10.0,
         sampling_rate: float = 10000.0,
         noise_level: float = 0.1,
+        random_seed: Optional[int] = None,
         ctx: Context = None
     ) -> str:
         """
@@ -409,6 +295,8 @@ def register(mcp: FastMCP) -> None:
         """
         if ctx:
             await ctx.info(f"Generating {signal_type} test signal...")
+
+        rng = np.random.default_rng(random_seed)
 
         # Time parameters
         t = np.linspace(0, duration, int(sampling_rate * duration))
@@ -449,10 +337,10 @@ def register(mcp: FastMCP) -> None:
 
         else:  # "normal"
             # Normal signal: broadband noise only
-            signal_clean = np.random.randn(len(t)) * 0.1
+            signal_clean = rng.standard_normal(len(t)) * 0.1
 
         # Add noise
-        noise = np.random.randn(len(t)) * noise_level
+        noise = rng.standard_normal(len(t)) * noise_level
         signal_data = signal_clean + noise
 
         # Save the signal

--- a/src/mcp_tools/analysis_tools.py
+++ b/src/mcp_tools/analysis_tools.py
@@ -32,124 +32,9 @@ from ..signal_processing.features import (
     segment_and_extract_features as _segment_and_extract_features,
     resolve_sampling_rate as _resolve_sampling_rate,
 )
+from ._utils import sanitize_filename, load_and_validate_metadata as _load_and_validate_metadata
 
 logger = logging.getLogger(__name__)
-
-
-async def load_and_validate_metadata(
-    ctx: Context,
-    filename: str,
-    provided_sampling_rate: Optional[float],
-    default_sampling_rate: float,
-    provided_segment_duration: Optional[float],
-    default_segment_duration: float
-) -> tuple[float, float]:
-    """
-    Load metadata and validate/confirm analysis parameters with user.
-
-    Critical parameter validation strategy:
-    1. SAMPLING RATE:
-       - Check metadata file first
-       - If metadata exists: use it, notify user
-       - If no metadata AND user provided: use user value, warn no verification
-       - If no metadata AND no user input: CRITICAL WARNING, ask user to confirm
-
-    2. SEGMENT DURATION:
-       - Always notify user of value being used
-       - Suggest they can modify if needed
-
-    Args:
-        ctx: MCP context for user communication
-        filename: Signal filename
-        provided_sampling_rate: Sampling rate provided by user (None if using default)
-        default_sampling_rate: Default sampling rate (e.g., 1000.0)
-        provided_segment_duration: Segment duration provided by user (None if using default)
-        default_segment_duration: Default segment duration (e.g., 1.0)
-
-    Returns:
-        Tuple of (validated_sampling_rate, validated_segment_duration)
-    """
-    filepath = DATA_DIR / filename
-    metadata_file = filepath.parent / (filepath.stem + "_metadata.json")
-
-    # Initialize with provided or default values
-    sampling_rate = provided_sampling_rate if provided_sampling_rate is not None else default_sampling_rate
-    segment_duration = provided_segment_duration if provided_segment_duration is not None else default_segment_duration
-
-    # Check if user explicitly provided values (not using defaults)
-    user_provided_sampling_rate = (provided_sampling_rate is not None and provided_sampling_rate != default_sampling_rate)
-    user_provided_segment_duration = (provided_segment_duration is not None and provided_segment_duration != default_segment_duration)
-
-    # STEP 1: Validate SAMPLING RATE (CRITICAL)
-    metadata_found = False
-    if metadata_file.exists():
-        import json
-        with open(metadata_file, 'r') as f:
-            metadata = json.load(f)
-            if 'sampling_rate' in metadata:
-                metadata_sampling_rate = metadata['sampling_rate']
-                metadata_found = True
-
-                if user_provided_sampling_rate and abs(sampling_rate - metadata_sampling_rate) > 0.1:
-                    # User provided DIFFERENT value than metadata
-                    await ctx.info(f"⚠️  CONFLICT: User provided {sampling_rate} Hz, but metadata says {metadata_sampling_rate} Hz")
-                    await ctx.info(f"   Using METADATA value: {metadata_sampling_rate} Hz (more reliable)")
-                    sampling_rate = metadata_sampling_rate
-                else:
-                    # Metadata found, use it
-                    await ctx.info(f"✅ Metadata found: sampling_rate = {metadata_sampling_rate} Hz")
-                    sampling_rate = metadata_sampling_rate
-
-    # CRITICAL: No metadata found
-    if not metadata_found:
-        if user_provided_sampling_rate:
-            # User provided value, no metadata to verify
-            await ctx.info(f"📌 Using user-provided sampling_rate = {sampling_rate} Hz")
-            await ctx.info(f"   ⚠️  No metadata file to verify - cannot confirm correctness")
-        else:
-            # NO metadata, NO user input - CRITICAL!
-            await ctx.info(f"")
-            await ctx.info(f"❌ CRITICAL: No metadata found and no sampling_rate provided!")
-            await ctx.info(f"")
-            await ctx.info(f"   File: {filename}")
-            await ctx.info(f"   Expected metadata: {metadata_file.name}")
-            await ctx.info(f"")
-            await ctx.info(f"   Sampling rate is CRITICAL for frequency analysis accuracy.")
-            await ctx.info(f"   Using default {sampling_rate} Hz may give COMPLETELY WRONG results!")
-            await ctx.info(f"")
-            await ctx.info(f"⚠️  PLEASE CONFIRM:")
-            await ctx.info(f"   • Do you know the sampling rate for '{filename}'?")
-            await ctx.info(f"   • If YES: Please provide sampling_rate parameter and re-run")
-            await ctx.info(f"   • If NO: Results will be UNRELIABLE - interpretation requires caution")
-            await ctx.info(f"")
-            await ctx.info(f"⚠️  PROCEEDING WITH DEFAULT {sampling_rate} Hz (likely incorrect!)")
-            await ctx.info(f"")
-
-    # STEP 2: Validate SEGMENT DURATION (important but less critical)
-    if user_provided_segment_duration:
-        await ctx.info(f"📊 Using segment_duration = {segment_duration}s (user-provided)")
-    else:
-        await ctx.info(f"📊 Using segment_duration = {segment_duration}s (default)")
-        await ctx.info(f"   💡 You can modify by providing segment_duration parameter")
-
-    # Calculate signal info
-    try:
-        signal_data = load_signal_data(filename)
-        if signal_data is None:
-            raise ValueError(f"Could not load signal data from: {filename}")
-        signal_duration_sec = len(signal_data) / sampling_rate
-        await ctx.info(f"")
-        await ctx.info(f"📏 Signal info: {len(signal_data)} samples, {signal_duration_sec:.2f}s duration at {sampling_rate} Hz")
-
-        if segment_duration is not None and segment_duration < signal_duration_sec:
-            await ctx.info(f"   Analyzing {segment_duration}s segment from {signal_duration_sec:.2f}s total")
-        else:
-            await ctx.info(f"   Analyzing full signal")
-        await ctx.info(f"")
-    except Exception as e:
-        logger.warning(f"Could not load signal for info: {e}")
-
-    return sampling_rate, segment_duration
 
 
 # ============================================================================
@@ -213,13 +98,15 @@ def register(mcp: FastMCP) -> None:
             FFTResult with frequencies, magnitudes and dominant peak
         """
         # Validate and load metadata with user confirmation
-        sampling_rate, segment_duration = await load_and_validate_metadata(
+        sampling_rate, segment_duration = await _load_and_validate_metadata(
             ctx=ctx,
             filename=filename,
+            data_dir=DATA_DIR,
+            load_signal_data_fn=load_signal_data,
             provided_sampling_rate=sampling_rate,
             default_sampling_rate=1000.0,
             provided_segment_duration=segment_duration,
-            default_segment_duration=1.0
+            default_segment_duration=1.0,
         )
 
         # Load data
@@ -359,13 +246,15 @@ def register(mcp: FastMCP) -> None:
             EnvelopeResult with peak information and diagnosis (optimized for chat display)
         """
         # Validate and load metadata with user confirmation
-        sampling_rate, segment_duration = await load_and_validate_metadata(
+        sampling_rate, segment_duration = await _load_and_validate_metadata(
             ctx=ctx,
             filename=filename,
+            data_dir=DATA_DIR,
+            load_signal_data_fn=load_signal_data,
             provided_sampling_rate=sampling_rate,
             default_sampling_rate=1000.0,
             provided_segment_duration=segment_duration,
-            default_segment_duration=1.0
+            default_segment_duration=1.0,
         )
 
         # Load data
@@ -640,8 +529,8 @@ def register(mcp: FastMCP) -> None:
         features_df = pd.DataFrame(features_list)
         feature_names = list(features_df.columns)
 
-        # Save features to file
-        features_file = DATA_DIR / f"features_{signal_file}"
+        # Save features to file (sanitize to prevent path traversal)
+        features_file = DATA_DIR / f"features_{sanitize_filename(signal_file)}"
         features_df.to_csv(features_file, index=False)
 
         if ctx:

--- a/src/mcp_tools/diagnostics_tools.py
+++ b/src/mcp_tools/diagnostics_tools.py
@@ -58,6 +58,7 @@ from ..signal_processing.features import (
     segment_and_extract_features as _segment_and_extract_features,
     resolve_sampling_rate as _resolve_sampling_rate,
 )
+from ._utils import safe_resolve, sanitize_filename
 
 logger = logging.getLogger(__name__)
 
@@ -906,11 +907,13 @@ def register(mcp: FastMCP) -> None:
                 if ctx:
                     await ctx.info(f"Healthy validation: {healthy_correct}/{healthy_total} correctly classified ({healthy_accuracy*100:.1f}%)")
 
-            # Part B: Validate on FAULT data
-            X_fault_pca = await _extract_and_transform_validation_features(
-                fault_signal_files, sampling_rate, segment_duration, overlap_ratio,
-                scaler, pca, strict=True, ctx=ctx
-            )
+            # Part B: Validate on FAULT data (only if fault files were provided)
+            X_fault_pca = None
+            if fault_signal_files:
+                X_fault_pca = await _extract_and_transform_validation_features(
+                    fault_signal_files, sampling_rate, segment_duration, overlap_ratio,
+                    scaler, pca, strict=True, ctx=ctx
+                )
 
             if X_fault_pca is not None:
                 # Predict (should be -1 for anomalies)
@@ -1034,11 +1037,16 @@ def register(mcp: FastMCP) -> None:
         if ctx:
             await ctx.info(f"Predicting anomalies in {signal_file}...")
 
+        # Validate model_name — must be a safe filename component
+        safe_name = sanitize_filename(model_name)
+        if safe_name != model_name:
+            raise ValueError(f"Invalid model_name '{model_name}'. Use only alphanumeric, underscore, hyphen, or dot characters.")
+
         # Load model, scaler, PCA
-        model_path = MODELS_DIR / f"{model_name}_model.pkl"
-        scaler_path = MODELS_DIR / f"{model_name}_scaler.pkl"
-        pca_path = MODELS_DIR / f"{model_name}_pca.pkl"
-        metadata_path = MODELS_DIR / f"{model_name}_metadata.json"
+        model_path = safe_resolve(MODELS_DIR, f"{model_name}_model.pkl")
+        scaler_path = safe_resolve(MODELS_DIR, f"{model_name}_scaler.pkl")
+        pca_path = safe_resolve(MODELS_DIR, f"{model_name}_pca.pkl")
+        metadata_path = safe_resolve(MODELS_DIR, f"{model_name}_metadata.json")
 
         if not model_path.exists():
             raise FileNotFoundError(f"Model not found: {model_path}. Train model first.")
@@ -1229,7 +1237,7 @@ def register(mcp: FastMCP) -> None:
         if ctx:
             await ctx.info(f"Extracting specifications from: {manual_filename}")
 
-        manual_path = RESOURCES_DIR / "machine_manuals" / manual_filename
+        manual_path = safe_resolve(RESOURCES_DIR / "machine_manuals", manual_filename)
 
         if not manual_path.exists():
             raise FileNotFoundError(
@@ -1362,7 +1370,7 @@ def register(mcp: FastMCP) -> None:
         if ctx:
             await ctx.info(f"Reading from: {manual_filename}")
 
-        manual_path = RESOURCES_DIR / "machine_manuals" / manual_filename
+        manual_path = safe_resolve(RESOURCES_DIR / "machine_manuals", manual_filename)
 
         if not manual_path.exists():
             raise FileNotFoundError(f"Manual not found: {manual_filename}")

--- a/src/signal_repository.py
+++ b/src/signal_repository.py
@@ -250,14 +250,18 @@ class SignalRepository:
 # ------------------------------------------------------------------
 
 _repository: Optional[SignalRepository] = None
+_repo_lock = threading.Lock()
 
 
 def get_repository() -> SignalRepository:
     """Get or create the global SignalRepository singleton."""
     global _repository
     if _repository is None:
-        max_gb = float(os.environ.get("PMM_SIGNAL_CACHE_GB", "10"))
-        _repository = SignalRepository(
-            max_memory_bytes=int(max_gb * 1024**3)
-        )
+        with _repo_lock:
+            # Double-checked locking
+            if _repository is None:
+                max_gb = float(os.environ.get("PMM_SIGNAL_CACHE_GB", "10"))
+                _repository = SignalRepository(
+                    max_memory_bytes=int(max_gb * 1024**3)
+                )
     return _repository

--- a/tests/test_acquisition_tools.py
+++ b/tests/test_acquisition_tools.py
@@ -9,7 +9,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 from mcp.server.fastmcp import FastMCP
 
-from predictive_maintenance_mcp.mcp_tools.acquisition_tools import register, load_and_validate_metadata
+from predictive_maintenance_mcp.mcp_tools.acquisition_tools import register
+from predictive_maintenance_mcp.mcp_tools._utils import load_and_validate_metadata
+from predictive_maintenance_mcp.signal_loader import load_signal_data
 
 
 # ---------------------------------------------------------------------------
@@ -73,6 +75,8 @@ class TestLoadAndValidateMetadata:
     async def test_uses_metadata_sampling_rate(self, data_dir, mock_ctx):
         rate, seg = await load_and_validate_metadata(
             mock_ctx, "test_sine.csv",
+            data_dir=data_dir,
+            load_signal_data_fn=load_signal_data,
             provided_sampling_rate=None,
             default_sampling_rate=1000.0,
             provided_segment_duration=None,
@@ -84,6 +88,8 @@ class TestLoadAndValidateMetadata:
     async def test_uses_default_when_no_metadata(self, data_dir, mock_ctx):
         rate, seg = await load_and_validate_metadata(
             mock_ctx, "real_train/baseline_1.csv",
+            data_dir=data_dir,
+            load_signal_data_fn=load_signal_data,
             provided_sampling_rate=None,
             default_sampling_rate=1000.0,
             provided_segment_duration=None,
@@ -96,6 +102,8 @@ class TestLoadAndValidateMetadata:
     async def test_metadata_overrides_user_on_conflict(self, data_dir, mock_ctx):
         rate, seg = await load_and_validate_metadata(
             mock_ctx, "test_sine.csv",
+            data_dir=data_dir,
+            load_signal_data_fn=load_signal_data,
             provided_sampling_rate=5000.0,  # different from metadata (10000)
             default_sampling_rate=1000.0,
             provided_segment_duration=None,
@@ -107,6 +115,8 @@ class TestLoadAndValidateMetadata:
     async def test_segment_duration_default(self, data_dir, mock_ctx):
         _, seg = await load_and_validate_metadata(
             mock_ctx, "test_sine.csv",
+            data_dir=data_dir,
+            load_signal_data_fn=load_signal_data,
             provided_sampling_rate=None,
             default_sampling_rate=1000.0,
             provided_segment_duration=None,
@@ -118,6 +128,8 @@ class TestLoadAndValidateMetadata:
     async def test_segment_duration_user_provided(self, data_dir, mock_ctx):
         _, seg = await load_and_validate_metadata(
             mock_ctx, "test_sine.csv",
+            data_dir=data_dir,
+            load_signal_data_fn=load_signal_data,
             provided_sampling_rate=None,
             default_sampling_rate=1000.0,
             provided_segment_duration=0.5,


### PR DESCRIPTION
## Summary

Phase 1 code quality review uncovered 8 bugs (2 critical, 5 high, 1 medium). All fixed and verified.

- **Path traversal vulnerability** (CRITICAL): User-controlled filenames in manual/model handlers could escape base directories via `../../`. Added `safe_resolve()` containment checks on all 6 affected locations.
- **TypeError crash** (CRITICAL): `train_anomaly_model` crashed when `fault_signal_files=None` but `healthy_validation_files` provided. Added guard.
- **Bearing confidence scoring** (HIGH): Both `>=2 harmonics` and `>=1 harmonic` mapped to `"high"`. Fixed second branch to `"moderate"`.
- **Singleton race condition** (HIGH): `get_repository()` not thread-safe under SSE/HTTP transports. Added `threading.Lock` double-checked locking.
- **Path injection in feature output** (HIGH): Unsanitized `signal_file` used in output filename. Added `sanitize_filename()`.
- **Unsafe pickle load** (HIGH): `model_name` not validated before constructing pickle paths. Added validation.
- **Code duplication** (HIGH): `load_and_validate_metadata` copy-pasted across two files (115 lines x2). Extracted to shared `_utils.py`.
- **Global PRNG mutation** (MEDIUM): `np.random.randn()` in `generate_test_signal` violated reproducibility invariant. Switched to `np.random.default_rng(seed)`.
- **Coverage threshold**: Raised `fail_under` from 60% to 85% to match project targets.

## Test plan

- [x] All 414 tests pass (0 failures)
- [x] Coverage: 86.95% (meets new 85% threshold)
- [x] Path traversal: `safe_resolve()` prevents `../../` escapes
- [x] Bearing confidence: 1 harmonic -> "moderate", 2+ harmonics -> "high"
- [x] No import breakage from `load_and_validate_metadata` extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)