### PR TITLE
Improve GitHub Pages copy and replace Gallery with plain‑language Results section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- Primary SEO -->
-  <title>Predictive Maintenance MCP Server — AI Agent for Condition Monitoring & Vibration Diagnostics</title>
-  <meta name="description" content="Open-source AI agent for predictive maintenance and condition monitoring. Claude Code plugin with 7 skills for bearing fault detection, vibration analysis, ISO 20816 compliance, and ML anomaly detection — via natural language through the Model Context Protocol.">
+  <title>Predictive Maintenance MCP Server — AI Copilot for Machine Health Monitoring</title>
+  <meta name="description" content="Open-source MCP server that helps maintenance teams understand machine vibration data in plain language. Detect bearing issues, assess risk, and generate clear reports directly on your infrastructure.">
   <meta name="keywords" content="ai agent predictive maintenance, claude plugin predictive maintenance, claude skills predictive maintenance, condition monitoring ai agent, predictive maintenance mcp, MCP server, vibration analysis, bearing fault detection, ISO 20816, FFT analysis, envelope analysis, AI diagnostics, Industry 4.0, condition monitoring, Model Context Protocol, Claude Code plugin, machine learning condition monitoring, ai vibration analysis, industrial ai agent, mcp tools predictive maintenance, open source predictive maintenance">
   <meta name="author" content="Luigi Gianpio Di Maggio">
   <meta name="robots" content="index, follow">
@@ -17,16 +17,16 @@
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Predictive Maintenance MCP Server — AI Agent for Condition Monitoring">
-  <meta property="og:description" content="Open-source AI agent and Claude Code plugin for predictive maintenance. Bearing fault detection, vibration analysis, ISO 20816 compliance, ML anomaly detection — all via natural language through MCP.">
+  <meta property="og:title" content="Predictive Maintenance MCP Server — AI Copilot for Machine Health">
+  <meta property="og:description" content="Open-source MCP server for predictive maintenance. Ask natural-language questions on machine vibration data and get clear diagnostics, risk levels, and actionable reports.">
   <meta property="og:url" content="https://lgdimaggio.github.io/predictive-maintenance-mcp/">
   <meta property="og:image" content="https://raw.githubusercontent.com/LGDiMaggio/predictive-maintenance-mcp/main/assets/predictive-maintenance-mcp_com.jpg">
   <meta property="og:site_name" content="Predictive Maintenance MCP Server">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Predictive Maintenance MCP Server — AI Agent & Claude Plugin">
-  <meta name="twitter:description" content="AI agent for predictive maintenance and condition monitoring. Claude Code plugin with 7 skills. Open source, privacy-first, production-ready.">
+  <meta name="twitter:title" content="Predictive Maintenance MCP Server — AI Copilot for Machine Diagnostics">
+  <meta name="twitter:description" content="Open-source MCP server for machine diagnostics: understand vibration data, identify likely faults, and generate clear maintenance reports.">
   <meta name="twitter:image" content="https://raw.githubusercontent.com/LGDiMaggio/predictive-maintenance-mcp/main/assets/predictive-maintenance-mcp_com.jpg">
 
   <!-- JSON-LD Structured Data -->
@@ -36,7 +36,7 @@
     "@type": "SoftwareApplication",
     "name": "Predictive Maintenance MCP Server",
     "alternateName": "AI Agent for Predictive Maintenance and Condition Monitoring",
-    "description": "Open-source AI agent and Claude Code plugin for predictive maintenance, condition monitoring, bearing fault detection, vibration analysis, ML anomaly detection, and ISO 20816 compliance — powered by the Model Context Protocol.",
+    "description": "Open-source MCP server for predictive maintenance that turns vibration data into understandable diagnostics, risk prioritization, and maintenance-ready reports.",
     "applicationCategory": "EngineeringApplication",
     "applicationSubCategory": "Predictive Maintenance, Condition Monitoring, Industrial AI",
     "operatingSystem": "Windows, macOS, Linux",
@@ -918,7 +918,7 @@
       <li><a href="#how-it-works">How It Works</a></li>
       <li><a href="#plugin">Plugin</a></li>
       <li><a href="#architecture">Architecture</a></li>
-      <li><a href="#gallery">Gallery</a></li>
+      <li><a href="#results">Results</a></li>
       <li><a href="#docs">Docs</a></li>
       <li><a href="https://github.com/LGDiMaggio/predictive-maintenance-mcp" class="nav-cta" target="_blank" rel="noopener">GitHub &#x2197;</a></li>
     </ul>
@@ -942,17 +942,17 @@
   <div class="container">
     <div class="hero-badge">
       <span class="pulse"></span>
-      Open-source &middot; runs on your machine &middot; fault diagnosis through conversation
+      Open-source &middot; local-first &middot; machine diagnostics in plain language
     </div>
 
     <h1>
-      Give Any AI Assistant<br>
-      <span class="gradient-text">Predictive Maintenance</span>
+      Understand Machine Health<br>
+      <span class="gradient-text">Without Signal-Processing Jargon</span>
     </h1>
 
     <p class="tagline">
-      Analyze vibration data, detect machinery faults, and generate professional diagnostic reports &mdash; through natural conversation.
-      An open-source MCP server and <strong>Claude Code plugin</strong> built to <strong>support expert decision-making</strong>, not replace it.
+      Ask simple questions about vibration data and get practical answers: <strong>is this machine safe</strong>, <strong>what is likely failing</strong>, and <strong>what should we do next</strong>.
+      This open-source MCP server supports maintenance engineers with evidence, not buzzwords.
     </p>
 
     <div class="cta-row">
@@ -994,7 +994,7 @@
       </div>
       <div class="stat-card">
         <div class="stat-num" data-target="6">0</div>
-        <div class="stat-label">ISO 13374 Modules</div>
+        <div class="stat-label">Core Engine Modules</div>
       </div>
       <div class="stat-card">
         <div class="stat-num" data-target="86">0</div>
@@ -1013,8 +1013,8 @@
   <div class="container">
     <div class="section-header reveal">
       <span class="overline">What Can It Do</span>
-      <h2>Upload a Signal, Get a Professional Diagnosis</h2>
-      <p>The AI calls 48 specialized analysis tools running locally on your machine. Your data never leaves your infrastructure.</p>
+      <h2>Upload a Signal, Get a Clear Maintenance Answer</h2>
+      <p>The assistant runs the full analysis pipeline locally, then explains results in clear language your team can act on.</p>
     </div>
 
     <div class="convo-grid">
@@ -1024,7 +1024,7 @@
           &ldquo;Is this bearing healthy?&rdquo;
         </div>
         <div class="convo-response">
-          Loads the signal, runs spectral analysis, checks for fault patterns, classifies severity per ISO 20816-3.
+          Loads your data, checks fault patterns, estimates severity, and returns a clear health verdict with supporting evidence.
         </div>
       </div>
       <div class="convo-card reveal">
@@ -1033,7 +1033,7 @@
           &ldquo;Generate a full diagnostic report&rdquo;
         </div>
         <div class="convo-response">
-          Produces an interactive HTML report with charts, fault markers, and severity assessment ready for your supervisor.
+          Generates a manager-friendly report with key charts, risk level, and recommended next actions.
         </div>
       </div>
       <div class="convo-card reveal">
@@ -1042,7 +1042,7 @@
           &ldquo;Extract specs from this pump manual and diagnose the signal&rdquo;
         </div>
         <div class="convo-response">
-          Reads the equipment manual, looks up the bearing model, calculates expected fault frequencies, matches them against the signal.
+          Uses machine documentation and bearing metadata to match expected fault signatures against measured data.
         </div>
       </div>
       <div class="convo-card reveal">
@@ -1051,7 +1051,7 @@
           &ldquo;Train an anomaly detector on my healthy baselines&rdquo;
         </div>
         <div class="convo-response">
-          Trains a machine learning model on normal data, scores new signals, highlights outliers with PCA visualization.
+          Learns normal behavior from baseline runs, then flags unusual patterns before they become failures.
         </div>
       </div>
     </div>
@@ -1063,8 +1063,8 @@
   <div class="container">
     <div class="section-header reveal">
       <span class="overline">48 Endpoints</span>
-      <h2>Tools at a Glance</h2>
-      <p>Five specialized categories covering the full ISO&nbsp;13374 diagnostic pipeline &mdash; all running locally on your machine.</p>
+      <h2>What You Get Out of the Box</h2>
+      <p>Five tool groups covering data ingestion, diagnostics, reporting, and guided workflows &mdash; all local by default.</p>
     </div>
     <div class="tools-overview reveal">
       <div class="tool-cat-card">
@@ -1077,19 +1077,19 @@
         <span class="tool-cat-icon">&#x1F4CA;</span>
         <div class="tool-cat-num" data-target="9">0</div>
         <div class="tool-cat-name">Analysis</div>
-        <div class="tool-cat-desc">FFT, envelope, PSD, STFT, 17+ features, signal plots</div>
+        <div class="tool-cat-desc">Frequency analysis, fault indicators, trend features, and visual checks</div>
       </div>
       <div class="tool-cat-card">
         <span class="tool-cat-icon">&#x2699;&#xFE0F;</span>
         <div class="tool-cat-num" data-target="14">0</div>
         <div class="tool-cat-name">Diagnostics</div>
-        <div class="tool-cat-desc">Bearing, gear, ISO 20816-3, ML anomaly, RAG docs, catalog</div>
+        <div class="tool-cat-desc">Bearing and gear checks, anomaly detection, documentation-aware diagnosis</div>
       </div>
       <div class="tool-cat-card">
         <span class="tool-cat-icon">&#x1F4C4;</span>
         <div class="tool-cat-num" data-target="8">0</div>
         <div class="tool-cat-name">Reporting</div>
-        <div class="tool-cat-desc">HTML/Plotly, Word DOCX, PCA, feature comparison, index</div>
+        <div class="tool-cat-desc">HTML and DOCX outputs designed for engineers, managers, and handover workflows</div>
       </div>
       <div class="tool-cat-card">
         <span class="tool-cat-icon">&#x1F9ED;</span>
@@ -1106,25 +1106,25 @@
   <div class="container">
     <div class="section-header reveal">
       <span class="overline">Capabilities</span>
-      <h2>Professional-Grade Analysis Tools</h2>
-      <p>Accessible through any MCP-compatible AI assistant.</p>
+      <h2>Built for Real Maintenance Decisions</h2>
+      <p>Accessible from any MCP-compatible assistant, with explanations focused on outcomes instead of jargon.</p>
     </div>
 
     <div class="features-grid">
       <div class="feature-card reveal">
         <div class="feature-icon">&#x1F4CA;</div>
-        <h3>FFT Spectrum Analysis</h3>
+        <h3>Frequency-Domain Insight</h3>
         <p>Frequency-domain decomposition with automatic peak detection, harmonic identification, and dB-normalized visualization.</p>
       </div>
       <div class="feature-card reveal">
         <div class="feature-icon green">&#x1F50D;</div>
-        <h3>Envelope Analysis</h3>
-        <p>Bearing-fault-focused demodulation. Reveals characteristic defect frequencies (BPFO, BPFI, BSF, FTF) hidden in raw signals.</p>
+        <h3>Early Bearing Fault Detection</h3>
+        <p>Highlights subtle impact patterns that often indicate early bearing wear, even when the raw signal looks normal.</p>
       </div>
       <div class="feature-card reveal">
         <div class="feature-icon purple">&#x1F4CF;</div>
-        <h3>ISO 20816-3 Assessment</h3>
-        <p>Automated vibration severity evaluation per international standards, with 4 severity zones and hypothesis-based confirmation.</p>
+        <h3>Risk-Zone Classification</h3>
+        <p>Automatic severity classification into intuitive risk zones so teams can prioritize interventions quickly.</p>
       </div>
       <div class="feature-card reveal">
         <div class="feature-icon amber">&#x1F916;</div>
@@ -1133,22 +1133,22 @@
       </div>
       <div class="feature-card reveal">
         <div class="feature-icon green">&#x1F4C4;</div>
-        <h3>Interactive Reports</h3>
+        <h3>Readable Engineering Reports</h3>
         <p>HTML reports with Plotly charts and structured Word diagnostics. 6 report types for ops teams and management.</p>
       </div>
       <div class="feature-card reveal">
         <div class="feature-icon purple">&#x1F4D6;</div>
-        <h3>Document Search (RAG)</h3>
+        <h3>Manual-Aware Diagnostics</h3>
         <p>Semantic search over equipment manuals and bearing catalogs. Extract specs from PDFs and match to signals automatically.</p>
       </div>
       <div class="feature-card reveal">
         <div class="feature-icon amber">&#x1F4C8;</div>
-        <h3>Prognostics &amp; RUL</h3>
+        <h3>Trend &amp; Remaining-Life Estimates</h3>
         <p>Remaining Useful Life estimation and trend analysis with confidence intervals &mdash; ISO 13374 Block 5. Move from reactive to predictive decisions.</p>
       </div>
       <div class="feature-card reveal">
         <div class="feature-icon green">&#x1F9E0;</div>
-        <h3>Decision Intelligence</h3>
+        <h3>Action Recommendations</h3>
         <p>Evidence-based diagnosis pipeline, alert triage, and contextual maintenance recommendations built on the ISO 13374 Block 6 advisory layer.</p>
       </div>
     </div>
@@ -1177,8 +1177,8 @@
       </div>
       <div class="step">
         <div class="step-num">3</div>
-        <h3>Get Expert Analysis</h3>
-        <p>AI orchestrates 48 tools &mdash; FFT, envelope, ISO checks, ML &mdash; and delivers evidence-based results with interactive reports.</p>
+        <h3>Get Explainable Results</h3>
+        <p>The assistant combines multiple analysis methods and returns a concise diagnosis, confidence signals, and recommended actions.</p>
       </div>
     </div>
   </div>
@@ -1213,7 +1213,7 @@
         </div>
         <div class="chat-msg ai">
           <div class="sender">Assistant</div>
-          Envelope analysis shows peaks at <strong>BPFO harmonics</strong> (1x, 2x, 3x), consistent with outer race wear on the drive-end bearing. I've generated an HTML report with spectrum, envelope, and ISO charts &mdash; saved to <code>reports/</code>.
+          The fault signature is consistent with <strong>outer-race bearing wear</strong> on the drive-end side. I've generated an HTML report with the key charts and a recommended action plan &mdash; saved to <code>reports/</code>.
         </div>
       </div>
     </div>
@@ -1225,7 +1225,7 @@
   <div class="container">
     <div class="section-header reveal">
       <span class="overline">Claude Code Plugin</span>
-      <h2>Skills, Agents &amp; Commands for Diagnostics</h2>
+      <h2>Automation for Faster Daily Work</h2>
       <p>7 skills, 2 autonomous agents, 3 slash commands &mdash; installable from the Claude Code marketplace.</p>
     </div>
 
@@ -1259,8 +1259,8 @@
   <div class="container">
     <div class="section-header reveal">
       <span class="overline">Architecture</span>
-      <h2>Privacy-First, Standards-Based Design</h2>
-      <p>Raw vibration data never leaves your machine. Only computed results flow to the LLM.</p>
+      <h2>Privacy-First Architecture</h2>
+      <p>Raw machine data remains local. You keep control of datasets, models, and generated reports.</p>
     </div>
 
     <div class="arch-wrapper reveal">
@@ -1294,7 +1294,7 @@
           <p>Works with Claude, ChatGPT, Microsoft Copilot Studio, or any MCP-compatible client. Use Ollama for fully air-gapped deployments.</p>
         </div>
         <div class="principle">
-          <h4>&#x1F3D7; ISO 13374 Six-Block Architecture</h4>
+          <h4>&#x1F3D7; Structured Diagnostic Pipeline</h4>
           <p>Each sub-package maps to an ISO&nbsp;13374 block: <code>signal_acquisition</code>&nbsp;(B1), <code>signal_processing</code>&nbsp;(B2), <code>diagnostics</code>&nbsp;(B3-4), <code>prognostics</code>&nbsp;(B5), <code>decision_support</code>&nbsp;(B6).</p>
         </div>
         <div class="principle">
@@ -1304,9 +1304,9 @@
       </div>
     </div>
     <div class="standards-strip reveal">
-      <span class="std-badge">ISO 13374 &mdash; Diagnostic Architecture</span>
-      <span class="std-badge">ISO 20816-3 &mdash; Vibration Severity</span>
-      <span class="std-badge">MIMOSA OSA-CBM &mdash; CBM Framework</span>
+      <span class="std-badge">Structured pipeline: ingest &rarr; analyze &rarr; diagnose &rarr; report</span>
+      <span class="std-badge">Local-by-default processing for sensitive machine data</span>
+      <span class="std-badge">Open standards compatible through MCP</span>
     </div>
   </div>
 </section>
@@ -1349,34 +1349,31 @@
   </div>
 </section>
 
-<!-- ==================== GALLERY ==================== -->
-<section id="gallery" class="how-section">
+<!-- ==================== RESULTS ==================== -->
+<section id="results" class="how-section">
   <div class="container">
     <div class="section-header reveal">
-      <span class="overline">Gallery</span>
-      <h2>Reports &amp; Visualizations</h2>
-      <p>Professional outputs generated through natural language commands.</p>
+      <span class="overline">Outcomes</span>
+      <h2>From Raw Signals to Better Decisions</h2>
+      <p>A modern workflow focused on clarity: understand risk quickly, communicate findings clearly, and plan next actions with confidence.</p>
     </div>
 
-    <div class="screenshots-grid">
-      <figure class="screenshot-card reveal">
-        <img src="https://raw.githubusercontent.com/LGDiMaggio/predictive-maintenance-mcp/main/assets/envelope_analysis.png"
-             alt="Envelope analysis showing BPFO, BPFI, BSF bearing fault frequencies"
-             loading="lazy" width="600" height="400">
-        <figcaption>Envelope analysis &mdash; bearing defect frequency identification</figcaption>
-      </figure>
-      <figure class="screenshot-card reveal">
-        <img src="https://raw.githubusercontent.com/LGDiMaggio/predictive-maintenance-mcp/main/assets/iso.png"
-             alt="ISO 20816-3 vibration severity chart with zone classification"
-             loading="lazy" width="600" height="400">
-        <figcaption>ISO 20816-3 vibration severity assessment</figcaption>
-      </figure>
-      <figure class="screenshot-card reveal">
-        <img src="https://raw.githubusercontent.com/LGDiMaggio/predictive-maintenance-mcp/main/assets/MCPserver.png"
-             alt="MCP server architecture showing 48 endpoints"
-             loading="lazy" width="600" height="400">
-        <figcaption>MCP server architecture &mdash; 48 endpoints by ISO 13374</figcaption>
-      </figure>
+    <div class="plugin-grid">
+      <div class="feature-card reveal">
+        <div class="feature-icon green">&#x1F7E2;</div>
+        <h3>Faster Triage</h3>
+        <p>Prioritize which assets need immediate attention versus routine follow-up using clear severity cues.</p>
+      </div>
+      <div class="feature-card reveal">
+        <div class="feature-icon purple">&#x1F4DD;</div>
+        <h3>Clear Communication</h3>
+        <p>Create shareable outputs for operators, reliability engineers, and management without rewriting technical notes.</p>
+      </div>
+      <div class="feature-card reveal">
+        <div class="feature-icon amber">&#x23F1;&#xFE0F;</div>
+        <h3>Less Time to Action</h3>
+        <p>Move from "what am I looking at?" to "what should we do now?" in minutes, directly from the chat workflow.</p>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
### Motivation
- Make the landing page clearer and more approachable by removing heavy acronym/jargon usage and focusing on practical outcomes for maintenance teams.
- Improve first impressions and SEO/social metadata so the project explains what it does in plain language and attracts non-specialist users.
- Replace screenshot-heavy "Gallery" with an outcomes-focused section that highlights triage, communication, and time-to-action benefits.

### Description
- Updated `docs/index.html` hero copy, title, tagline, CTAs and conversational examples to emphasize plain-language diagnostics and recommended actions instead of technical acronyms.
- Revised SEO/Open Graph/Twitter/JSON-LD metadata to match the new positioning and improve shareability.
- Replaced the `Gallery` screenshot block with a `Results`/Outcomes section and updated the navigation to point to `#results` instead of `#gallery`.
- Simplified feature, tools and architecture wording (feature headings and short descriptions) and reduced prominent acronym/standards badges in visible claims while keeping technical context in the architecture area.

### Testing
- Parsed the edited `docs/index.html` with Python's `html.parser` (`HTMLParser`) to validate the HTML structure, and the parse completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c936db0b4483369192b3d46d61a73f)