### PR TITLE
fix: fs-aware envelope band default and clean refusal on undeclared unit (v0.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-07-13
+
+Patch release: two robustness fixes of the same class caught while
+diagnosing crash reports from a pre-0.9.0 server.
+
+### Fixed
+- `generate_envelope_report` now resolves its default upper band edge
+  fs-aware (`min(5000, Nyquist-1)`) instead of a fixed 5000 Hz. On any
+  signal sampled below 10 kHz the fixed default exceeded Nyquist and the
+  report failed with an invalid-band error; a default envelope report now
+  succeeds on sub-10 kHz signals. An explicitly requested band above
+  Nyquist is still rejected — never clamped silently.
+- The ISO unit conversion (`_convert_to_velocity_mm_s` /
+  `assess_severity_raw`) now refuses an undeclared (`None`) unit with an
+  actionable message instead of crashing with `'NoneType' object has no
+  attribute 'lower'`. The live `diagnose_vibration` / `assess_severity`
+  paths already guarded this; the fix hardens the pure conversion for any
+  direct caller — refusing, never guessing a unit (consistent with the
+  declared-unit discipline).
+
 ## [0.9.0] - 2026-07-13
 
 Consolidation release: one credible diagnostic engine behind one unified API.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "Predictive Maintenance MCP Server: An open-source framework for integrating Large Language Models with predictive maintenance and fault diagnosis workflows"
-version: 0.9.0
+version: 0.9.1
 date-released: 2026-07-13
 authors:
   - family-names: Di Maggio
@@ -52,7 +52,7 @@ preferred-citation:
     - family-names: Di Maggio
       given-names: Luigi Gianpio
   year: 2026
-  version: 0.9.0
+  version: 0.9.1
   repository-code: "https://github.com/LGDiMaggio/predictive-maintenance-mcp"
   license: MIT
   doi: "10.5281/zenodo.17611542"

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Contributions welcome from **everyone** — not just programmers. Domain experts
   title   = {Predictive Maintenance MCP Server},
   author  = {Di Maggio, Luigi Gianpio},
   year    = {2025},
-  version = {0.9.0},
+  version = {0.9.1},
   url     = {https://github.com/LGDiMaggio/predictive-maintenance-mcp},
   doi     = {10.5281/zenodo.17611542}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "predictive-maintenance-mcp"
-version = "0.9.0"
+version = "0.9.1"
 description = "AI agent for predictive maintenance & condition monitoring — Open-source MCP server and Claude Code plugin with 52 endpoints for vibration analysis, bearing fault detection, ISO 20816 severity assessment, ML anomaly detection, and remaining useful life estimation via natural language"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.LGDiMaggio/predictive-maintenance-mcp",
   "title": "Predictive Maintenance",
   "description": "Industrial vibration analysis, bearing fault diagnosis, ISO 20816, and ML anomaly detection",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "predictive-maintenance-mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,7 +8,7 @@ Installable as 'predictive-maintenance-mcp' from PyPI.
 Package name: predictive_maintenance_mcp (mapped from src/ directory).
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 __author__ = "Luigi Gianpio Di Maggio"
 __license__ = "MIT"
 

--- a/src/diagnostics/iso20816.py
+++ b/src/diagnostics/iso20816.py
@@ -207,7 +207,7 @@ def classify_zone(
 def _convert_to_velocity_mm_s(
     signal: np.ndarray,
     fs: float,
-    signal_unit: str,
+    signal_unit: Optional[str],
 ) -> tuple[np.ndarray, bool, str]:
     """Convert signal to velocity in mm/s if needed.
 
@@ -215,9 +215,19 @@ def _convert_to_velocity_mm_s(
         (velocity_mm_s, conversion_performed, original_unit)
 
     Raises:
-        ValueError: If ``signal_unit`` is not one of the declared vocabulary
-            ('g', 'm/s²'/'m/s2', 'm/s', 'mm/s'). Units are never assumed.
+        ValueError: If ``signal_unit`` is ``None`` (not declared) or not one
+            of the declared vocabulary ('g', 'm/s²'/'m/s2', 'm/s', 'mm/s').
+            Units are never assumed or guessed from amplitude.
     """
+    # Defense in depth: the live MCP boundary already refuses an undeclared
+    # unit, but a direct/future caller must fail cleanly here too — never
+    # crash with an opaque AttributeError, and never silently assume a unit.
+    if signal_unit is None:
+        raise ValueError(
+            "signal unit not declared — ISO severity requires a declared "
+            "unit ('g'|'m/s2'|'mm/s'|'m/s'); units are never guessed from "
+            "amplitude."
+        )
     unit = signal_unit.lower()
 
     if unit in ("g", "m/s²", "m/s2"):

--- a/src/mcp_tools/report_tools.py
+++ b/src/mcp_tools/report_tools.py
@@ -336,7 +336,7 @@ async def generate_fft_report(
 async def generate_envelope_report(
     signal_id: str,
     filter_low: float = 500.0,
-    filter_high: float = 5000.0,
+    filter_high: Optional[float] = None,
     max_freq: float = 500.0,
     num_peaks: int = 15,
     bearing_freqs: Optional[dict[str, float]] = None,
@@ -355,7 +355,9 @@ async def generate_envelope_report(
         Args:
             signal_id: ID of the stored signal (from load_signal).
             filter_low: Bandpass filter low cutoff (Hz). Default 500 Hz
-            filter_high: Bandpass filter high cutoff (Hz). Default 5000 Hz
+            filter_high: Bandpass filter high cutoff (Hz). Default (None)
+                adapts to the signal: min(5000, Nyquist-1). An explicit value
+                above Nyquist is rejected, never clamped.
             max_freq: Max envelope spectrum frequency to display. Default 500 Hz
             num_peaks: Number of peaks to detect. Default 15
             bearing_freqs: Optional dict with BPFO, BPFI, BSF, FTF
@@ -381,6 +383,15 @@ async def generate_envelope_report(
 
     signal_data, info = resolve_signal(signal_id)
     sampling_rate = info.sampling_rate
+
+    # Resolve the default upper edge fs-aware: the fixed 5000 Hz default used
+    # to exceed Nyquist on sub-10 kHz signals and raise. A None (default)
+    # filter_high adapts to the signal; an explicit value is honored as-is and
+    # still validated (an over-Nyquist band the caller asked for is never
+    # clamped silently). min(5000, Nyquist-1) matches the digital-filter
+    # corner realized below and compute_envelope_spectrum's own default.
+    if filter_high is None:
+        filter_high = min(5000.0, sampling_rate / 2 - 1.0)
 
     # U9 band-validation sweep: an invalid band vs Nyquist raises — this
     # used to feed scipy an unnormalizable corner (or silently mis-filter).

--- a/tests/fixtures/tool_inventory.json
+++ b/tests/fixtures/tool_inventory.json
@@ -727,9 +727,16 @@
             "title": "Bearing Freqs"
           },
           "filter_high": {
-            "default": 5000.0,
-            "title": "Filter High",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Filter High"
           },
           "filter_low": {
             "default": 500.0,

--- a/tests/test_iso20816.py
+++ b/tests/test_iso20816.py
@@ -329,6 +329,18 @@ class TestUnitConversion:
         with pytest.raises(ValueError, match="Unknown signal_unit"):
             assess_severity_with_axis(signal, fs=10000, signal_unit="mils")
 
+    def test_none_unit_refused_not_attributeerror(self):
+        """Defense-in-depth: a None unit is refused with an actionable
+        ValueError, never an opaque AttributeError from .lower()
+        (regression: "'NoneType' object has no attribute 'lower'").
+
+        The live MCP boundary already guards None, but the pure conversion
+        must fail cleanly if a future caller forgets — refusing, never
+        guessing a unit."""
+        signal = np.random.randn(10000) * 0.1
+        with pytest.raises(ValueError, match="not declared"):
+            assess_severity_with_axis(signal, fs=10000, signal_unit=None)
+
 
 class TestInvalidParameters:
     def test_invalid_group_support(self):

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -367,6 +367,28 @@ class TestGenerateEnvelopeReport:
         assert Path(result["file_path"]).exists()
 
     @pytest.mark.asyncio
+    async def test_default_band_is_fs_aware(self, tools, data_dir, repo, reports_dir):
+        """The default filter_high must adapt to the signal's Nyquist. On a
+        sub-10 kHz signal the former fixed 5000 Hz default exceeded Nyquist
+        and the report raised; the default now resolves fs-aware and the
+        report succeeds without the caller specifying a band."""
+        sid = _load_extra_signal(repo, data_dir, "env_8k.csv", fs=8000)
+        result = await tools["generate_envelope_report"](signal_id=sid)
+        assert "file_path" in result
+        # The echoed band is contained within Nyquist (4000 Hz here).
+        assert result["metadata"]["filter_band"][1] <= 4000.0
+
+    @pytest.mark.asyncio
+    async def test_explicit_band_above_nyquist_still_raises(
+        self, tools, data_dir, repo, reports_dir
+    ):
+        """An explicitly requested band above Nyquist is never silently
+        clamped — only the default is fs-aware."""
+        sid = _load_extra_signal(repo, data_dir, "env_8k2.csv", fs=8000)
+        with pytest.raises(ValueError, match="Nyquist"):
+            await tools["generate_envelope_report"](signal_id=sid, filter_high=5000.0)
+
+    @pytest.mark.asyncio
     async def test_envelope_report_bearing_freqs_from_companion_metadata(
         self, tools, data_dir, repo, reports_dir
     ):


### PR DESCRIPTION
## Summary

Patch release **v0.9.1**. Two robustness fixes of the same class, found by diagnosing crash reports that originated on a pre-0.9.0 server. Both reported symptoms were already resolved in v0.9.0 at the tool boundary; this release hardens the underlying functions so the same failures cannot resurface through any other caller.

## Fixes

**`generate_envelope_report` — fs-aware default band**
The default upper band edge was a fixed `5000 Hz`, which exceeds Nyquist on any signal sampled below 10 kHz (e.g. 8 kHz), so a default envelope report on such a signal raised an invalid-band error. The default now resolves fs-aware to `min(5000, Nyquist-1)` — matching the digital-filter corner realized downstream and `compute_envelope_spectrum`'s own default. An explicitly requested band above Nyquist is still rejected (never clamped silently). *Reproduced at fs=8000 and fs=5000; fixed.*

**ISO unit conversion — clean refusal on an undeclared unit**
`_convert_to_velocity_mm_s` / `assess_severity_raw` crashed with `'NoneType' object has no attribute 'lower'` when handed a `None` (undeclared) unit. The live `diagnose_vibration` / `assess_severity` paths already guard this (a structured refusal), so the crash was not reachable through the tools — but the pure conversion now refuses `None` with an actionable message too, hardening the latent crash for any direct caller. It refuses, it never guesses a unit (consistent with the v0.9.0 declared-unit discipline). *Reproduced directly; fixed.*

Note: the reported "default to 'g'" idea was intentionally **not** taken — defaulting a unit reintroduces exactly the amplitude-based guessing that v0.9.0 removed.

## Tests & verification

- Test-first: both bugs reproduced (opaque `AttributeError`; invalid-band `ValueError` at fs=8000) before the fix, then confirmed fixed. Added a regression for each, plus a guard that an explicit over-Nyquist band still raises.
- Tool inventory fixture regenerated for the `filter_high` signature change (`float=5000` → `Optional[float]=None`); the surface stays **33 tools + 3 prompts**.
- Full suite: **887 passed, 17 skipped, coverage 92.18%**.

Fixes the crashes tracked while running `/ce-debug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
