### PR TITLE
Add root Claude Code marketplace manifest for hosted plugin distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,47 @@
+{
+  "name": "predictive-maintenance-marketplace",
+  "owner": {
+    "name": "Luigi Di Maggio",
+    "email": "luigi.dimaggio@polito.it"
+  },
+  "metadata": {
+    "description": "Industrial-grade predictive maintenance plugins for Claude Code. Provides vibration analysis, bearing/gear fault diagnosis, anomaly detection, and ISO 20816-3 compliance workflows.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "predictive-maintenance",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/LGDiMaggio/predictive-maintenance-mcp.git",
+        "path": "plugin"
+      },
+      "description": "Complete predictive maintenance toolkit: 7 skills, 2 agents, and 3 commands for vibration analysis, bearing/gear fault diagnosis, anomaly detection, ISO standards compliance, and diagnostic report generation. Requires the predictive-maintenance-mcp server.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Luigi Di Maggio",
+        "email": "luigi.dimaggio@polito.it"
+      },
+      "homepage": "https://github.com/LGDiMaggio/predictive-maintenance-mcp",
+      "repository": "https://github.com/LGDiMaggio/predictive-maintenance-mcp",
+      "license": "MIT",
+      "keywords": [
+        "predictive-maintenance",
+        "vibration-analysis",
+        "bearing-fault",
+        "gear-diagnosis",
+        "iso-20816",
+        "anomaly-detection",
+        "condition-monitoring"
+      ],
+      "category": "industrial-engineering",
+      "tags": [
+        "mcp",
+        "signal-processing",
+        "fault-diagnosis",
+        "iso-13374",
+        "machine-learning"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -451,6 +451,9 @@ The project includes a **distributable Claude Code plugin for predictive mainten
 
 **From the marketplace:**
 
+> This repository now ships a **repository-root marketplace** at `.claude-plugin/marketplace.json` for hosted distribution (e.g., `owner/repo`). It resolves the plugin via `git-subdir` (`path: "plugin"`) so installation works directly from GitHub.
+
+
 ```shell
 /plugin marketplace add LGDiMaggio/predictive-maintenance-mcp
 /plugin install predictive-maintenance@predictive-maintenance-marketplace
@@ -459,6 +462,10 @@ The project includes a **distributable Claude Code plugin for predictive mainten
 **Local development:**
 
 ```shell
+/plugin marketplace add .
+/plugin install predictive-maintenance@predictive-maintenance-marketplace
+
+# Optional: test only the plugin subdirectory marketplace
 /plugin marketplace add ./plugin
 /plugin install predictive-maintenance@predictive-maintenance-marketplace
 ```

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -15,9 +15,15 @@ The `predictive-maintenance-mcp` MCP server must be installed and connected. See
 /plugin install predictive-maintenance@predictive-maintenance-marketplace
 ```
 
+> This repo also includes `.claude-plugin/marketplace.json` at repository root for hosted distribution (`owner/repo`).
+
 ### Local Development
 
 ```shell
+/plugin marketplace add .
+/plugin install predictive-maintenance@predictive-maintenance-marketplace
+
+# Optional: test only the plugin subdirectory marketplace
 /plugin marketplace add ./plugin
 /plugin install predictive-maintenance@predictive-maintenance-marketplace
 ```


### PR DESCRIPTION
### Motivation
- Make the Claude Code plugin installable directly from a GitHub-hosted repository by providing a repository-root marketplace manifest that follows the Claude Code "host and distribute marketplaces" pattern.
- Ensure the plugin resolves correctly when installed as `owner/repo` by pointing the marketplace entry to the plugin subdirectory.

### Description
- Add a repository-root marketplace file at `.claude-plugin/marketplace.json` that declares the `predictive-maintenance` plugin with `source: "git-subdir"` and `path: "plugin"` to allow hosted distribution from the repo root.
- Update `README.md` to document and prefer testing the repository-root marketplace with `/plugin marketplace add .` while keeping `./plugin` as an optional subdirectory test path.
- Update `plugin/README.md` with the same repository-root marketplace note and local development instructions.

### Testing
- Verified JSON validity with `jq . .claude-plugin/marketplace.json`, `jq . plugin/.claude-plugin/marketplace.json`, and `jq . plugin/.claude-plugin/plugin.json`, all of which succeeded.
- Verified installation/docs references with `rg -n "repository-root marketplace|plugin marketplace add \\.|git-subdir|plugin marketplace add ./plugin" README.md plugin/README.md .claude-plugin/marketplace.json`, which returned the expected matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c7e772d8a88336b3700dc50d9145dc)