### PR TITLE
feat(reports): integrated diagnostic report with server-authored advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,55 @@ with identical names and input schemas. `tests/fixtures/tool_inventory.json`
 was **not** regenerated: it passes as-is against mcp 2.0.0, which is the
 evidence that the migration is protocol-invisible.
 
+### Added
+- `generate_diagnostic_report` — one integrated diagnostic document covering
+  signal overview, ISO severity, anomaly state, characteristic-frequency
+  matching, spectral energy, an annotated envelope spectrum, and recommended
+  actions. Additive: the surface grows from 36 to 37 endpoints (33 → 34
+  tools), no existing tool signature changes.
+- Server-authored advisory layer (`decision_support.advisory`). Every
+  evaluative sentence a report shows is written by the server that computed
+  the numbers and returned to the caller in a `statements` list. The previous
+  arrangement let the caller author report content — see
+  `generate_diagnostic_report_docx`'s `sections` argument — which is how a
+  rendering ends up carrying faithful numbers under a standard name, machine
+  class, or confidence grade this codebase does not produce.
+- Indicator-disagreement reconciliation: when the ISO zone reads acceptable
+  while the fault pattern does not, the report says so explicitly and names
+  which indicator governs the recommended action.
+- Baseline comparison: supplying a healthy reference signal turns absolute
+  readings into deltas, including envelope amplitude at the characteristic
+  frequency the verdict rests on — the figure that separates "the machine got
+  noisier" from "this defect grew".
+- Annotated envelope spectrum (`figures`), drawn as inline SVG with the
+  characteristic-frequency bands at the tolerance the diagnosis actually
+  used, so the match is visible rather than asserted. No CDN script and no
+  hover-only labels: the report opens with no network access and the
+  annotation survives a static export.
+- Optional `[pdf]` extra. The PDF is a rendering of the same HTML document
+  rather than a second layout, so both renderings carry identical statements
+  by construction; a test asserts it.
+- Report authorship policy in the server instructions: standard names,
+  machine classes, zones, and confidence levels are not the caller's to coin,
+  and `evidence_strength` is a count of corroborating findings that must
+  never be rendered as a probability.
+
+### Fixed
+- The shared HTML report base template interpolated the report title — which
+  carries a user-supplied signal identifier — without escaping, and embedded
+  its metadata JSON in a way a `</script>` sequence in any value could close
+  early. Both affected every report family.
+- The envelope spectrum drawn in the integrated report is now computed by the
+  same path the bearing matching consumes (`envelope_spectrum_arrays`), so a
+  figure cannot show a peak the verdict never saw.
+
+### Changed
+- `tests/test_surface_parity.py` previously required every registered tool to
+  be a migration destination of the v0.8.x surface, which forbade adding any
+  new capability. It now requires every tool to be migrated **or** declared
+  in `POST_U9_ADDITIONS`, preserving the "no orphan tools" property while
+  allowing intentional additions.
+
 ## [0.9.1] - 2026-07-13
 
 Patch release: two robustness fixes of the same class caught while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,11 @@ All notable changes to the Predictive Maintenance MCP Server project will be doc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - 2026-08-08
+## [0.11.0] - 2026-08-08
 
-Minor release rather than a patch: the dependency floor change below is
-breaking for installs, and this project's pre-1.0 semver treats that as a
-MINOR bump.
-
-### Changed
-- **BREAKING (install):** migrated the server to the mcp 2.x API and raised
-  the floor to `mcp[cli]>=2.0.0`. mcp 2.0.0 removed `mcp.server.fastmcp`,
-  so `FastMCP` is now `MCPServer` from `mcp.server.mcpserver`. The two APIs
-  cannot be supported from one source tree, so mcp 1.x is no longer
-  installable with this package.
-- Transport wiring no longer goes through `mcp.settings`: mcp 2.x dropped
-  `Settings.host` / `Settings.port`, so `--host` / `--port` are passed to
-  `mcp.run()` as per-transport kwargs. `stdio` is invoked without them
-  (`run_stdio_async` accepts neither).
-
-The registered surface is unchanged — 33 tools, 0 resources, 3 prompts,
-with identical names and input schemas. `tests/fixtures/tool_inventory.json`
-was **not** regenerated: it passes as-is against mcp 2.0.0, which is the
-evidence that the migration is protocol-invisible.
+Adds the integrated diagnostic report. Additive: no existing tool
+signature changes, and the endpoint surface grows from 36 to 37
+(33 -> 34 tools).
 
 ### Added
 - `generate_diagnostic_report` — one integrated diagnostic document covering
@@ -76,12 +60,22 @@ evidence that the migration is protocol-invisible.
   in `POST_U9_ADDITIONS`, preserving the "no orphan tools" property while
   allowing intentional additions.
 
-## [0.9.1] - 2026-07-13
+## [0.10.0] - 2026-08-08
 
-Patch release: two robustness fixes of the same class caught while
-diagnosing crash reports from a pre-0.9.0 server.
+Minor release rather than a patch: the dependency floor change below is
+breaking for installs, and this project's pre-1.0 semver treats that as a
+MINOR bump.
 
 ### Changed
+- **BREAKING (install):** migrated the server to the mcp 2.x API and raised
+  the floor to `mcp[cli]>=2.0.0`. mcp 2.0.0 removed `mcp.server.fastmcp`,
+  so `FastMCP` is now `MCPServer` from `mcp.server.mcpserver`. The two APIs
+  cannot be supported from one source tree, so mcp 1.x is no longer
+  installable with this package.
+- Transport wiring no longer goes through `mcp.settings`: mcp 2.x dropped
+  `Settings.host` / `Settings.port`, so `--host` / `--port` are passed to
+  `mcp.run()` as per-transport kwargs. `stdio` is invoked without them
+  (`run_stdio_async` accepts neither).
 - **Public export shape.** `predictive_maintenance_mcp.mcp` is a declared
   export (`__all__` in `src/__init__.py`) and its runtime type changes from
   `mcp.server.fastmcp.FastMCP` to `mcp.server.mcpserver.MCPServer`. It no
@@ -102,6 +96,16 @@ diagnosing crash reports from a pre-0.9.0 server.
   (still async, still functional, but they now emit a warning that is shown
   by default). This release does not migrate the ~116 call sites; that is
   tracked separately.
+
+The registered surface is unchanged — 33 tools, 0 resources, 3 prompts,
+with identical names and input schemas. `tests/fixtures/tool_inventory.json`
+was **not** regenerated: it passes as-is against mcp 2.0.0, which is the
+evidence that the migration is protocol-invisible.
+
+## [0.9.1] - 2026-07-13
+
+Patch release: two robustness fixes of the same class caught while
+diagnosing crash reports from a pre-0.9.0 server.
 
 ### Fixed
 - `generate_envelope_report` now resolves its default upper band edge

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "Predictive Maintenance MCP Server: An open-source framework for integrating Large Language Models with predictive maintenance and fault diagnosis workflows"
-version: 0.10.0
+version: 0.11.0
 date-released: 2026-07-13
 authors:
   - family-names: Di Maggio
@@ -51,7 +51,7 @@ preferred-citation:
     - family-names: Di Maggio
       given-names: Luigi Gianpio
   year: 2026
-  version: 0.10.0
+  version: 0.11.0
   repository-code: "https://github.com/LGDiMaggio/predictive-maintenance-mcp"
   license: MIT
   doi: "10.5281/zenodo.17611542"

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ Find the full path to `uvx` (`which uvx` on macOS/Linux, `where uvx` on Windows)
 | *"Extract specs from test_pump_manual.pdf and diagnose the signal"* | Reads the equipment manual, looks up the bearing model, calculates expected fault frequencies, matches them against the signal |
 | *"Train an anomaly detector on my healthy baselines, then flag anomalies"* | Trains a machine learning model on normal data, scores new signals, highlights outliers |
 
-The AI doesn't guess — it calls **36 specialized MCP endpoints** (33 tools + 3 prompts) running locally on your machine. Every signal is referenced by a single `signal_id` handle from load to report. Your data never leaves your infrastructure.
+The AI doesn't guess — it calls **37 specialized MCP endpoints** (34 tools + 3 prompts) running locally on your machine. Every signal is referenced by a single `signal_id` handle from load to report. Your data never leaves your infrastructure.
 
 <details>
-<summary><b>See the full endpoint list (36 MCP endpoints: 33 tools, 3 prompts)</b></summary>
+<summary><b>See the full endpoint list (37 MCP endpoints: 34 tools, 3 prompts)</b></summary>
 
 ### Signal Lifecycle (5)
 
@@ -135,7 +135,7 @@ The AI doesn't guess — it calls **36 specialized MCP endpoints** (33 tools + 3
 | `extract_manual_specs` | Extract structured specs from PDFs |
 | `list_machine_manuals` | Browse available documentation |
 
-### Reporting (8)
+### Reporting (9)
 
 | Tool | Description |
 |------|-------------|
@@ -143,6 +143,7 @@ The AI doesn't guess — it calls **36 specialized MCP endpoints** (33 tools + 3
 | `generate_fft_report` | Interactive frequency analysis report |
 | `generate_envelope_report` | Envelope analysis with fault markers |
 | `generate_iso_report` | Severity zone visualization |
+| `generate_diagnostic_report` | Integrated diagnostic report, HTML and PDF, wording authored by the server |
 | `generate_diagnostic_report_docx` | Structured Word document report |
 | `generate_pca_visualization_report` | PCA anomaly projection |
 | `generate_feature_comparison_report` | Cross-signal feature comparison |
@@ -286,7 +287,7 @@ The codebase follows a **modular architecture** organized around the ISO 13374 S
 
 ```
 src/predictive_maintenance_mcp/
-├── mcp_tools/                 # MCP endpoint registration (36 MCP endpoints)
+├── mcp_tools/                 # MCP endpoint registration (37 MCP endpoints)
 │   ├── acquisition_tools.py   # Signal loading & management
 │   ├── analysis_tools.py      # Spectral & statistical analysis
 │   ├── diagnostics_tools.py   # Fault detection, ML, document search
@@ -347,7 +348,7 @@ pytest --cov=src --cov-report=html      # with coverage report
 
 ## Roadmap
 
-- [x] 36 MCP endpoints (33 tools, 3 prompts) with modular architecture and a single `signal_id` handle
+- [x] 37 MCP endpoints (34 tools, 3 prompts) with modular architecture and a single `signal_id` handle
 - [x] Claude Code plugin (8 skills, 2 agents, 3 commands)
 - [x] 86% test coverage, CI/CD on 3 platforms
 - [x] Docker + SSE/HTTP transport for enterprise deployment

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Contributions welcome from **everyone** — not just programmers. Domain experts
   title   = {Predictive Maintenance MCP Server},
   author  = {Di Maggio, Luigi Gianpio},
   year    = {2025},
-  version = {0.10.0},
+  version = {0.11.0},
   url     = {https://github.com/LGDiMaggio/predictive-maintenance-mcp},
   doi     = {10.5281/zenodo.17611542}
 }

--- a/docs/brainstorms/2026-08-06-diagnostic-report-value-and-authorship.md
+++ b/docs/brainstorms/2026-08-06-diagnostic-report-value-and-authorship.md
@@ -1,0 +1,165 @@
+---
+date: 2026-08-06
+topic: diagnostic-report-value-and-authorship
+---
+
+# Diagnostic Report: Value and Authorship
+
+## Summary
+
+A single integrated diagnostic report for the bearing-fault path, generated deterministically by the server, that states the finding, the reasoning behind it, and the recommended action — with an annotated envelope spectrum as the explanatory evidence. A conversational reading layer sits on top and cites that document rather than re-authoring it.
+
+---
+
+## Problem Frame
+
+The server currently emits one HTML report per analysis tool (`envelope_analysis_*`, `fft_spectrum_*`, `feature_comparison_*` in `reports/`). The only output that synthesises across tools is DOCX. Report tools return a file path plus a short summary to the caller, so a client LLM never holds enough structured evidence to reason about the case itself.
+
+No reader outside the project author has ever opened one of these reports. They function today as demonstration artefacts, not work artefacts. The intended readers are a maintenance technician deciding whether to act on a machine, and a company or evaluating stakeholder judging whether the diagnosis is credible. Both share two properties: they receive the output **detached from the conversation that produced it**, and they **cannot verify any claim it makes**.
+
+A hand-composed alternative (an LLM rendering a rich report inline in chat) was structurally far better than the current HTML: it placed calculated versus measured bearing frequencies side by side with a match verdict, explicitly reconciled an acceptable ISO zone against a 100% anomaly ratio, and ranked maintenance actions by urgency. The numeric values it displayed were faithful to the server. Its **labels were not**:
+
+- It titled the severity block with the bare, edition-less standard number followed by "Machine Class II". `src/diagnostics/iso20816.py` is the single source of zone truth and deliberately emits `"ISO 20816-3 (thresholds from ISO 10816-3:2009)"` together with a mandatory caveat about the 2022 edition merging zones A and B ([iso20816.py:141](src/diagnostics/iso20816.py:141)). Both the edition and the caveat were dropped. (The repository's own guard test forbids writing that imprecise citation anywhere, including here — which is why this sentence describes it rather than quoting it.)
+- "Machine Class II" does not exist in this codebase. The taxonomy is `(machine_group, support_type)` — Group 1/2 × rigid/flexible ([iso20816.py:41](src/diagnostics/iso20816.py:41)). The class vocabulary was imported from a standard the project does not use.
+- It displayed a "Confidence: high" chip. The codebase refuses to produce one, in three separate places and on purpose: [recommendations.py:40](src/decision_support/recommendations.py:40) takes no confidence input because it would be repeated verbatim in advisory output; [diagnostics_tools.py:958](src/mcp_tools/diagnostics_tools.py:958) derives no confidence label; [models.py:516](src/models.py:516) warns that the available fit metric is a heuristic and must not be presented as a probability.
+
+The cost shape differs by reader. For an evaluating stakeholder, one label the tool does not actually stand behind discredits the whole artefact — and the author is not in the room to correct it. For a technician, it is a machine stopped, or left running, for a reason nobody can reconstruct afterwards.
+
+---
+
+## Actors
+
+- A1. Maintenance technician: receives the report outside the session, decides whether and when to intervene.
+- A2. Evaluating stakeholder (customer, reviewer): judges whether the diagnosis and the tool behind it are trustworthy.
+- A3. Analyst: runs the MCP session, produces the report, and answers follow-up questions about it.
+- A4. Client LLM: orchestrates the tools, renders and comments on results in the conversation.
+
+---
+
+## Key Flows
+
+- F1. Produce a bearing diagnosis of record
+  - **Trigger:** A3 asks the client to diagnose a vibration signal with bearing metadata available.
+  - **Actors:** A3, A4, server
+  - **Steps:** signal loaded → analyses run across envelope, ISO severity, anomaly detection, characteristic-frequency matching → server composes one integrated document containing every evaluative statement in its own words → document written to disk and its authored content returned to the client.
+  - **Outcome:** a self-contained document exists that states finding, reasoning, evidence and recommended action, and can be opened by A1 or A2 with no access to the conversation.
+  - **Covered by:** R1, R3, R5, R6, R7, R8, R10, R12, R13, R14
+
+- F2. Read and interrogate the diagnosis
+  - **Trigger:** A3 (or A4 on A3's behalf) discusses the result in the session — summarising it, or testing an alternative hypothesis such as misalignment.
+  - **Actors:** A3, A4
+  - **Steps:** A4 works from the authored statements returned in F1 → summarises, reorders or visualises them → when asked something the document does not answer, says so rather than filling the gap.
+  - **Outcome:** the conversation adds interpretation and exploration without introducing any claim absent from the document.
+  - **Covered by:** R4, R15
+
+---
+
+## Requirements
+
+**Authorship boundary**
+
+- R1. Every evaluative statement in the report is authored by the server as a complete string: the verdict, the standard's name with its caveat, the zone and its description, the reason a frequency match counts as a match, and each recommended action.
+- R2. The server emits no confidence score or confidence label. Where the report needs to convey strength of evidence, it does so by listing the facts that support the finding, not by grading them.
+- R3. What the server returns to the client includes the authored statements and the data behind each figure — not only a file path and a short summary as today.
+- R4. When the client LLM presents or comments on a result, it reuses the server's statements. It does not coin standard names, machine classes, zone letters, severity words, or confidence levels of its own.
+
+The boundary in one view:
+
+| Element | Authored by server | Rendered / discussed by LLM |
+|---|---|---|
+| Numeric values, peaks, zone boundaries | Yes | Displays |
+| Standard name and its caveat | Yes | Quotes verbatim |
+| Fault verdict and its justification | Yes | Quotes, may summarise |
+| Contradiction between indicators | Yes | Quotes, may expand |
+| Recommended actions and urgency | Yes | Quotes, may reorder for reading |
+| Layout, typography, emphasis, chart styling | No | Free |
+| Exploration of alternative hypotheses | No | Free, marked as conversation, not as report content |
+| Confidence level | Never produced | Never introduced |
+
+**Integrated report content**
+
+- R5. One document covers the whole bearing case: signal overview, ISO severity, anomaly state, characteristic-frequency matching, spectral energy distribution, and recommended actions. It replaces the need to open several per-tool reports to reach a conclusion.
+- R6. When indicators disagree — for example an acceptable ISO zone alongside a high anomaly ratio — the document states the disagreement explicitly and explains which indicator governs the recommended action and why.
+- R7. Every recommendation carries its motivation and names the evidence it rests on.
+- R8. When a healthy baseline signal is available for the same machine, the document compares against it and expresses the key indicators as deltas, not only as absolute values.
+- R9. When an input is missing — no baseline, no bearing metadata, signal outside the ISO evaluation scope — the document says what is missing and what conclusion is therefore unavailable, rather than silently omitting the section.
+
+**Explanatory graphics**
+
+- R10. The envelope spectrum is annotated: BPFO, BPFI, BSF and FTF lines overlaid with a visible tolerance band, so that a reader can see the dominant peak falling inside one band and outside the others. The annotation carries the argument without interaction, so the figure makes the same point in a static rendering as in an interactive one.
+- R11. A figure earns its place only if it closes a piece of reasoning. If removing it would not weaken any conclusion in the document, it does not belong in the document.
+
+**Document of record**
+
+- R12. The document exists in two renderings produced from the same authored content: a self-contained HTML working view and a PDF deliverable. Both open on their own with no access to the session that produced them, and both carry the same statements — a reader comparing the two finds no claim in one that is absent from the other.
+- R13. The same signal analysed with the same parameters produces the same document, apart from generation timestamp. This holds per rendering.
+- R14. The document carries its own provenance: source signal, the analysis parameters used, and the server version that produced it.
+
+**Conversational reading layer**
+
+- R15. The reading layer works from the same authored statements as the document and introduces no assertion the document does not contain. When asked something outside them, it says the analysis does not answer it.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R6.** Given a signal whose RMS velocity places it in an acceptable ISO zone while the anomaly detector flags every segment, when the document is generated, it states that the two indicators describe different stages of the same condition and names which one governs the recommended action.
+- AE2. **Covers R8, R9.** Given no baseline signal is available for the machine, when the document is generated, the comparison section is present and states that no baseline was available and which conclusion is therefore unavailable — it does not disappear.
+- AE3. **Covers R9.** Given bearing metadata is absent, when the document is generated, no characteristic-frequency matching is presented and the document states that the match could not be attempted and why.
+- AE4. **Covers R1, R4.** Given the client renders a summary of the result in conversation, when it names the standard, the zone or the recommended action, those appear exactly as the server authored them, caveat included.
+- AE5. **Covers R13.** Given the same signal is analysed twice with identical parameters, when both documents are compared, they differ only in generation timestamp.
+- AE6. **Covers R2.** Given a textbook-clear outer-race signature, when the document is generated, it presents the supporting facts (match within tolerance, harmonic present, energy concentrated in the high band) and assigns no confidence grade to the finding.
+
+---
+
+## Success Criteria
+
+- A maintenance technician handed only the document, with no access to the conversation, can say what is wrong, why the tool concluded that, and what to do next.
+- An external technical reviewer reading the document finds no label, standard name, class, or confidence claim that the codebase does not actually produce.
+- The reference case that motivated this work, regenerated under the new model, contains neither a confidence grade nor a standard name the project does not use.
+- `ce-plan` can proceed without having to decide who is allowed to assert what — that boundary is settled here.
+
+---
+
+## Scope Boundaries
+
+- The existing per-tool HTML reports and the DOCX generator stay as they are. One case is taken to full depth before anything is generalised.
+- Diagnostic paths other than rolling-element bearing faults (gears, imbalance, misalignment, looseness).
+- Multi-acquisition trending, historical evolution, and RUL presentation.
+- Fleet or multi-machine views.
+- Aesthetic redesign of the current templates as an end in itself — the visual weakness is a symptom of missing synthesis, and restyling without the authored reasoning would leave the output equally mute.
+- Implementing the conversational reading layer. Its constraints are defined here (R4, R15) so that the document design does not foreclose it, but the document of record is built first.
+
+---
+
+## Key Decisions
+
+- **Deterministic document first, conversational layer second.** Both readers who matter receive the output detached from the session, so the artefact that survives the conversation is the one that must exist. Once the server authors its reasoning in structured form, the conversational layer costs little more.
+- **The server authors claims; the LLM renders them.** This is a direct response to an observed failure, not a precaution — the rendered alternative carried faithful numbers under invented labels, and the readers who receive it cannot detect the difference.
+- **No confidence label, preserved deliberately.** The codebase already refuses to emit one in three places. Making the payload richer must not become a back door for reintroducing it.
+- **Baseline comparison is in scope.** For a technician, a delta against a healthy machine carries more decision value than an absolute figure, and healthy baseline signals with metadata already exist in the dataset.
+- **One end-to-end case before generalising.** The open question is whether an integrated, reasoned document changes what a reader does. That is answerable with one path and not more cheaply with several.
+- **Two renderings, one authored source.** HTML serves the analyst's working view and PDF serves the technician and the evaluating stakeholder, who attach and archive rather than browse. Splitting the rendering is acceptable precisely because the authored content is shared — the divergence risk that motivated the authorship boundary would return if each rendering composed its own text.
+
+---
+
+## Dependencies / Assumptions
+
+- `src/diagnostics/iso20816.py` is the single source of zone boundaries and already carries the mandatory standard caveat with every result. Verified.
+- Healthy baseline signals with accompanying metadata exist in `data/signals/real_train/` (`baseline_1`, `baseline_2`). Verified.
+- No reader outside the project author has yet used the generated reports. Stated by the project author; the reports are therefore treated as having no installed-base compatibility constraint.
+- Assumption, unverified: the clients in use can render the returned authored content richly. If a target client cannot, the document of record still satisfies both external readers on its own.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R3][Technical] How the authored content reaches the client — an enriched tool return versus an MCP resource — and what that implies for context cost on large cases.
+- [Affects R10][Technical] How the annotated spectrum is rendered server-side while keeping the figure readable at report scale in both renderings.
+- [Affects R12][Technical] How the PDF rendering is produced, and what dependency that adds. The project pins dependencies deliberately and keeps core processing free of anything beyond NumPy/SciPy, so the addition needs to sit outside that boundary.
+- [Affects R12][Technical] Whether both renderings are always emitted or the caller selects one, and how R13's determinism is demonstrated across the pair.
+- [Affects R13][Technical] How determinism is achieved and demonstrated given that the document carries a generation timestamp.
+- [Affects R8][Needs research] How a signal is associated with the correct baseline — explicit caller argument, metadata field, or convention — and what happens when several candidates exist.
+- [Affects R6][Needs research] Which indicator disagreements occur in practice beyond the ISO-versus-anomaly case, so that the authored explanations cover them rather than falling back to generic wording.

--- a/docs/plans/2026-08-06-001-feat-integrated-diagnostic-report-plan.md
+++ b/docs/plans/2026-08-06-001-feat-integrated-diagnostic-report-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Integrated diagnostic report with server-authored advisory"
 type: feat
-status: active
+status: completed
 date: 2026-08-06
 origin: docs/brainstorms/2026-08-06-diagnostic-report-value-and-authorship.md
 ---

--- a/docs/plans/2026-08-06-001-feat-integrated-diagnostic-report-plan.md
+++ b/docs/plans/2026-08-06-001-feat-integrated-diagnostic-report-plan.md
@@ -1,0 +1,419 @@
+---
+title: "feat: Integrated diagnostic report with server-authored advisory"
+type: feat
+status: active
+date: 2026-08-06
+origin: docs/brainstorms/2026-08-06-diagnostic-report-value-and-authorship.md
+---
+
+# feat: Integrated diagnostic report with server-authored advisory
+
+## Summary
+
+Build a server-authored advisory layer on top of the existing `diagnose_vibration` pipeline, then render it as one integrated report in two formats (self-contained HTML and PDF) with an annotated envelope spectrum as the explanatory figure. The implementation extends the existing synthesis engine rather than adding a parallel one, and moves report content authorship from the caller to the server.
+
+---
+
+## Problem Frame
+
+The server already runs a cross-tool diagnosis (`diagnose_vibration` in `src/decision_support/diagnosis_pipeline.py`) but has no renderer for its integrated result — the HTML reports are one per analysis tool, and the only integrated output is DOCX. That DOCX tool takes a caller-supplied `sections` dict including a free-text `diagnosis` string, so the report's evaluative content is authored by whoever calls it, not by the server that computed it. The origin document records what that costs when the caller is an LLM: faithful numbers presented under invented labels, with a mandatory standards caveat silently dropped.
+
+---
+
+## Assumptions
+
+*This plan was authored in pipeline mode without synchronous user confirmation. The items below are agent inferences that fill gaps in the origin document — un-validated bets that should be reviewed before implementation proceeds.*
+
+- The new capability is exposed as **one new MCP tool** rather than by changing an existing tool's signature. This grows the frozen surface from 33 to 34 tools and requires a deliberate inventory-fixture regeneration (see U5). The alternative — folding multi-format output into `generate_diagnostic_report_docx` — would break backward compatibility on a minor version, which the project's invariants forbid.
+- `generate_diagnostic_report_docx` is **left in place unchanged**. Its caller-authored `sections` contract is the pattern this plan moves away from, but changing it is a breaking change and belongs in a follow-up.
+- The existing `evidence_strength` value (`none`/`weak`/`moderate`/`strong`, computed in `_synthesize_diagnosis`) is the correct thing to surface and is **not** a confidence score. The report renders it with its own vocabulary and states how it accumulates, so a reader cannot mistake it for a probability. This is the most likely origin of the observed "Confidence: high" chip.
+- Baseline association is by **explicit caller argument** (a second stored signal id), not by convention or metadata lookup. The origin document deferred this question; explicit is the reversible choice.
+- PDF is produced from the same authored content via an optional extra, following the existing `HAS_DOCX` pattern. It is sequenced last so a CI failure in the new dependency cannot block the rest.
+
+---
+
+## Requirements
+
+- R1. Every evaluative statement in the report is authored by the server as a complete string.
+- R2. No confidence score or label is emitted; evidential strength is conveyed by listing supporting facts.
+- R3. The server returns authored statements plus figure data, not only a file path and summary.
+- R4. Callers reuse the server's statements and do not coin standards, classes, zones, or confidence levels.
+- R5. One document covers signal overview, ISO severity, anomaly state, characteristic-frequency matching, spectral energy, and actions.
+- R6. Disagreeing indicators are stated explicitly, with the one that governs the action named.
+- R7. Every recommendation carries its motivation and names its evidence.
+- R8. Comparison against a healthy baseline signal when available, expressed as deltas.
+- R9. Missing inputs are stated along with the conclusion they make unavailable, not silently omitted.
+- R10. Annotated envelope spectrum with characteristic-frequency lines and tolerance band; readable statically.
+- R11. Figures that close no reasoning are excluded.
+- R12. Two renderings from the same authored content, both self-contained, carrying identical statements.
+- R13. Same signal and parameters produce the same document apart from timestamp.
+- R14. Provenance carried in the document: source signal, analysis parameters, server version.
+- R15. The conversational reading layer introduces no assertion absent from the document.
+
+**Origin actors:** A1 (maintenance technician), A2 (evaluating stakeholder), A3 (analyst), A4 (client LLM)
+**Origin flows:** F1 (produce a bearing diagnosis of record), F2 (read and interrogate the diagnosis)
+**Origin acceptance examples:** AE1 (covers R6), AE2 (covers R8, R9), AE3 (covers R9), AE4 (covers R1, R4), AE5 (covers R13), AE6 (covers R2)
+
+---
+
+## Scope Boundaries
+
+- Existing per-tool HTML reports (`generate_fft_report`, `generate_envelope_report`, `generate_iso_report`) and `generate_diagnostic_report_docx` are not modified.
+- Diagnostic paths other than rolling-element bearing faults.
+- Multi-acquisition trending, historical evolution, and RUL presentation.
+- Fleet or multi-machine views.
+- Restyling the existing HTML templates as an end in itself.
+
+### Deferred to Follow-Up Work
+
+- Migrating `generate_diagnostic_report_docx` to server-authored content: breaking signature change, separate major-version PR.
+- Adding the annotated-figure treatment to the standalone envelope report: separate PR once the figure builder proves out.
+- Raising coverage on `src/html_templates.py` and `src/report_generator.py`, currently excluded in `pyproject.toml`: separate PR.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/decision_support/diagnosis_pipeline.py` — `diagnose_vibration` already orchestrates FFT, PSD, STFT, bearing checks, ISO severity, and anomaly detection; `_synthesize_diagnosis` already produces statement lines, recommendation strings, and a categorical evidence strength. This is the extension point, not a thing to duplicate.
+- `src/decision_support/recommendations.py` — `generate_recommendations` is already server-authored and already refuses a confidence input. Its `{action, urgency, description}` shape is the model for the advisory payload.
+- `src/diagnostics/iso20816.py` — single source of zone boundaries and the mandatory standards caveat string. The report must render that string, never a paraphrase.
+- `src/report_generator.py` — `save_*_report` functions, `timestamped_report_name`, and the `HAS_DOCX` optional-dependency guard pattern to mirror for PDF.
+- `src/html_templates.py` — `get_base_template` plus per-report builders; the new integrated template joins this module.
+- `src/path_safety.py` — `safe_resolve` guards all report writes.
+- `tests/test_tool_inventory.py`, `tests/test_surface_parity.py` — the MCP surface is frozen at 33 tools / 0 resources / 3 prompts. Both must be updated deliberately when U5 lands.
+- `tests/test_error_contract.py` — failures raise, never return error-shaped dicts.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/`, `docs/solutions/security-issues/` — reviewed for report-path and standards-labelling precedent before implementing U4 and U6.
+
+---
+
+## Key Technical Decisions
+
+- **Extend `_synthesize_diagnosis` output rather than write a second reasoning path.** Two engines producing statements about the same signal is exactly the divergence the origin document is trying to eliminate (see origin: `docs/brainstorms/2026-08-06-diagnostic-report-value-and-authorship.md`).
+- **The advisory payload is the single source of report content; both renderings consume it.** HTML and PDF never compose their own text. This is what makes R12's "identical statements" testable rather than aspirational.
+- **Determinism is asserted on content, not filenames.** `timestamped_report_name` deliberately appends a timestamp and a monotonic sequence so re-runs never overwrite. R13 is therefore tested by comparing rendered bodies with provenance timestamps excluded.
+- **Missing inputs produce authored refusal statements, not absent sections.** This mirrors the existing `_refused_iso_block` pattern in the pipeline, which already returns `status`/`reason`/`remedy` instead of dropping the block.
+- **Evidence strength is rendered with its accumulation rationale attached.** Showing `strong` without saying it counts corroborating independent findings is what invites a reader — or a model — to reinterpret it as a probability.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- How the authored content reaches the caller: as part of the new tool's return value, alongside the file paths. Adding an MCP resource is ruled out — the surface deliberately dropped all resources at v0.9.0.
+- Whether both renderings are always emitted: the tool takes a formats argument defaulting to both, so a caller that only wants HTML pays nothing for PDF.
+- Baseline association: explicit caller-supplied signal id (see Assumptions).
+
+### Deferred to Implementation
+
+- Which PDF backend to use, and whether it can render the annotated figure without a headless-browser dependency. Decided in U6 against the actual figure output.
+- Whether the annotated spectrum is best produced as a static image embedded in both renderings, or as Plotly in HTML plus a static export in PDF. Depends on what the PDF backend accepts; R12 constrains the outcome, not the mechanism.
+- Exact set of indicator disagreements worth authoring beyond the ISO-versus-anomaly case. Discovered by running U1 against the real signals in `data/signals/real_train/`.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    A[diagnose_vibration result] --> B[advisory builder]
+    C[baseline signal result<br/>optional] --> B
+    B --> D[authored advisory payload<br/>statements + figure data + provenance]
+    D --> E[HTML rendering]
+    D --> F[PDF rendering]
+    D --> G[tool return value<br/>to the calling client]
+    E --> H[annotated envelope figure]
+    F --> H
+```
+
+The advisory payload is the only place evaluative text is written. Everything downstream of it — both file renderings and the value handed back to the client — reads the same authored strings, which is what makes "no claim in one that is absent from the other" checkable.
+
+---
+
+## Implementation Units
+
+### U1. Server-authored advisory builder
+
+**Goal:** Turn a `diagnose_vibration` result into a structured set of server-authored statements: verdict, standard label with its caveat, evidence statements, indicator-disagreement reconciliation, and recommendations each carrying its motivation.
+
+**Requirements:** R1, R2, R6, R7, R9
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/decision_support/advisory.py`
+- Modify: `src/decision_support/__init__.py`
+- Test: `tests/test_advisory.py`
+
+**Approach:**
+- Consume the dict returned by `diagnose_vibration`; do not re-run analysis.
+- Reuse `generate_recommendations` for the action set and attach to each action the evidence statement that justifies it, rather than inventing a parallel recommendation ladder.
+- Render the ISO block by reading the standards string owned by `src/diagnostics/iso20816.py`; never format a standard name locally.
+- Add reconciliation logic for disagreeing indicators — the ISO-zone-acceptable versus high-anomaly-ratio case first — producing an authored statement that names which indicator governs the recommended action.
+- Where the pipeline returned a refusal block (`status: "refused"`), carry its `reason` and `remedy` into an authored statement rather than dropping the section.
+- Emit evidence strength together with a sentence describing what it counts. No field named or valued as a confidence.
+
+**Execution note:** Implement test-first. The authorship rules are assertions about output content, and writing them first is what keeps the vocabulary from drifting during implementation.
+
+**Patterns to follow:**
+- `src/decision_support/recommendations.py` — closed vocabulary, explicit `ValueError` on unknown input, docstring stating what is deliberately not accepted.
+- `src/decision_support/diagnosis_pipeline.py` `_refused_iso_block` — the `status`/`reason`/`remedy` refusal shape.
+
+**Test scenarios:**
+- Happy path: a result with a detected outer-race fault yields a verdict statement naming the fault, an evidence list including the frequency match and its deviation, and at least one recommendation carrying a motivation string.
+- Happy path: the ISO statement contains the standards caveat string exactly as `iso20816` publishes it.
+- Covers AE1. Edge case: ISO zone B with anomaly ratio 1.0 produces an explicit disagreement statement naming which indicator governs the action.
+- Covers AE6. Edge case: a strongly-corroborated result exposes no field whose name or value reads as a confidence or probability; evidence strength is accompanied by its accumulation description.
+- Covers AE3. Error path: a result with no bearing block produces an authored statement that matching was not attempted and why, not an absent section.
+- Error path: a result whose ISO block is a refusal carries the pipeline's `reason` and `remedy` verbatim into the advisory.
+- Edge case: a clean signal with no findings yields a "no fault evidence" verdict and a monitoring recommendation, with no fault-specific actions.
+
+**Verification:**
+- Every string in the advisory payload originates in this module, `recommendations.py`, `iso20816.py`, or the pipeline — no evaluative text is expected from a caller.
+- A grep of the module finds no occurrence of the word "confidence" outside a docstring that explains its absence.
+
+---
+
+### U2. Baseline comparison
+
+**Goal:** Express the key indicators as deltas against a healthy baseline signal when one is supplied, and state the absence explicitly when one is not.
+
+**Requirements:** R8, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `src/decision_support/advisory.py`
+- Test: `tests/test_advisory.py`
+
+**Approach:**
+- Accept an optional second diagnosis result (the baseline) and compute deltas on the indicators a technician acts on: RMS velocity, anomaly ratio, and envelope energy at the matched characteristic frequency.
+- Author the comparison as statements, not as a bare number table — a delta without a sentence saying what it means is the mute-data failure the origin document is targeting.
+- When no baseline is supplied, emit the authored absence statement from U1's refusal shape rather than skipping the block.
+- Guard against comparing incompatible signals (different sampling rate, different declared unit) with an explicit refusal statement.
+
+**Patterns to follow:**
+- U1's authored-refusal shape for the no-baseline and incompatible-baseline cases.
+
+**Test scenarios:**
+- Happy path: a faulted signal compared against `baseline_1` yields a delta statement on RMS velocity with direction and magnitude.
+- Covers AE2. Edge case: no baseline supplied yields a present comparison block stating the absence and the conclusion it makes unavailable.
+- Error path: a baseline with a different declared signal unit yields a refusal statement naming the mismatch, not a computed delta.
+- Edge case: a baseline identical to the signal yields near-zero deltas and a statement that no change was observed, not an empty block.
+
+**Verification:**
+- Running the advisory against `data/signals/real_train/OuterRaceFault_1.csv` with `baseline_1.csv` produces deltas; running it without a baseline produces the absence statement.
+
+---
+
+### U3. Annotated envelope spectrum figure
+
+**Goal:** Produce the explanatory figure — envelope spectrum with BPFO/BPFI/BSF/FTF lines overlaid and the tolerance band shaded — such that the match is visible without interaction.
+
+**Requirements:** R10, R11
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `src/figures.py`
+- Test: `tests/test_figures.py`
+
+**Approach:**
+- Build the figure from the envelope spectrum and the characteristic frequencies already computed by the pipeline's bearing block; do not recompute either.
+- Annotate each characteristic frequency with its label and draw the tolerance band used by the matching logic, so the reader sees the same tolerance the verdict used.
+- Keep annotation in the figure itself rather than in a legend — the point must survive a static export for the PDF rendering.
+- Degrade to a plain annotated envelope spectrum when no bearing metadata is available, consistent with U1's authored absence statement.
+
+**Patterns to follow:**
+- `src/html_templates.py` chart construction for Plotly figure assembly conventions.
+
+**Test scenarios:**
+- Happy path: with bearing metadata present, the figure data contains one annotated marker per characteristic frequency and a shaded band whose width matches the matching tolerance.
+- Edge case: with no bearing metadata, the figure is produced without characteristic-frequency annotations and does not raise.
+- Edge case: a characteristic frequency above the plotted range is omitted from annotations rather than drawn off-axis.
+- Happy path: the annotation text for the matched frequency includes both the calculated and the measured value.
+
+**Verification:**
+- The figure exported statically still shows which band the dominant peak falls into.
+
+---
+
+### U4. Integrated HTML rendering
+
+**Goal:** Render the advisory payload as one self-contained HTML document covering the whole bearing case, carrying provenance.
+
+**Requirements:** R5, R12, R13, R14
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `src/html_templates.py`
+- Modify: `src/report_generator.py`
+- Test: `tests/test_reports.py`
+
+**Approach:**
+- Add an integrated report template alongside the existing per-analysis builders, consuming only the advisory payload and the figure from U3.
+- The template places text; it does not compose text. Any string it renders comes from the payload.
+- Include a provenance block: source signal id and path, analysis parameters, and server version.
+- Reuse `timestamped_report_name` and the existing `safe_resolve` write path so the new report inherits the non-overwriting and path-safety behavior.
+
+**Patterns to follow:**
+- `src/report_generator.py` `save_iso_report` — signature shape, metadata embedding, and return dict.
+- `src/html_templates.py` `get_base_template` — the embedded-metadata script block.
+
+**Test scenarios:**
+- Happy path: the rendered document contains the verdict, the ISO statement with its caveat, the disagreement statement when present, and every recommendation from the payload.
+- Covers AE4. Happy path: every evaluative sentence in the rendered output appears verbatim in the advisory payload.
+- Covers AE5. Integration: rendering the same payload twice produces byte-identical bodies once provenance timestamps are excluded.
+- Edge case: a payload containing authored absence statements renders those sections rather than omitting them.
+- Integration: the report writes under the configured reports directory and a traversal-shaped signal label cannot escape it.
+- Happy path: the provenance block names the source signal, the parameters, and the server version.
+
+**Verification:**
+- Opening the generated file with no server running shows the complete diagnosis, including figures.
+
+---
+
+### U5. MCP tool surface
+
+**Goal:** Expose the integrated report as a tool that returns both the authored statements and the written file paths, and state the authorship rule where callers will read it.
+
+**Requirements:** R3, R4, R15
+
+**Dependencies:** U4
+
+**Files:**
+- Modify: `src/mcp_tools/report_tools.py`
+- Modify: `src/server.py`
+- Modify: `tests/fixtures/tool_inventory.json`
+- Test: `tests/test_report_tools.py`, `tests/test_tool_inventory.py`, `tests/test_surface_parity.py`
+
+**Approach:**
+- Add one tool taking a signal id, the diagnosis inputs the pipeline already needs, an optional baseline signal id, and a formats argument defaulting to both renderings.
+- The return value carries the authored statements alongside the file paths — this is what closes the gap that left previous callers inventing content.
+- The tool's docstring states that the returned statements are to be reused verbatim and that standards names, machine classes, zones, and confidence levels are not to be coined by the caller.
+- Extend the server's existing evidence-based inference policy with the same rule, so it reaches clients that read the server instructions rather than the tool docstring.
+- Regenerate `tests/fixtures/tool_inventory.json` using the documented snapshot recipe and update the frozen count in `tests/test_surface_parity.py` from 33 to 34, with a fixture-history note recording why.
+
+**Execution note:** Regenerate the inventory fixture with the recipe in the `tests/test_tool_inventory.py` docstring — never hand-edit it.
+
+**Patterns to follow:**
+- `src/mcp_tools/report_tools.py` `generate_diagnostic_report_docx` — signal-handle validation via `resolve_signal`, `ctx.info` progress reporting, return dict shape. Follow its structure, not its caller-authored `sections` contract.
+- `tests/test_tool_inventory.py` fixture-history docstring — the convention for recording an intentional surface change.
+
+**Test scenarios:**
+- Happy path: calling the tool on a loaded signal returns authored statements and one file path per requested format.
+- Error path: an unknown signal id raises rather than returning an error-shaped dict.
+- Edge case: requesting only the HTML format produces one file and no PDF path.
+- Covers AE4. Integration: the statements in the return value match those rendered in the written file.
+- Integration: the registered surface counts 34 tools, and the inventory fixture matches the live registration.
+- Happy path: the tool docstring states the caller-authorship prohibition.
+
+**Verification:**
+- Full test suite passes, including the inventory and parity tests, with the surface change recorded intentionally rather than silenced.
+
+---
+
+### U6. PDF rendering
+
+**Goal:** Produce the PDF deliverable from the same advisory payload, behind an optional dependency.
+
+**Requirements:** R12, R13
+
+**Dependencies:** U4
+
+**Files:**
+- Modify: `src/report_generator.py`
+- Modify: `pyproject.toml`
+- Test: `tests/test_reports.py`
+
+**Approach:**
+- Add a `pdf` optional extra and an availability guard mirroring the existing `HAS_DOCX` pattern; a missing dependency raises with an install hint, consistent with the DOCX path.
+- The PDF renderer consumes the same payload as the HTML renderer. Choose a backend that does not require a headless browser if the figure export allows it; decide against the real U3 output.
+- Add the extra to the `full` aggregate extra.
+
+**Patterns to follow:**
+- `src/report_generator.py` `HAS_DOCX` guard and the `save_diagnostic_report_docx` missing-dependency error message.
+
+**Test scenarios:**
+- Happy path: with the extra installed, a PDF is produced and is non-empty.
+- Error path: with the extra absent, requesting the PDF format raises with an install hint naming the extra.
+- Covers AE5. Integration: two renderings of the same payload produce identical extracted text once provenance timestamps are excluded.
+- Integration: the PDF contains the same verdict, ISO statement, and recommendations as the HTML rendering of the same payload.
+
+**Verification:**
+- The parity test between the two renderings passes on a real signal from `data/signals/real_train/`.
+
+---
+
+### U7. Cross-rendering parity and documentation
+
+**Goal:** Pin R12's "identical statements" guarantee as an executable test, and document the new capability.
+
+**Requirements:** R12, R13, R14
+
+**Dependencies:** U5, U6
+
+**Files:**
+- Test: `tests/test_reports.py`
+- Modify: `README.md`, `CHANGELOG.md`
+- Modify: `docs/` tool documentation
+
+**Approach:**
+- Add a parity test that extracts every authored statement from both renderings and asserts set equality — this is the test that makes the authorship boundary a guarantee rather than a convention.
+- Document the new tool with its input and output shape, and state the authorship rule in user-facing documentation, not only in the docstring.
+- Record the surface change (33 to 34 tools) and the new optional extra in `CHANGELOG.md`.
+
+**Test scenarios:**
+- Integration: the set of authored statements extracted from the HTML rendering equals the set extracted from the PDF rendering.
+- Integration: a statement present in the advisory payload but absent from either rendering fails the test.
+
+**Verification:**
+- Documentation describes the tool and its authorship contract; the changelog records the surface and dependency changes.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** the advisory builder sits between `diagnose_vibration` and the report layer. Nothing existing calls it, so the blast radius is confined to the new tool until the DOCX migration is taken up separately.
+- **Error propagation:** failures raise per `tests/test_error_contract.py`. Missing *inputs* are not failures — they become authored absence statements, which is a deliberate distinction from missing *dependencies*, which raise.
+- **State lifecycle risks:** report writes are non-overwriting by construction; a partially-written PDF on a backend failure must not leave a truncated file presented as complete.
+- **API surface parity:** the frozen inventory and parity tests both encode the tool count and must be updated in the same unit that adds the tool, or CI fails at U5.
+- **Integration coverage:** the cross-rendering parity test in U7 is the only place where "both renderings carry identical statements" is actually proven; unit tests on either renderer alone cannot establish it.
+- **Unchanged invariants:** existing report tools, their signatures, and their outputs are untouched. `iso20816` remains the single source of zone boundaries — this plan reads it and never redefines thresholds.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| A new PDF dependency breaks CI or is unavailable on a target platform | Optional extra behind an availability guard, sequenced last; the HTML rendering and every unit before U6 land independently |
+| The frozen tool inventory fails CI when the new tool registers | U5 regenerates the fixture with the documented recipe and updates the parity count in the same unit, with the reason recorded in the fixture history |
+| The advisory layer duplicates reasoning already in `_synthesize_diagnosis` and the two drift | U1 consumes the pipeline result and reuses `generate_recommendations`; it does not re-derive verdicts |
+| Evidence strength is re-read downstream as a confidence, reproducing the failure this work exists to fix | Rendered with its accumulation description attached; U1 asserts no confidence-shaped field exists |
+| Determinism is asserted on filenames and fails spuriously | R13 is tested on rendered content with provenance timestamps excluded; filenames are intentionally unique |
+| Coverage gate at 85% fails because new report code lands in currently-excluded modules | New logic goes in `src/decision_support/advisory.py` and `src/figures.py`, which are not excluded; only template rendering touches the excluded modules |
+
+---
+
+## Documentation / Operational Notes
+
+- `README.md` tool list and the docs site need the new tool and its authorship contract.
+- `CHANGELOG.md` records a surface addition (33 to 34 tools) and a new optional extra under the next minor version — additive only, no breaking change.
+- Installing the PDF extra is required for the second rendering; the tool raises with an install hint when it is absent.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-08-06-diagnostic-report-value-and-authorship.md](docs/brainstorms/2026-08-06-diagnostic-report-value-and-authorship.md)
+- Related code: `src/decision_support/diagnosis_pipeline.py`, `src/decision_support/recommendations.py`, `src/diagnostics/iso20816.py`, `src/report_generator.py`, `src/html_templates.py`
+- Surface constraints: `tests/test_tool_inventory.py`, `tests/test_surface_parity.py`

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -66,7 +66,7 @@ Quick entry points for common workflows.
 
 ## MCP Tool Coverage
 
-This plugin provides domain expertise for all 33 tools (plus 3 guided prompts — 36 endpoints total) of the predictive-maintenance-mcp server. Every signal is referenced by the `signal_id` returned by `load_signal`.
+This plugin provides domain expertise for all 34 tools (plus 3 guided prompts — 37 endpoints total) of the predictive-maintenance-mcp server. Every signal is referenced by the `signal_id` returned by `load_signal`.
 
 - **Signal Lifecycle**: load_signal, list_signals, get_signal_info, generate_test_signal, clear_signals
 - **Spectral & Statistical Analysis**: analyze_fft, analyze_envelope, analyze_statistics, extract_features_from_signal, compute_power_spectral_density, compute_spectrogram_stft

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,11 +128,16 @@ ocr = [
 docx = [
     "python-docx>=1.0",
 ]
+pdf = [
+    # Renders the integrated diagnostic report's own HTML to PDF, so both
+    # renderings come from one document rather than two layouts.
+    "weasyprint>=60.0",
+]
 sse = [
     "uvicorn>=0.30",
 ]
 full = [
-    "predictive-maintenance-mcp[docs,ml,viz,vector-search,ocr,docx,sse]",
+    "predictive-maintenance-mcp[docs,ml,viz,vector-search,ocr,docx,pdf,sse]",
 ]
 dev = [
     "pytest>=8.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "predictive-maintenance-mcp"
-version = "0.10.0"
+version = "0.11.0"
 description = "AI agent for predictive maintenance & condition monitoring — Open-source MCP server and Claude Code plugin with 52 endpoints for vibration analysis, bearing fault detection, ISO 20816 severity assessment, ML anomaly detection, and remaining useful life estimation via natural language"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.LGDiMaggio/predictive-maintenance-mcp",
   "title": "Predictive Maintenance",
   "description": "Industrial vibration analysis, bearing fault diagnosis, ISO 20816, and ML anomaly detection",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "predictive-maintenance-mcp",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,7 +8,7 @@ Installable as 'predictive-maintenance-mcp' from PyPI.
 Package name: predictive_maintenance_mcp (mapped from src/ directory).
 """
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 __author__ = "Luigi Gianpio Di Maggio"
 __license__ = "MIT"
 

--- a/src/decision_support/__init__.py
+++ b/src/decision_support/__init__.py
@@ -8,6 +8,10 @@ plus rule-based recommendations and threshold alerting.
 from .diagnosis_pipeline import (  # noqa: F401
     diagnose_vibration,
 )
+from .advisory import (  # noqa: F401
+    build_advisory,
+    collect_statements,
+)
 from .recommendations import generate_recommendations  # noqa: F401
 from .alerts import (  # noqa: F401
     check_alert_thresholds,

--- a/src/decision_support/advisory.py
+++ b/src/decision_support/advisory.py
@@ -235,7 +235,9 @@ def _build_anomaly_block(anomaly: Optional[dict]) -> dict:
 
 def _build_energy_block(stft_summary: dict) -> dict:
     """Author the spectral-energy block from the STFT band breakdown."""
-    bands = stft_summary.get("energy_per_band") or {}
+    # compute_stft_spectrogram emits a list of {"band", "energy"} entries.
+    entries = stft_summary.get("energy_per_band") or []
+    bands = {entry["band"]: entry["energy"] for entry in entries}
     if not bands:
         return {
             "status": ABSENT,

--- a/src/decision_support/advisory.py
+++ b/src/decision_support/advisory.py
@@ -27,6 +27,7 @@ Three rules hold throughout:
 
 from __future__ import annotations
 
+import math
 from typing import Any, Optional
 
 from ..diagnostics.bearing_analyzer import FAULT_TYPE_CANONICAL
@@ -147,6 +148,7 @@ def _build_bearing_block(bearing_faults: Optional[dict]) -> dict:
                 "expected_hz": check["expected_frequency_hz"],
                 "measured_hz": check.get("detected_frequency_hz"),
                 "deviation_pct": check.get("deviation_pct"),
+                "magnitude": check.get("magnitude"),
                 "harmonics": len(check.get("harmonics_detected") or []),
                 "matched": bool(check.get("detected")),
                 "evidence_strength": check.get("evidence_strength", "none"),
@@ -544,13 +546,222 @@ def build_baseline_comparison(
             "deltas": [],
         }
 
+    incompatible = _baseline_incompatibility(diagnosis, baseline)
+    if incompatible:
+        return {
+            "status": REFUSED,
+            "statement": (
+                f"Baseline comparison was refused: {incompatible} A delta "
+                f"between measurements taken under different conditions "
+                f"would look like a change in machine condition."
+            ),
+            "remedy": (
+                "Supply a baseline acquired from the same measurement point "
+                "under the same declared conditions."
+            ),
+            "deltas": [],
+        }
+
+    deltas = [
+        delta
+        for delta in (
+            _rms_delta(diagnosis, baseline),
+            _anomaly_delta(diagnosis, baseline),
+            _envelope_delta(diagnosis, baseline),
+        )
+        if delta is not None
+    ]
+
+    if not deltas:
+        return {
+            "status": ABSENT,
+            "statement": (
+                f"A baseline was supplied ({baseline.get('signal_id')}), but "
+                f"no indicator could be compared: the two diagnoses share no "
+                f"assessed block. Whether this condition is new, stable, or "
+                f"worsening cannot be determined."
+            ),
+            "remedy": (
+                "Ensure both signals declare their unit so the severity and "
+                "anomaly blocks are assessed rather than refused."
+            ),
+            "deltas": [],
+        }
+
+    moved = [d for d in deltas if d["direction"] != "unchanged"]
+    if not moved:
+        statement = (
+            f"Compared with baseline {baseline.get('signal_id')}: no "
+            f"measurable change in any compared indicator. The condition "
+            f"described above is stable, not developing."
+        )
+    else:
+        headline = max(moved, key=lambda d: abs(d["delta"]))
+        statement = (
+            f"Compared with baseline {baseline.get('signal_id')}: "
+            f"{len(moved)} of {len(deltas)} indicators moved. "
+            f"{headline['statement']}"
+        )
+
     return {
-        "status": ABSENT,
-        "statement": (
-            "Baseline comparison is not yet available for this signal pair."
-        ),
+        "status": ASSESSED,
+        "statement": statement,
+        "baseline_signal_id": baseline.get("signal_id"),
         "remedy": "",
-        "deltas": [],
+        "deltas": deltas,
+    }
+
+
+def _baseline_incompatibility(diagnosis: dict, baseline: dict) -> str:
+    """Return a reason the two signals cannot be compared, or an empty string."""
+    signal_iso = diagnosis.get("iso_severity", {})
+    baseline_iso = baseline.get("iso_severity", {})
+    if signal_iso.get("status") == "assessed" and baseline_iso.get("status") == "assessed":
+        signal_unit = signal_iso.get("original_unit")
+        baseline_unit = baseline_iso.get("original_unit")
+        if signal_unit != baseline_unit:
+            return (
+                f"the signal declares its unit as '{signal_unit}' while the "
+                f"baseline declares '{baseline_unit}'."
+            )
+
+    signal_bearing = diagnosis.get("bearing_id")
+    baseline_bearing = baseline.get("bearing_id")
+    if signal_bearing and baseline_bearing and signal_bearing != baseline_bearing:
+        return (
+            f"the signal was analysed against bearing '{signal_bearing}' and "
+            f"the baseline against '{baseline_bearing}'."
+        )
+
+    return ""
+
+
+def _direction(delta: float, tolerance: float) -> str:
+    if abs(delta) < tolerance:
+        return "unchanged"
+    return "higher" if delta > 0 else "lower"
+
+
+def _rms_delta(diagnosis: dict, baseline: dict) -> Optional[dict]:
+    signal_iso = diagnosis.get("iso_severity", {})
+    baseline_iso = baseline.get("iso_severity", {})
+    if signal_iso.get("status") != "assessed" or baseline_iso.get("status") != "assessed":
+        return None
+
+    now = signal_iso["rms_velocity_mm_s"]
+    then = baseline_iso["rms_velocity_mm_s"]
+    delta = now - then
+    direction = _direction(delta, 0.005)
+    if direction == "unchanged":
+        statement = (
+            f"RMS velocity is unchanged against baseline "
+            f"({now:.2f} mm/s, was {then:.2f} mm/s)."
+        )
+    else:
+        statement = (
+            f"RMS velocity is {abs(delta):.2f} mm/s {direction} than baseline "
+            f"({now:.2f} mm/s, was {then:.2f} mm/s)."
+        )
+    return {
+        "indicator": "rms_velocity",
+        "unit": "mm/s",
+        "value": now,
+        "baseline_value": then,
+        "delta": round(delta, 4),
+        "direction": direction,
+        "statement": statement,
+    }
+
+
+def _anomaly_delta(diagnosis: dict, baseline: dict) -> Optional[dict]:
+    signal_anomaly = diagnosis.get("anomaly_detection")
+    baseline_anomaly = baseline.get("anomaly_detection")
+    if not signal_anomaly or not baseline_anomaly:
+        return None
+
+    now = signal_anomaly["anomaly_ratio"] * 100
+    then = baseline_anomaly["anomaly_ratio"] * 100
+    delta = now - then
+    direction = _direction(delta, 0.05)
+    if direction == "unchanged":
+        statement = (
+            f"The share of anomalous segments is unchanged against baseline "
+            f"({now:.0f}%, was {then:.0f}%) — a difference of under one "
+            f"percentage point."
+        )
+    else:
+        statement = (
+            f"The share of anomalous segments is {abs(delta):.0f} percentage "
+            f"points {direction} than baseline ({now:.0f}%, was {then:.0f}%)."
+        )
+    return {
+        "indicator": "anomaly_ratio",
+        "unit": "percentage points",
+        "value": round(now, 2),
+        "baseline_value": round(then, 2),
+        "delta": round(delta, 2),
+        "direction": direction,
+        "statement": statement,
+    }
+
+
+def _envelope_delta(diagnosis: dict, baseline: dict) -> Optional[dict]:
+    """Compare envelope amplitude at the fault frequency that actually matched.
+
+    This is the delta that separates "the machine is noisier" from "this
+    specific defect grew": it looks only at the frequency the verdict rests on.
+    """
+    signal_faults = diagnosis.get("bearing_faults")
+    baseline_faults = baseline.get("bearing_faults")
+    if not signal_faults or not baseline_faults:
+        return None
+
+    matched = next(
+        (
+            c
+            for c in signal_faults.get("fault_checks", [])
+            if c.get("detected") and c.get("magnitude")
+        ),
+        None,
+    )
+    if matched is None:
+        return None
+
+    reference = next(
+        (
+            c
+            for c in baseline_faults.get("fault_checks", [])
+            if c["fault_type"] == matched["fault_type"] and c.get("magnitude")
+        ),
+        None,
+    )
+    if reference is None:
+        return None
+
+    now = matched["magnitude"]
+    then = reference["magnitude"]
+    delta_db = 20 * math.log10(now / then)
+    direction = _direction(delta_db, 0.05)
+    acronym = matched["fault_type"]
+    if direction == "unchanged":
+        statement = (
+            f"Envelope amplitude at the {acronym} frequency is unchanged "
+            f"against baseline."
+        )
+    else:
+        statement = (
+            f"Envelope amplitude at the {acronym} frequency is "
+            f"{abs(delta_db):.1f} dB {direction} than baseline — the defect "
+            f"signature itself, not overall machine noise."
+        )
+    return {
+        "indicator": "envelope_magnitude",
+        "unit": "dB",
+        "value": now,
+        "baseline_value": then,
+        "delta": round(delta_db, 2),
+        "direction": direction,
+        "statement": statement,
     }
 
 

--- a/src/decision_support/advisory.py
+++ b/src/decision_support/advisory.py
@@ -55,6 +55,13 @@ _REQUIRED_KEYS = ("signal_id", "iso_severity", "fft_summary", "stft_summary")
 
 _ACCEPTABLE_ZONES = ("A", "B")
 
+#: Which baseline delta leads the comparison sentence, most specific first.
+#: Chosen by what the movement MEANS, not by magnitude: the three deltas are
+#: measured in dB, mm/s and percentage points, so "the biggest number" would
+#: rank them by unit scale rather than by diagnostic weight — the anomaly
+#: ratio, living on a 0-100 scale, would win almost every time.
+_HEADLINE_ORDER = ("envelope_magnitude", "rms_velocity", "anomaly_ratio")
+
 
 def _fault_label(canonical: Optional[str]) -> str:
     """Render a canonical fault type as prose ('outer_race' -> 'outer race')."""
@@ -460,12 +467,17 @@ def _build_recommendations(
     ]
 
     if zone is not None:
+        # generate_recommendations emits the zone action(s) first, then one
+        # entry per fault type in the order given. Split on that structure
+        # rather than on the wording of the description: matching a prose
+        # prefix would silently mislabel every recommendation the day that
+        # sentence is reworded.
+        zone_only = generate_recommendations(severity_zone=zone)
         base = generate_recommendations(severity_zone=zone, fault_types=fault_types)
-        for entry in base:
-            if entry["description"].startswith("Detected fault"):
-                acronym = _acronym_for(
-                    entry["description"].removeprefix("Detected fault: ").rstrip(".")
-                )
+        for index, entry in enumerate(base):
+            fault_index = index - len(zone_only)
+            if fault_index >= 0:
+                acronym = _acronym_for(fault_types[fault_index])
                 motivation = (
                     "The characteristic frequency of this bearing element "
                     "matched a peak in the envelope spectrum within tolerance"
@@ -598,7 +610,7 @@ def build_baseline_comparison(
             f"described above is stable, not developing."
         )
     else:
-        headline = max(moved, key=lambda d: abs(d["delta"]))
+        headline = min(moved, key=lambda d: _HEADLINE_ORDER.index(d["indicator"]))
         statement = (
             f"Compared with baseline {baseline.get('signal_id')}: "
             f"{len(moved)} of {len(deltas)} indicators moved. "

--- a/src/decision_support/advisory.py
+++ b/src/decision_support/advisory.py
@@ -1,0 +1,681 @@
+"""ISO 13374 Block 6 — server-authored advisory.
+
+Every evaluative sentence a report shows a human is written *here*, by the
+server that computed the numbers. Renderers place these strings; they never
+compose their own.
+
+This exists because the previous arrangement let the caller author report
+content (see ``generate_diagnostic_report_docx``'s ``sections`` argument).
+When the caller is a language model, the numbers survive the trip and the
+labels do not: a superseded standard name, a machine-class vocabulary this
+codebase does not use, and a "confidence" grade that
+:mod:`..decision_support.recommendations` deliberately refuses to produce.
+
+Three rules hold throughout:
+
+1. Standard names, zone descriptions, and threshold provenance are read from
+   :mod:`..diagnostics.iso20816` — the single source of that vocabulary — and
+   never re-typed here.
+2. No field, value, or sentence is a confidence or a probability. Evidential
+   weight is conveyed by naming the facts that support a finding, and the
+   categorical ``evidence_strength`` always travels with a sentence saying
+   what it counts.
+3. A missing input produces an authored statement about the absence and the
+   conclusion it makes unavailable. It never produces a missing section — a
+   silently absent block reads as "nothing to report".
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from ..diagnostics.bearing_analyzer import FAULT_TYPE_CANONICAL
+from .recommendations import generate_recommendations
+
+#: Block status vocabulary. ``ASSESSED`` means the block reached a verdict;
+#: ``REFUSED`` means the engine declined to answer and said why; ``ABSENT``
+#: means an input the block needs was never supplied.
+ASSESSED = "assessed"
+REFUSED = "refused"
+ABSENT = "absent"
+
+#: Always rendered next to ``evidence_strength``. The categorical value on its
+#: own invites a reader — or a model — to hear a probability; this sentence is
+#: what stops that reading.
+EVIDENCE_STRENGTH_EXPLANATION = (
+    "Evidence strength counts independent corroborating findings — it is "
+    "not a confidence score and not a probability."
+)
+
+#: Keys a ``diagnose_vibration`` result must carry. Guessing at a partial
+#: result would produce authored sentences about numbers that were never
+#: computed, which is the failure mode this module exists to prevent.
+_REQUIRED_KEYS = ("signal_id", "iso_severity", "fft_summary", "stft_summary")
+
+_ACCEPTABLE_ZONES = ("A", "B")
+
+
+def _fault_label(canonical: Optional[str]) -> str:
+    """Render a canonical fault type as prose ('outer_race' -> 'outer race')."""
+    return canonical.replace("_", " ") if canonical else ""
+
+
+def _acronym_for(canonical: Optional[str]) -> str:
+    """Reverse-map a canonical fault type to its bearing acronym."""
+    for acronym, value in FAULT_TYPE_CANONICAL.items():
+        if value == canonical:
+            return acronym
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# ISO severity
+# ---------------------------------------------------------------------------
+
+
+def _build_iso_block(iso: dict) -> dict:
+    """Author the ISO severity block, or carry the engine's refusal forward."""
+    if iso.get("status") == "refused":
+        return {
+            "status": REFUSED,
+            "statement": (
+                f"ISO severity was not assessed. {iso['reason']}"
+            ),
+            "reason": iso["reason"],
+            "remedy": iso["remedy"],
+            "standard_note": None,
+        }
+
+    zone = iso["zone"]
+    rms = iso["rms_velocity_mm_s"]
+    severity = iso.get("severity_level", "")
+    description = iso.get("zone_description", "")
+    boundaries = iso.get("boundaries", {})
+
+    statement = (
+        f"ISO 20816-3: RMS velocity {rms:.2f} mm/s places this machine in "
+        f"Zone {zone} ({severity}) for machine group "
+        f"{iso.get('machine_group')} on a {iso.get('support_type')} support. "
+        f"{description}"
+    ).strip()
+
+    return {
+        "status": ASSESSED,
+        "statement": statement,
+        "zone": zone,
+        "severity_level": severity,
+        "rms_velocity_mm_s": rms,
+        "boundaries": boundaries,
+        "evaluation_band": iso.get("frequency_range"),
+        # Verbatim from iso20816 — the caveat that the 2022 edition merges
+        # zones A and B travels with every verdict or it travels with none.
+        "standard_note": iso.get("threshold_provenance"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Bearing characteristic-frequency matching
+# ---------------------------------------------------------------------------
+
+
+def _build_bearing_block(bearing_faults: Optional[dict]) -> dict:
+    """Author the frequency-matching block, or state why it was not attempted."""
+    if not bearing_faults:
+        return {
+            "status": ABSENT,
+            "statement": (
+                "Bearing characteristic-frequency matching was not attempted: "
+                "no bearing designation was supplied for this signal, so BPFO, "
+                "BPFI, BSF and FTF could not be computed. Without it, a "
+                "spectral peak cannot be attributed to a specific bearing "
+                "element."
+            ),
+            "remedy": (
+                "Re-run the diagnosis with a bearing_id present in the "
+                "catalog, or add the bearing designation to the signal's "
+                "companion metadata."
+            ),
+            "rows": [],
+        }
+
+    rows = []
+    for check in bearing_faults.get("fault_checks", []):
+        rows.append(
+            {
+                "fault_type": check["fault_type"],
+                "fault_canonical": check.get("fault_type_canonical"),
+                "expected_hz": check["expected_frequency_hz"],
+                "measured_hz": check.get("detected_frequency_hz"),
+                "deviation_pct": check.get("deviation_pct"),
+                "harmonics": len(check.get("harmonics_detected") or []),
+                "matched": bool(check.get("detected")),
+                "evidence_strength": check.get("evidence_strength", "none"),
+            }
+        )
+
+    matched = [r for r in rows if r["matched"]]
+    if matched:
+        parts = [
+            f"{r['fault_type']} expected at {r['expected_hz']:.2f} Hz, "
+            f"measured at {r['measured_hz']:.2f} Hz "
+            f"({r['deviation_pct']:.2f}% deviation)"
+            for r in matched
+        ]
+        statement = (
+            f"Bearing {bearing_faults.get('bearing_id')} at "
+            f"{bearing_faults.get('shaft_frequency_hz', 0.0):.1f} Hz shaft "
+            f"speed: {'; '.join(parts)}. The remaining characteristic "
+            f"frequencies did not match."
+        )
+    else:
+        statement = (
+            f"Bearing {bearing_faults.get('bearing_id')}: none of the four "
+            f"characteristic frequencies (BPFO, BPFI, BSF, FTF) matched a "
+            f"peak in the envelope spectrum within tolerance."
+        )
+
+    return {
+        "status": ASSESSED,
+        "statement": statement,
+        "bearing_id": bearing_faults.get("bearing_id"),
+        "shaft_frequency_hz": bearing_faults.get("shaft_frequency_hz"),
+        "bearing_frequencies": bearing_faults.get("bearing_frequencies", {}),
+        "rows": rows,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Anomaly detection
+# ---------------------------------------------------------------------------
+
+
+def _build_anomaly_block(anomaly: Optional[dict]) -> dict:
+    """Author the anomaly block, or state that no model verdict exists."""
+    if not anomaly:
+        return {
+            "status": ABSENT,
+            "statement": (
+                "No anomaly-model verdict is available for this signal: no "
+                "trained model was found. The pattern-level check that would "
+                "corroborate or contradict the severity reading is therefore "
+                "missing from this assessment."
+            ),
+            "remedy": (
+                "Train an anomaly model on healthy signals from this machine, "
+                "then re-run the diagnosis."
+            ),
+        }
+
+    health = anomaly["overall_health"]
+    ratio = anomaly["anomaly_ratio"]
+    segments = anomaly.get("num_segments")
+    counted = (
+        f"{round(ratio * segments)} of {segments} segments"
+        if segments
+        else f"{ratio * 100:.1f}% of segments"
+    )
+    return {
+        "status": ASSESSED,
+        "statement": (
+            f"Anomaly model verdict: {health} — {counted} "
+            f"({ratio * 100:.1f}%) fall outside the learned healthy pattern."
+        ),
+        "overall_health": health,
+        "anomaly_ratio": ratio,
+        "num_segments": segments,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Spectral energy distribution
+# ---------------------------------------------------------------------------
+
+
+def _build_energy_block(stft_summary: dict) -> dict:
+    """Author the spectral-energy block from the STFT band breakdown."""
+    bands = stft_summary.get("energy_per_band") or {}
+    if not bands:
+        return {
+            "status": ABSENT,
+            "statement": (
+                "No spectral energy distribution is available: the STFT band "
+                "breakdown was not computed, so the frequency region carrying "
+                "the signal's energy cannot be named."
+            ),
+            "bands": {},
+        }
+
+    total = sum(bands.values())
+    dominant = max(bands, key=lambda k: bands[k])
+    share = (bands[dominant] / total * 100) if total else 0.0
+    return {
+        "status": ASSESSED,
+        "statement": (
+            f"Spectral energy is concentrated in the {dominant} band "
+            f"({share:.0f}% of total STFT energy). High-frequency dominance is "
+            f"consistent with impulsive excitation of structural resonances; "
+            f"low-frequency dominance is consistent with shaft-order sources "
+            f"such as unbalance or misalignment."
+        ),
+        "bands": dict(bands),
+        "dominant_band": dominant,
+        "dominant_share_pct": round(share, 1),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Verdict and evidence
+# ---------------------------------------------------------------------------
+
+
+def _build_verdict(
+    bearing_block: dict, iso_block: dict, anomaly_block: dict
+) -> dict:
+    """Author the headline verdict from the blocks that reached one."""
+    matched = [r for r in bearing_block.get("rows", []) if r["matched"]]
+    if matched:
+        primary = max(
+            matched,
+            key=lambda r: {"high": 3, "moderate": 2, "low": 1}.get(
+                r["evidence_strength"], 0
+            ),
+        )
+        canonical = primary["fault_canonical"]
+        label = _fault_label(canonical)
+        return {
+            "statement": (
+                f"A {label} fault is indicated: the envelope spectrum peak "
+                f"matches the {primary['fault_type']} characteristic frequency "
+                f"of this bearing within {primary['deviation_pct']:.2f}%."
+            ),
+            "fault_canonical": canonical,
+            "fault_acronym": primary["fault_type"],
+        }
+
+    if bearing_block["status"] == ASSESSED:
+        headline = (
+            "No bearing fault is indicated: no characteristic frequency "
+            "matched a peak in the envelope spectrum."
+        )
+    else:
+        headline = (
+            "No bearing fault verdict was reached, because characteristic-"
+            "frequency matching was not attempted."
+        )
+
+    if iso_block["status"] == ASSESSED and iso_block["zone"] not in _ACCEPTABLE_ZONES:
+        headline += (
+            f" Broadband vibration is nonetheless elevated "
+            f"(Zone {iso_block['zone']}), so a non-bearing source should be "
+            f"considered."
+        )
+    elif anomaly_block.get("overall_health") in ("Faulty", "Suspicious"):
+        headline += (
+            " The anomaly model nonetheless flags this signal as departing "
+            "from the learned healthy pattern, so a source outside the "
+            "bearing's characteristic frequencies should be considered."
+        )
+
+    return {"statement": headline, "fault_canonical": None, "fault_acronym": ""}
+
+
+def _build_evidence(
+    diagnosis: dict,
+    bearing_block: dict,
+    iso_block: dict,
+    anomaly_block: dict,
+    energy_block: dict,
+) -> dict:
+    """Collect the facts that support the verdict, as authored sentences."""
+    statements: list[str] = []
+
+    for row in bearing_block.get("rows", []):
+        if not row["matched"]:
+            continue
+        acronym = row["fault_type"]
+        sentence = (
+            f"{acronym} match: expected {row['expected_hz']:.2f} Hz, measured "
+            f"{row['measured_hz']:.2f} Hz, deviation {row['deviation_pct']:.2f}%."
+        )
+        if row["harmonics"]:
+            sentence += (
+                f" {row['harmonics']} harmonic(s) of {acronym} are also "
+                f"present, which a single noise peak would not produce."
+            )
+        statements.append(sentence)
+
+    if iso_block["status"] == ASSESSED:
+        statements.append(iso_block["statement"])
+    if anomaly_block["status"] == ASSESSED:
+        statements.append(anomaly_block["statement"])
+    if energy_block["status"] == ASSESSED:
+        statements.append(energy_block["statement"])
+
+    peak = diagnosis.get("fft_summary", {}).get("peak_frequency_hz")
+    if peak is not None:
+        statements.append(
+            f"Dominant frequency in the raw spectrum: {peak:.1f} Hz."
+        )
+
+    return {
+        "strength": diagnosis.get("evidence_strength", "none"),
+        "strength_explanation": EVIDENCE_STRENGTH_EXPLANATION,
+        "statements": statements,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Indicator disagreement (R6)
+# ---------------------------------------------------------------------------
+
+
+def _build_disagreements(
+    iso_block: dict, bearing_block: dict, anomaly_block: dict
+) -> list[dict]:
+    """Name the indicators that disagree, and which one governs the action.
+
+    A refused ISO block is not an indicator and cannot disagree with one — an
+    absent verdict is silence, not a contradicting opinion.
+    """
+    if iso_block["status"] != ASSESSED:
+        return []
+    if iso_block["zone"] not in _ACCEPTABLE_ZONES:
+        return []
+
+    dissenting: list[str] = []
+    if anomaly_block.get("overall_health") in ("Faulty", "Suspicious"):
+        dissenting.append(
+            f"the anomaly model ({anomaly_block['overall_health']}, "
+            f"{anomaly_block['anomaly_ratio'] * 100:.0f}% of segments)"
+        )
+    strong_matches = [
+        r
+        for r in bearing_block.get("rows", [])
+        if r["matched"] and r["evidence_strength"] in ("high", "moderate")
+    ]
+    if strong_matches:
+        names = ", ".join(r["fault_type"] for r in strong_matches)
+        dissenting.append(f"the characteristic-frequency match ({names})")
+
+    if not dissenting:
+        return []
+
+    return [
+        {
+            "statement": (
+                f"Indicators disagree. Zone {iso_block['zone']} describes "
+                f"overall vibration energy as acceptable, while "
+                f"{' and '.join(dissenting)} indicate a developing fault. "
+                f"These are not contradictory: a localised defect can be "
+                f"unambiguous in the envelope spectrum while the broadband "
+                f"level it contributes is still low. The fault-pattern "
+                f"evidence governs the recommended action; the ISO zone "
+                f"describes how far the condition has progressed."
+            ),
+            "governing_indicator": "fault-pattern evidence",
+            "deferring_indicator": f"ISO zone {iso_block['zone']}",
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Recommendations (R7)
+# ---------------------------------------------------------------------------
+
+
+def _build_recommendations(
+    iso_block: dict,
+    bearing_block: dict,
+    anomaly_block: dict,
+    disagreements: list[dict],
+) -> list[dict]:
+    """Attach a motivation and its supporting evidence to each action."""
+    recommendations: list[dict] = []
+
+    if iso_block["status"] == REFUSED:
+        recommendations.append(
+            {
+                "action": iso_block["remedy"],
+                "urgency": "medium",
+                "description": (
+                    "The severity verdict is unavailable until this is "
+                    "resolved."
+                ),
+                "motivation": iso_block["reason"],
+                "evidence": [iso_block["statement"]],
+            }
+        )
+        zone = None
+    else:
+        zone = iso_block["zone"]
+
+    fault_types = [
+        r["fault_canonical"]
+        for r in bearing_block.get("rows", [])
+        if r["matched"] and r["fault_canonical"]
+    ]
+
+    if zone is not None:
+        base = generate_recommendations(severity_zone=zone, fault_types=fault_types)
+        for entry in base:
+            if entry["description"].startswith("Detected fault"):
+                acronym = _acronym_for(
+                    entry["description"].removeprefix("Detected fault: ").rstrip(".")
+                )
+                motivation = (
+                    "The characteristic frequency of this bearing element "
+                    "matched a peak in the envelope spectrum within tolerance"
+                    + (f" ({acronym})." if acronym else ".")
+                )
+                evidence = [bearing_block["statement"]]
+            else:
+                severity = iso_block.get("severity_level")
+                motivation = (
+                    f"ISO Zone {zone} is classified as {severity.lower()}."
+                    if severity
+                    else f"ISO Zone {zone}."
+                )
+                evidence = [iso_block["statement"]]
+            recommendations.append(
+                {**entry, "motivation": motivation, "evidence": evidence}
+            )
+
+    if disagreements:
+        recommendations.insert(
+            0,
+            {
+                "action": (
+                    "Treat this as actionable despite the acceptable ISO zone"
+                ),
+                "urgency": "medium",
+                "description": (
+                    "Fault-pattern evidence and the severity zone describe "
+                    "different stages of the same condition."
+                ),
+                "motivation": disagreements[0]["statement"],
+                "evidence": [disagreements[0]["statement"]],
+            },
+        )
+
+    if anomaly_block["status"] == ABSENT:
+        recommendations.append(
+            {
+                "action": anomaly_block["remedy"],
+                "urgency": "low",
+                "description": (
+                    "Pattern-level corroboration is unavailable without a "
+                    "trained model."
+                ),
+                "motivation": anomaly_block["statement"],
+                "evidence": [anomaly_block["statement"]],
+            }
+        )
+
+    return recommendations
+
+
+# ---------------------------------------------------------------------------
+# Baseline comparison (R8)
+# ---------------------------------------------------------------------------
+
+
+def build_baseline_comparison(
+    diagnosis: dict, baseline: Optional[dict]
+) -> dict[str, Any]:
+    """Author the comparison against a healthy reference signal.
+
+    An absolute figure tells a technician where the machine is; a delta tells
+    them where it is going. When no baseline is supplied the block still
+    renders — it states the absence and the conclusion that absence costs.
+    """
+    if not baseline:
+        return {
+            "status": ABSENT,
+            "statement": (
+                "No healthy baseline was supplied for this machine, so the "
+                "readings below are absolute rather than relative. Whether "
+                "this condition is new, stable, or worsening cannot be "
+                "determined from a single acquisition."
+            ),
+            "remedy": (
+                "Re-run the diagnosis with a baseline signal id from the same "
+                "machine in a known-good state."
+            ),
+            "deltas": [],
+        }
+
+    return {
+        "status": ABSENT,
+        "statement": (
+            "Baseline comparison is not yet available for this signal pair."
+        ),
+        "remedy": "",
+        "deltas": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Provenance
+# ---------------------------------------------------------------------------
+
+
+def _build_provenance(diagnosis: dict) -> dict:
+    """Record what was analysed and by which server version."""
+    # Imported inside the function: the package __init__ pulls in the MCP
+    # server, and this module is imported from within that import chain.
+    from .. import __version__
+
+    return {
+        "signal_id": diagnosis.get("signal_id"),
+        "rpm": diagnosis.get("rpm"),
+        "bearing_id": diagnosis.get("bearing_id"),
+        "machine_group": diagnosis.get("machine_group"),
+        "support_type": diagnosis.get("support_type"),
+        "server_version": __version__,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_advisory(
+    diagnosis: dict,
+    baseline_diagnosis: Optional[dict] = None,
+) -> dict[str, Any]:
+    """Turn a ``diagnose_vibration`` result into server-authored statements.
+
+    Every string in the returned payload is written here or by a module this
+    one reads from. Renderers place these strings; a renderer that composes
+    its own evaluative sentence has broken the contract this function exists
+    to hold.
+
+    Args:
+        diagnosis: A result from
+            :func:`..decision_support.diagnosis_pipeline.diagnose_vibration`.
+        baseline_diagnosis: Optional result for a healthy reference signal on
+            the same machine. When omitted, the comparison block states the
+            absence and the conclusion it makes unavailable.
+
+    Returns:
+        The advisory payload: verdict, evidence, per-indicator blocks,
+        indicator disagreements, baseline comparison, recommendations, and
+        provenance.
+
+    Raises:
+        ValueError: If ``diagnosis`` is not a recognisable diagnosis result.
+            Authoring sentences about numbers that were never computed is the
+            failure this module exists to prevent, so a partial input is
+            refused rather than filled in.
+    """
+    missing = [k for k in _REQUIRED_KEYS if k not in diagnosis]
+    if missing:
+        raise ValueError(
+            f"Not a diagnose_vibration result — missing {missing}. Pass the "
+            f"dict returned by diagnose_vibration(); the advisory layer does "
+            f"not re-run analysis and cannot author statements about values "
+            f"it was not given."
+        )
+
+    iso_block = _build_iso_block(diagnosis["iso_severity"])
+    bearing_block = _build_bearing_block(diagnosis.get("bearing_faults"))
+    anomaly_block = _build_anomaly_block(diagnosis.get("anomaly_detection"))
+    energy_block = _build_energy_block(diagnosis["stft_summary"])
+
+    verdict = _build_verdict(bearing_block, iso_block, anomaly_block)
+    evidence = _build_evidence(
+        diagnosis, bearing_block, iso_block, anomaly_block, energy_block
+    )
+    disagreements = _build_disagreements(iso_block, bearing_block, anomaly_block)
+    baseline_block = build_baseline_comparison(diagnosis, baseline_diagnosis)
+    recommendations = _build_recommendations(
+        iso_block, bearing_block, anomaly_block, disagreements
+    )
+
+    return {
+        "signal_id": diagnosis["signal_id"],
+        "verdict": verdict,
+        "evidence": evidence,
+        "iso": iso_block,
+        "bearing_match": bearing_block,
+        "anomaly": anomaly_block,
+        "spectral_energy": energy_block,
+        "disagreements": disagreements,
+        "baseline_comparison": baseline_block,
+        "recommendations": recommendations,
+        "provenance": _build_provenance(diagnosis),
+    }
+
+
+def collect_statements(advisory: dict) -> list[str]:
+    """Return every authored statement in the payload, in document order.
+
+    This is the surface the cross-rendering parity test asserts on: a
+    statement present here and absent from a rendering means that rendering
+    dropped something the server said.
+    """
+    statements: list[str] = []
+
+    def add(value: Optional[str]) -> None:
+        if value and value not in statements:
+            statements.append(value)
+
+    add(advisory["verdict"]["statement"])
+    for block_key in ("iso", "bearing_match", "anomaly", "spectral_energy"):
+        add(advisory[block_key].get("statement"))
+        add(advisory[block_key].get("remedy"))
+    for entry in advisory["disagreements"]:
+        add(entry["statement"])
+    add(advisory["baseline_comparison"].get("statement"))
+    for sentence in advisory["baseline_comparison"].get("deltas", []):
+        add(sentence.get("statement"))
+    for sentence in advisory["evidence"]["statements"]:
+        add(sentence)
+    add(advisory["evidence"]["strength_explanation"])
+    for rec in advisory["recommendations"]:
+        add(rec["action"])
+        add(rec["description"])
+        add(rec["motivation"])
+
+    return statements

--- a/src/figures.py
+++ b/src/figures.py
@@ -15,7 +15,6 @@ so the argument survives a static export.
 
 from __future__ import annotations
 
-import math
 from typing import Any, Optional, Sequence
 
 import numpy as np
@@ -147,6 +146,151 @@ def build_annotated_envelope_figure(
         "omitted_labels": omitted,
         "caption": _caption(bands, omitted, tolerance_pct, matched),
     }
+
+
+def figure_to_svg(
+    figure: dict[str, Any], width: int = 900, height: int = 420
+) -> str:
+    """Render a figure description as a standalone inline SVG.
+
+    SVG rather than a charting library because the report must open with no
+    network access and must survive export to a static format. A chart that
+    needs a CDN script is not a self-contained document, and a chart whose
+    labels only appear on hover loses its argument the moment it is printed.
+
+    Args:
+        figure: A description from :func:`build_annotated_envelope_figure`.
+        width: Canvas width in pixels.
+        height: Canvas height in pixels.
+
+    Returns:
+        An ``<svg>`` element with no external references.
+
+    Raises:
+        ValueError: If the figure is not a kind this renderer knows.
+    """
+    if figure.get("kind") != ANNOTATED_ENVELOPE:
+        raise ValueError(
+            f"Unknown figure kind {figure.get('kind')!r} — this renderer "
+            f"draws {ANNOTATED_ENVELOPE} only."
+        )
+
+    left, right, top, bottom = 70, 20, 34, 56
+    plot_w = width - left - right
+    plot_h = height - top - bottom
+
+    xs = figure["x"]
+    ys = figure["y"]
+    x_max = max(xs) if xs else 1.0
+    y_min = min(min(ys), -6.0) if ys else -60.0
+
+    def px(value: float) -> float:
+        return round(left + (value / x_max) * plot_w, 2) if x_max else left
+
+    def py(value: float) -> float:
+        span = -y_min or 1.0
+        return round(top + ((0.0 - value) / span) * plot_h, 2)
+
+    parts: list[str] = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'width="100%" role="img" aria-label="{_esc(figure["caption"])}">',
+        f'<rect x="0" y="0" width="{width}" height="{height}" fill="#ffffff"/>',
+    ]
+
+    # Horizontal gridlines every 10 dB, so amplitude differences are readable
+    # off the page rather than only by hovering.
+    tick = -10.0
+    while tick > y_min:
+        y_pos = py(tick)
+        parts.append(
+            f'<line x1="{left}" y1="{y_pos}" x2="{left + plot_w}" y2="{y_pos}" '
+            f'stroke="#e8e8e8" stroke-width="1"/>'
+        )
+        parts.append(
+            f'<text x="{left - 8}" y="{y_pos + 4}" font-size="11" fill="#7f8c8d" '
+            f'text-anchor="end">{tick:.0f}</text>'
+        )
+        tick -= 10.0
+
+    # Tolerance bands behind the trace: the reader must see the peak sitting
+    # inside one and outside the rest.
+    for band in figure["bands"]:
+        x_low, x_high = px(band["low_hz"]), px(band["high_hz"])
+        band_w = max(x_high - x_low, 1.5)
+        fill = "#e74c3c" if band["matched"] else "#95a5a6"
+        opacity = "0.28" if band["matched"] else "0.14"
+        parts.append(
+            f'<rect x="{x_low}" y="{top}" width="{round(band_w, 2)}" '
+            f'height="{plot_h}" fill="{fill}" fill-opacity="{opacity}"/>'
+        )
+        centre = px(band["center_hz"])
+        parts.append(
+            f'<line x1="{centre}" y1="{top}" x2="{centre}" y2="{top + plot_h}" '
+            f'stroke="{fill}" stroke-width="1" stroke-dasharray="4 3"/>'
+        )
+
+    points = " ".join(f"{px(x)},{py(y)}" for x, y in zip(xs, ys))
+    parts.append(
+        f'<polyline points="{points}" fill="none" stroke="#2c3e50" '
+        f'stroke-width="1.2"/>'
+    )
+
+    # Axes
+    parts.append(
+        f'<line x1="{left}" y1="{top}" x2="{left}" y2="{top + plot_h}" '
+        f'stroke="#2c3e50" stroke-width="1.5"/>'
+    )
+    parts.append(
+        f'<line x1="{left}" y1="{top + plot_h}" x2="{left + plot_w}" '
+        f'y2="{top + plot_h}" stroke="#2c3e50" stroke-width="1.5"/>'
+    )
+    for fraction in (0.0, 0.25, 0.5, 0.75, 1.0):
+        value = x_max * fraction
+        x_pos = px(value)
+        parts.append(
+            f'<line x1="{x_pos}" y1="{top + plot_h}" x2="{x_pos}" '
+            f'y2="{top + plot_h + 5}" stroke="#2c3e50" stroke-width="1"/>'
+        )
+        parts.append(
+            f'<text x="{x_pos}" y="{top + plot_h + 19}" font-size="11" '
+            f'fill="#7f8c8d" text-anchor="middle">{value:.0f}</text>'
+        )
+
+    # Annotations, staggered vertically so adjacent bands do not collide.
+    for index, annotation in enumerate(figure["annotations"]):
+        x_pos = px(annotation["x"])
+        y_pos = max(py(annotation["y"]) - 10, top + 12 + (index % 2) * 14)
+        weight = "700" if annotation["matched"] else "500"
+        colour = "#c0392b" if annotation["matched"] else "#5d6d7e"
+        anchor = "start" if x_pos < left + plot_w * 0.75 else "end"
+        parts.append(
+            f'<text x="{round(x_pos + (4 if anchor == "start" else -4), 2)}" '
+            f'y="{y_pos}" font-size="11" font-weight="{weight}" fill="{colour}" '
+            f'text-anchor="{anchor}">{_esc(annotation["text"])}</text>'
+        )
+
+    parts.append(
+        f'<text x="{left + plot_w / 2}" y="{height - 8}" font-size="12" '
+        f'fill="#2c3e50" text-anchor="middle">{_esc(figure["x_label"])}</text>'
+    )
+    parts.append(
+        f'<text x="14" y="{top + plot_h / 2}" font-size="12" fill="#2c3e50" '
+        f'text-anchor="middle" transform="rotate(-90 14 {top + plot_h / 2})">'
+        f'{_esc(figure["y_label"])}</text>'
+    )
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def _esc(text: str) -> str:
+    """Escape text for embedding in SVG markup."""
+    return (
+        str(text)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
 
 
 def _defect_frequencies(

--- a/src/figures.py
+++ b/src/figures.py
@@ -37,6 +37,41 @@ _FLOOR_DB = 1e-12
 #: width diverge from the tolerance it claims to represent.
 _BAND_PRECISION = 6
 
+#: Cap on plotted trace points, so a long high-rate acquisition does not
+#: produce a report too heavy to send.
+_MAX_TRACE_POINTS = 2400
+
+
+def _decimate_preserving_peaks(
+    x: np.ndarray, y: np.ndarray, max_points: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Reduce the trace to at most ``max_points`` without losing peaks.
+
+    Plain decimation would drop samples, and in a spectrum the samples it
+    drops are exactly the narrow peaks the whole figure exists to show. This
+    keeps the maximum within each bucket instead, so a peak survives at the
+    frequency where it occurred.
+    """
+    if max_points <= 0 or x.size <= max_points:
+        return x, y
+
+    bucket = int(np.ceil(x.size / max_points))
+    usable = (x.size // bucket) * bucket
+    head_y = y[:usable].reshape(-1, bucket)
+    head_x = x[:usable].reshape(-1, bucket)
+    peak_offsets = np.argmax(head_y, axis=1)
+    rows = np.arange(head_y.shape[0])
+
+    kept_x = head_x[rows, peak_offsets]
+    kept_y = head_y[rows, peak_offsets]
+
+    if usable < x.size:
+        tail_index = usable + int(np.argmax(y[usable:]))
+        kept_x = np.append(kept_x, x[tail_index])
+        kept_y = np.append(kept_y, y[tail_index])
+
+    return kept_x, kept_y
+
 
 def build_annotated_envelope_figure(
     env_frequencies: Sequence[float] | np.ndarray,
@@ -45,6 +80,7 @@ def build_annotated_envelope_figure(
     matched: Optional[dict[str, Any]] = None,
     tolerance_pct: float = 5.0,
     max_freq: Optional[float] = None,
+    max_points: int = _MAX_TRACE_POINTS,
 ) -> dict[str, Any]:
     """Build the annotated envelope spectrum as renderer-agnostic data.
 
@@ -64,6 +100,10 @@ def build_annotated_envelope_figure(
             diagnosis did not make.
         max_freq: Upper edge of the frequency axis. ``None`` extends the axis
             to cover every characteristic frequency.
+        max_points: Cap on trace points. A long acquisition at a high
+            sampling rate resolves the plotted band far more finely than any
+            screen or page can show, and every extra point is bytes in a
+            document meant to be emailed.
 
     Returns:
         A JSON-serialisable figure description: axis data, tolerance bands,
@@ -93,8 +133,7 @@ def build_annotated_envelope_figure(
     axis_max = _resolve_axis_max(freqs, defects, max_freq)
 
     mask = freqs <= axis_max
-    x = freqs[mask]
-    y_linear = mags[mask]
+    x, y_linear = _decimate_preserving_peaks(freqs[mask], mags[mask], max_points)
     peak = float(np.max(y_linear))
     if peak <= 0.0:
         y_db = np.zeros_like(y_linear)

--- a/src/figures.py
+++ b/src/figures.py
@@ -1,0 +1,240 @@
+"""Explanatory figures for diagnostic reports.
+
+A figure earns its place in a report only if removing it would weaken a
+conclusion. The annotated envelope spectrum earns its place: it is where a
+reader sees that the dominant peak falls inside one characteristic-frequency
+band and outside the other three, drawn against the same tolerance the verdict
+used.
+
+Figures are built as plain data — lists, floats, strings — rather than as
+rendered output, for two reasons. Both the HTML and the PDF rendering consume
+the same structure, so neither can quietly show something the other does not;
+and the annotation lives in the figure data rather than in a hover interaction,
+so the argument survives a static export.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional, Sequence
+
+import numpy as np
+
+#: Figure kind discriminator, so a renderer can dispatch without guessing.
+ANNOTATED_ENVELOPE = "annotated_envelope_spectrum"
+
+#: Keys that ride along in a bearing-frequency dict without being defect
+#: frequencies. Drawing shaft speed as a fault band would invent a defect.
+_NON_FAULT_KEYS = frozenset({"shaft_freq_hz", "shaft_frequency_hz", "rpm"})
+
+#: Default upper edge of the frequency axis. Bearing defect frequencies for
+#: industrial rolling-element bearings sit well below this; the axis extends
+#: automatically when a characteristic frequency would otherwise fall outside.
+_DEFAULT_MAX_FREQ_HZ = 500.0
+
+_FLOOR_DB = 1e-12
+
+#: Decimal places kept on band edges. Coarser rounding makes the drawn band
+#: width diverge from the tolerance it claims to represent.
+_BAND_PRECISION = 6
+
+
+def build_annotated_envelope_figure(
+    env_frequencies: Sequence[float] | np.ndarray,
+    env_magnitudes: Sequence[float] | np.ndarray,
+    bearing_frequencies: Optional[dict[str, float]] = None,
+    matched: Optional[dict[str, Any]] = None,
+    tolerance_pct: float = 5.0,
+    max_freq: Optional[float] = None,
+) -> dict[str, Any]:
+    """Build the annotated envelope spectrum as renderer-agnostic data.
+
+    Args:
+        env_frequencies: Envelope spectrum frequency axis (Hz).
+        env_magnitudes: Envelope spectrum magnitudes, linear scale.
+        bearing_frequencies: Characteristic frequencies keyed by acronym
+            (``BPFO``, ``BPFI``, ``BSF``, ``FTF``). Non-defect entries such as
+            ``shaft_freq_hz`` are ignored. ``None`` produces a plain spectrum
+            with a caption saying why it carries no bands.
+        matched: The check that matched, as ``{"fault_type": ...,
+            "measured_hz": ..., "deviation_pct": ...}``. Its band and
+            annotation are flagged so a renderer can emphasise them.
+        tolerance_pct: The matching tolerance, drawn as the band half-width.
+            This must be the tolerance the verdict actually used — a figure
+            drawn against a different tolerance would show a match the
+            diagnosis did not make.
+        max_freq: Upper edge of the frequency axis. ``None`` extends the axis
+            to cover every characteristic frequency.
+
+    Returns:
+        A JSON-serialisable figure description: axis data, tolerance bands,
+        annotations, the labels that fell outside the axis, and a caption.
+
+    Raises:
+        ValueError: If the spectrum is empty or the two arrays disagree in
+            length — a figure drawn from a malformed spectrum would look
+            exactly like a figure drawn from a real one.
+    """
+    freqs = np.asarray(env_frequencies, dtype=float)
+    mags = np.asarray(env_magnitudes, dtype=float)
+
+    if freqs.size == 0 or mags.size == 0:
+        raise ValueError(
+            "Cannot build an envelope figure from an empty spectrum — pass "
+            "the frequency and magnitude arrays from compute_envelope_spectrum."
+        )
+    if freqs.size != mags.size:
+        raise ValueError(
+            f"Envelope frequency and magnitude arrays disagree in length "
+            f"({freqs.size} vs {mags.size}); they must come from the same "
+            f"spectrum computation."
+        )
+
+    defects = _defect_frequencies(bearing_frequencies)
+    axis_max = _resolve_axis_max(freqs, defects, max_freq)
+
+    mask = freqs <= axis_max
+    x = freqs[mask]
+    y_linear = mags[mask]
+    peak = float(np.max(y_linear))
+    if peak <= 0.0:
+        y_db = np.zeros_like(y_linear)
+    else:
+        y_db = 20.0 * np.log10((y_linear + _FLOOR_DB) / peak)
+
+    matched_label = (matched or {}).get("fault_type")
+    bands: list[dict[str, Any]] = []
+    annotations: list[dict[str, Any]] = []
+    omitted: list[str] = []
+
+    for label, center in defects:
+        if center > axis_max:
+            omitted.append(label)
+            continue
+        half = center * tolerance_pct / 100.0
+        is_matched = label == matched_label
+        bands.append(
+            {
+                "label": label,
+                "center_hz": round(center, _BAND_PRECISION),
+                # Rounded at a precision fine enough that the band edges still
+                # span exactly 2x the tolerance — rounding the two edges more
+                # coarsely distorts the width the reader is asked to trust.
+                "low_hz": round(center - half, _BAND_PRECISION),
+                "high_hz": round(center + half, _BAND_PRECISION),
+                "matched": is_matched,
+            }
+        )
+        annotations.append(
+            {
+                "label": label,
+                "x": round(center, _BAND_PRECISION),
+                "y": _local_peak_db(x, y_db, center - half, center + half),
+                "text": _annotation_text(label, center, matched if is_matched else None),
+                "matched": is_matched,
+            }
+        )
+
+    return {
+        "kind": ANNOTATED_ENVELOPE,
+        "x": [round(float(v), 4) for v in x],
+        "y": [round(float(v), 4) for v in y_db],
+        "x_label": "Frequency (Hz)",
+        "y_label": "Envelope amplitude (dB relative to peak)",
+        "tolerance_pct": tolerance_pct,
+        "bands": bands,
+        "annotations": annotations,
+        "omitted_labels": omitted,
+        "caption": _caption(bands, omitted, tolerance_pct, matched),
+    }
+
+
+def _defect_frequencies(
+    bearing_frequencies: Optional[dict[str, float]],
+) -> list[tuple[str, float]]:
+    """Return defect frequencies in ascending order, excluding shaft speed."""
+    if not bearing_frequencies:
+        return []
+    entries = [
+        (label, float(value))
+        for label, value in bearing_frequencies.items()
+        if label not in _NON_FAULT_KEYS and value and float(value) > 0.0
+    ]
+    return sorted(entries, key=lambda item: item[1])
+
+
+def _resolve_axis_max(
+    freqs: np.ndarray,
+    defects: list[tuple[str, float]],
+    max_freq: Optional[float],
+) -> float:
+    """Choose the frequency axis upper edge."""
+    spectrum_max = float(np.max(freqs))
+    if max_freq is not None:
+        return min(float(max_freq), spectrum_max)
+
+    wanted = _DEFAULT_MAX_FREQ_HZ
+    if defects:
+        # Leave headroom past the highest defect band so it is not clipped at
+        # the axis edge, where a reader cannot see which side the peak is on.
+        wanted = max(wanted, defects[-1][1] * 1.25)
+    return min(wanted, spectrum_max)
+
+
+def _local_peak_db(
+    x: np.ndarray, y_db: np.ndarray, low: float, high: float
+) -> float:
+    """Height at which to anchor a band's annotation."""
+    window = (x >= low) & (x <= high)
+    if not window.any():
+        return round(float(np.min(y_db)), 4)
+    return round(float(np.max(y_db[window])), 4)
+
+
+def _annotation_text(
+    label: str, center: float, matched: Optional[dict[str, Any]]
+) -> str:
+    """Annotation copy — carries the numbers, so a static export still argues."""
+    if not matched:
+        return f"{label} {center:.2f} Hz"
+
+    measured = matched.get("measured_hz")
+    deviation = matched.get("deviation_pct")
+    text = f"{label} {center:.2f} Hz — peak at {measured:.1f} Hz"
+    if deviation is not None:
+        text += f" ({deviation:.2f}% off)"
+    return text
+
+
+def _caption(
+    bands: list[dict[str, Any]],
+    omitted: list[str],
+    tolerance_pct: float,
+    matched: Optional[dict[str, Any]],
+) -> str:
+    """Author the sentence that says what the figure is evidence of."""
+    if not bands:
+        return (
+            "Envelope spectrum. No bearing designation was supplied, so no "
+            "characteristic-frequency bands are drawn and a peak cannot be "
+            "attributed to a specific bearing element from this figure."
+        )
+
+    labels = ", ".join(band["label"] for band in bands)
+    caption = (
+        f"Envelope spectrum with the {labels} characteristic frequencies "
+        f"overlaid. Each shaded band is the ±{tolerance_pct:g}% matching "
+        f"tolerance used by the diagnosis, so a peak inside a band is a match "
+        f"and a peak outside every band is not."
+    )
+    if matched and matched.get("fault_type"):
+        caption += (
+            f" The dominant peak falls inside the {matched['fault_type']} "
+            f"band and outside the others."
+        )
+    if omitted:
+        caption += (
+            f" {', '.join(omitted)} lies beyond the plotted range and is not "
+            f"shown."
+        )
+    return caption

--- a/src/html_templates.py
+++ b/src/html_templates.py
@@ -11,32 +11,52 @@ from typing import Dict, List, Any, Optional
 def get_base_template(
     title: str,
     content: str,
-    metadata: Optional[Dict[str, Any]] = None
+    metadata: Optional[Dict[str, Any]] = None,
+    include_plotly: bool = True
 ) -> str:
     """
     Base HTML template with professional styling.
-    
+
     Args:
         title: Report title
         content: Main HTML content
         metadata: Optional metadata dict (stored as JSON in data attribute)
-    
+        include_plotly: Load Plotly from CDN. The per-analysis reports need it
+            for their interactive charts. Reports that must open with no
+            network access pass ``False`` and draw with inline SVG instead —
+            a document that fetches a script is not self-contained.
+
     Returns:
         Complete HTML document
     """
+    import html as _html
     import json
-    
-    metadata_json = json.dumps(metadata or {}, indent=2)
+
+    # Titles carry signal identifiers, which originate in user input. The
+    # <title> element is not a raw-HTML slot the way `content` is.
+    safe_title = _html.escape(str(title))
+
+    # Inside a <script> block the JSON is parsed by the HTML tokenizer first,
+    # so a literal "</script>" sequence in any value would close the element
+    # early. "<\/" is a valid JSON escape for "</" and is inert in HTML.
+    metadata_json = json.dumps(metadata or {}, indent=2, default=str).replace(
+        "</", "<\\/"
+    )
     metadata_section = f'<script type="application/json" id="report-metadata">\n{metadata_json}\n</script>'
-    
+    plotly_tag = (
+        '<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>'
+        if include_plotly
+        else '<!-- self-contained: no external scripts -->'
+    )
+
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="Predictive Maintenance MCP Server">
-    <title>{title}</title>
-    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+    <title>{safe_title}</title>
+    {plotly_tag}
     <style>
         * {{
             margin: 0;

--- a/src/integrated_report.py
+++ b/src/integrated_report.py
@@ -1,0 +1,319 @@
+"""Integrated diagnostic report template.
+
+This module places strings; it never composes them. Every evaluative sentence
+it renders arrives already written from
+:mod:`.decision_support.advisory`, and the template's only job is layout.
+
+The analogy that shaped it is the radiology report: an annotated image, the
+findings, the impression, the recommendation — and nobody expects the imaging
+software to write the impression. What this template contributes is the
+annotation and the arrangement, not the judgement.
+
+It lives outside :mod:`.html_templates` for two reasons: that module is
+already long and is excluded from the coverage gate, and this one is the
+report whose contract most needs test coverage.
+"""
+
+from __future__ import annotations
+
+import html
+from typing import Any, Optional
+
+from .figures import figure_to_svg
+from .html_templates import get_base_template
+
+_URGENCY_BADGE = {
+    "low": "badge-success",
+    "medium": "badge-warning",
+    "high": "badge-warning",
+    "critical": "badge-danger",
+}
+
+_STATUS_BADGE = {
+    "assessed": "badge-info",
+    "refused": "badge-warning",
+    "absent": "badge-warning",
+}
+
+_MUTED = "color:var(--text-secondary);"
+
+
+def _esc(value: Any) -> str:
+    """Escape a value for HTML. Signal ids reach this template from user input."""
+    return html.escape(str(value if value is not None else ""))
+
+
+def _remedy_paragraph(remedy: Optional[str]) -> str:
+    if not remedy:
+        return ""
+    return (
+        f'<p style="margin-top:0.75rem;{_MUTED}">'
+        f"<strong>To resolve:</strong> {_esc(remedy)}</p>"
+    )
+
+
+def _status_badge(status: Optional[str]) -> str:
+    css = _STATUS_BADGE.get(status or "", "badge-info")
+    return (
+        f'<span class="badge {css}" style="margin-left:0.5rem;">'
+        f"{_esc(status)}</span>"
+    )
+
+
+def _block_card(title: str, block: dict[str, Any]) -> str:
+    """Render one indicator block, including its authored absence statement.
+
+    A block whose input was missing still renders. A silently omitted section
+    reads as "nothing to report", which is a different claim from "this could
+    not be determined, and here is what that costs you".
+    """
+    return (
+        '<div class="card">'
+        f'<h2 class="card-title">{_esc(title)}'
+        f'{_status_badge(block.get("status"))}</h2>'
+        f'<p>{_esc(block.get("statement"))}</p>'
+        f'{_remedy_paragraph(block.get("remedy"))}'
+        "</div>"
+    )
+
+
+def _bearing_table(block: dict[str, Any]) -> str:
+    """Calculated against measured, with a verdict per bearing element.
+
+    Putting the two numbers side by side is what lets a reader check the
+    match rather than accept it.
+    """
+    rows = block.get("rows") or []
+    if not rows:
+        return ""
+
+    cells = []
+    for row in rows:
+        measured = (
+            f"{row['measured_hz']:.2f} Hz" if row.get("measured_hz") else "&mdash;"
+        )
+        deviation = (
+            f"{row['deviation_pct']:.2f}%"
+            if row.get("deviation_pct") is not None
+            else "&mdash;"
+        )
+        verdict_css = "badge-danger" if row["matched"] else "badge-success"
+        verdict_text = "match" if row["matched"] else "no match"
+        cells.append(
+            "<tr>"
+            f"<td>{_esc(row['fault_type'])}</td>"
+            f"<td>{row['expected_hz']:.2f} Hz</td>"
+            f"<td>{measured}</td>"
+            f"<td>{deviation}</td>"
+            f'<td><span class="badge {verdict_css}">{verdict_text}</span></td>'
+            "</tr>"
+        )
+
+    return (
+        '<div class="card">'
+        '<h2 class="card-title">Calculated against measured</h2>'
+        '<table style="width:100%;border-collapse:collapse;">'
+        '<thead><tr style="text-align:left;border-bottom:2px solid var(--border-color);">'
+        "<th>Element</th><th>Calculated</th><th>Measured</th>"
+        "<th>Deviation</th><th>Verdict</th></tr></thead>"
+        f'<tbody>{"".join(cells)}</tbody>'
+        "</table></div>"
+    )
+
+
+def _figure_card(figure: Optional[dict[str, Any]]) -> str:
+    """The figure that closes the matching argument, or a note that it is absent."""
+    if not figure:
+        return (
+            '<div class="card">'
+            '<h2 class="card-title">Envelope spectrum</h2>'
+            "<p>This report carries no envelope spectrum figure, so the "
+            "frequency match cannot be checked visually here &mdash; only "
+            "against the values in the table above.</p>"
+            "</div>"
+        )
+
+    return (
+        '<div class="chart-container">'
+        '<h2 class="card-title">Envelope spectrum</h2>'
+        f"{figure_to_svg(figure)}"
+        f'<p style="margin-top:1rem;{_MUTED}font-size:0.9rem;">'
+        f'{_esc(figure["caption"])}</p>'
+        "</div>"
+    )
+
+
+def _recommendations_card(recommendations: list[dict[str, Any]]) -> str:
+    """Each action with the reasoning and the evidence it rests on."""
+    if not recommendations:
+        return ""
+
+    items = []
+    for rec in recommendations:
+        urgency = rec.get("urgency", "medium")
+        badge = _URGENCY_BADGE.get(urgency, "badge-info")
+        evidence = "".join(
+            f'<p style="margin-top:0.25rem;{_MUTED}font-size:0.9rem;">'
+            f"Evidence: {_esc(item)}</p>"
+            for item in rec.get("evidence", [])
+        )
+        items.append(
+            '<div style="padding:1rem 0;border-bottom:1px solid var(--border-color);">'
+            '<p style="font-weight:600;font-size:1.05rem;">'
+            f'<span class="badge {badge}" style="margin-right:0.5rem;">'
+            f"{_esc(urgency)}</span>{_esc(rec['action'])}</p>"
+            f'<p style="margin-top:0.4rem;">{_esc(rec.get("description"))}</p>'
+            f'<p style="margin-top:0.4rem;{_MUTED}">'
+            f"<strong>Why:</strong> {_esc(rec.get('motivation'))}</p>"
+            f"{evidence}</div>"
+        )
+
+    return (
+        '<div class="card">'
+        '<h2 class="card-title">Recommended actions</h2>'
+        f'{"".join(items)}</div>'
+    )
+
+
+def _baseline_card(baseline: dict[str, Any]) -> str:
+    deltas = "".join(
+        f'<li style="margin-bottom:0.4rem;">{_esc(delta["statement"])}</li>'
+        for delta in baseline.get("deltas", [])
+    )
+    delta_list = (
+        f'<ul style="margin-top:0.75rem;padding-left:1.25rem;">{deltas}</ul>'
+        if deltas
+        else ""
+    )
+    return (
+        '<div class="card">'
+        '<h2 class="card-title">Comparison with baseline'
+        f'{_status_badge(baseline.get("status"))}</h2>'
+        f'<p>{_esc(baseline.get("statement"))}</p>'
+        f"{delta_list}"
+        f'{_remedy_paragraph(baseline.get("remedy"))}'
+        "</div>"
+    )
+
+
+def _iso_card(iso: dict[str, Any]) -> str:
+    note = (
+        f'<p style="margin-top:0.75rem;font-size:0.875rem;{_MUTED}">'
+        f'{_esc(iso["standard_note"])}</p>'
+        if iso.get("standard_note")
+        else ""
+    )
+    return (
+        '<div class="card">'
+        '<h2 class="card-title">ISO severity'
+        f'{_status_badge(iso.get("status"))}</h2>'
+        f'<p>{_esc(iso.get("statement"))}</p>'
+        f"{note}"
+        f'{_remedy_paragraph(iso.get("remedy"))}'
+        "</div>"
+    )
+
+
+def _evidence_card(evidence: dict[str, Any]) -> str:
+    items = "".join(
+        f'<li style="margin-bottom:0.5rem;">{_esc(item)}</li>'
+        for item in evidence["statements"]
+    )
+    return (
+        '<div class="card">'
+        '<h2 class="card-title">Evidence</h2>'
+        f'<p><strong>Evidence strength: {_esc(evidence["strength"])}</strong></p>'
+        f'<p style="{_MUTED}font-size:0.9rem;margin-top:0.25rem;">'
+        f'{_esc(evidence["strength_explanation"])}</p>'
+        f'<ul style="margin-top:0.9rem;padding-left:1.25rem;">{items}</ul>'
+        "</div>"
+    )
+
+
+def _provenance_card(provenance: dict[str, Any], generated_at: str) -> str:
+    fields = [
+        ("Signal", provenance.get("signal_id")),
+        ("Shaft speed (RPM)", provenance.get("rpm")),
+        ("Bearing", provenance.get("bearing_id")),
+        (
+            "ISO machine group / support",
+            f"{provenance.get('machine_group')} / {provenance.get('support_type')}",
+        ),
+        ("Server version", provenance.get("server_version")),
+        ("Generated", generated_at),
+    ]
+    cells = "".join(
+        '<div class="info-item">'
+        f'<div class="info-label">{_esc(label)}</div>'
+        f'<div class="info-value" style="font-size:1rem;">{_esc(value)}</div>'
+        "</div>"
+        for label, value in fields
+    )
+    return (
+        '<div class="card">'
+        '<h2 class="card-title">Provenance</h2>'
+        f'<div class="info-grid">{cells}</div>'
+        "</div>"
+    )
+
+
+def create_integrated_diagnostic_report(
+    advisory: dict[str, Any],
+    figure: Optional[dict[str, Any]] = None,
+    generated_at: str = "",
+) -> str:
+    """Render the server-authored advisory as one integrated document.
+
+    Args:
+        advisory: Payload from
+            :func:`.decision_support.advisory.build_advisory`. Every
+            evaluative string rendered here comes from it.
+        figure: Optional description from
+            :func:`.figures.build_annotated_envelope_figure`.
+        generated_at: Generation timestamp, passed in rather than read from
+            the clock. Reproducibility is a claim about content, and a
+            template that reads the clock cannot make it.
+
+    Returns:
+        A complete, self-contained HTML document with no external references.
+    """
+    verdict = advisory["verdict"]
+
+    disagreements = "".join(
+        '<div class="card" style="border-left:4px solid var(--warning-color);">'
+        '<h2 class="card-title">Indicators disagree</h2>'
+        f'<p>{_esc(entry["statement"])}</p></div>'
+        for entry in advisory["disagreements"]
+    )
+
+    content = (
+        '<div class="header"><div class="header-content">'
+        f'<h1>Diagnostic report &mdash; {_esc(advisory["signal_id"])}</h1>'
+        f'<p class="subtitle">{_esc(verdict["statement"])}</p>'
+        "</div></div>"
+        '<div class="container">'
+        f"{_evidence_card(advisory['evidence'])}"
+        f"{_iso_card(advisory['iso'])}"
+        f"{disagreements}"
+        f"{_block_card('Bearing frequency matching', advisory['bearing_match'])}"
+        f"{_bearing_table(advisory['bearing_match'])}"
+        f"{_figure_card(figure)}"
+        f"{_block_card('Anomaly detection', advisory['anomaly'])}"
+        f"{_block_card('Spectral energy distribution', advisory['spectral_energy'])}"
+        f"{_baseline_card(advisory['baseline_comparison'])}"
+        f"{_recommendations_card(advisory['recommendations'])}"
+        f"{_provenance_card(advisory['provenance'], generated_at)}"
+        "</div>"
+    )
+
+    return get_base_template(
+        title=f"Diagnostic report - {advisory['signal_id']}",
+        content=content,
+        metadata={
+            "report_type": "integrated_diagnostic",
+            "provenance": advisory["provenance"],
+            "verdict": verdict,
+            "evidence_strength": advisory["evidence"]["strength"],
+        },
+        include_plotly=False,
+    )

--- a/src/mcp_tools/report_tools.py
+++ b/src/mcp_tools/report_tools.py
@@ -15,10 +15,16 @@ from scipy.signal import hilbert, butter, sosfiltfilt
 from mcp.server.mcpserver import MCPServer, Context
 
 from ..config import MODELS_DIR, REPORTS_DIR
+from ..decision_support.advisory import build_advisory
+from ..decision_support.diagnosis_pipeline import (
+    diagnose_vibration as _diagnose_vibration,
+)
+from ..figures import build_annotated_envelope_figure
 from ..models import StoredSignalInfo
 from ..report_generator import (
     save_fft_report,
     save_envelope_report,
+    save_integrated_diagnostic_report,
     save_iso_report,
     read_report_metadata,
     list_reports,
@@ -31,7 +37,11 @@ from ._utils import resolve_model_paths, resolve_signal
 # Canonical modular twin of the ISO evaluation tool (module-level function
 # since U6) — replaces the former runtime import from the deprecated monolith.
 from .diagnostics_tools import assess_severity
-from ..signal_processing.spectral import validate_bandpass_band
+from ..signal_processing.spectral import (
+    envelope_spectrum_arrays,
+    resolve_envelope_band,
+    validate_bandpass_band,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -999,8 +1009,207 @@ async def generate_feature_comparison_report(
     }
 
 
+#: Frequency tolerance used by the bearing matching engine. The figure draws
+#: this exact value, so a reader sees the tolerance the verdict applied.
+_MATCH_TOLERANCE_PCT = 5.0
+
+#: Renderings this tool can emit. HTML is self-contained and needs nothing
+#: extra; PDF needs the optional ``[pdf]`` extra.
+_SUPPORTED_FORMATS = ("html", "pdf")
+
+
+def _matched_check(diagnosis: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """The strongest matching fault check, for figure emphasis."""
+    faults = diagnosis.get("bearing_faults")
+    if not faults:
+        return None
+    order = {"high": 3, "moderate": 2, "low": 1}
+    detected = [
+        check
+        for check in faults.get("fault_checks", [])
+        if check.get("detected") and check.get("detected_frequency_hz")
+    ]
+    if not detected:
+        return None
+    best = max(detected, key=lambda c: order.get(c.get("evidence_strength"), 0))
+    return {
+        "fault_type": best["fault_type"],
+        "measured_hz": best["detected_frequency_hz"],
+        "deviation_pct": best.get("deviation_pct"),
+    }
+
+
+def _envelope_figure(
+    signal: np.ndarray, fs: float, diagnosis: dict[str, Any]
+) -> dict[str, Any]:
+    """Build the annotated envelope spectrum for this diagnosis.
+
+    Uses the same spectrum computation the bearing matching consumed, so the
+    figure cannot show a peak the verdict never saw.
+    """
+    band = resolve_envelope_band(fs, None)
+    env_frequencies, env_magnitudes = envelope_spectrum_arrays(signal, fs, band)
+    faults = diagnosis.get("bearing_faults") or {}
+    return build_annotated_envelope_figure(
+        env_frequencies,
+        env_magnitudes,
+        faults.get("bearing_frequencies"),
+        matched=_matched_check(diagnosis),
+        tolerance_pct=_MATCH_TOLERANCE_PCT,
+    )
+
+
+async def generate_diagnostic_report(
+    signal_id: str,
+    rpm: float,
+    bearing_id: Optional[str] = None,
+    machine_group: Literal[1, 2] = 2,
+    support_type: Literal["rigid", "flexible"] = "rigid",
+    baseline_signal_id: Optional[str] = None,
+    formats: Optional[list[str]] = None,
+    ctx: Context | None = None,
+) -> dict[str, Any]:
+    """Generate the integrated diagnostic report — one document, whole case.
+
+    Runs the full diagnosis, then renders signal overview, ISO severity,
+    anomaly state, characteristic-frequency matching, spectral energy, an
+    annotated envelope spectrum, and recommended actions into a single
+    self-contained document.
+
+    AUTHORSHIP CONTRACT — this matters more than it may appear. Every
+    evaluative sentence in the returned ``statements`` list was written by
+    this server. Reuse them verbatim when presenting the result. Do NOT coin
+    standard names, machine classes, severity zones, or confidence levels of
+    your own: this server deliberately publishes no confidence figure, and
+    the standards caveat that travels with every severity verdict must not be
+    dropped or paraphrased. If a question is not answered by these
+    statements, say so rather than filling the gap.
+
+    Unlike ``generate_diagnostic_report_docx``, this tool takes no content
+    sections from the caller. Supply the analysis inputs; the wording is the
+    server's.
+
+    Args:
+        signal_id: ID of the stored signal (from load_signal).
+        rpm: Machine operating speed in RPM.
+        bearing_id: Bearing designation for characteristic-frequency
+            matching. Omitted means the matching section states why it was
+            not attempted rather than disappearing.
+        machine_group: ISO 20816-3 group — 1 (large, >300 kW) or 2 (medium,
+            15-300 kW). Default 2.
+        support_type: 'rigid' or 'flexible'. Default 'rigid'.
+        baseline_signal_id: Optional stored signal from the same machine in a
+            known-good state. Supplying it turns absolute readings into
+            deltas, which is what tells a reader whether a condition is new
+            or stable.
+        formats: Renderings to produce — any of 'html', 'pdf'. Defaults to
+            ['html']. 'pdf' requires
+            ``pip install predictive-maintenance-mcp[pdf]``.
+        ctx: MCP context.
+
+    Returns:
+        Dict with ``statements`` (every authored sentence, in document
+        order), ``files`` (one entry per rendering), ``verdict``,
+        ``evidence_strength``, and ``provenance``.
+
+    Raises:
+        ValueError: If a signal id is not loaded, has no sampling rate, or an
+            unsupported format is requested.
+    """
+    requested = [fmt.lower() for fmt in (formats or ["html"])]
+    unsupported = [fmt for fmt in requested if fmt not in _SUPPORTED_FORMATS]
+    if unsupported:
+        raise ValueError(
+            f"Unsupported report format(s) {unsupported} — choose from "
+            f"{list(_SUPPORTED_FORMATS)}."
+        )
+
+    signal_data, info = resolve_signal(signal_id)
+    if ctx:
+        await ctx.info(f"Diagnosing '{signal_id}' at {rpm} RPM")
+
+    diagnosis = _diagnose_vibration(
+        signal=signal_data,
+        fs=info.sampling_rate,
+        rpm=rpm,
+        signal_id=signal_id,
+        bearing_id=bearing_id,
+        machine_group=machine_group,
+        support_type=support_type,
+        signal_unit=info.signal_unit,
+    )
+
+    baseline_diagnosis = None
+    if baseline_signal_id:
+        baseline_data, baseline_info = resolve_signal(baseline_signal_id)
+        if ctx:
+            await ctx.info(f"Diagnosing baseline '{baseline_signal_id}'")
+        baseline_diagnosis = _diagnose_vibration(
+            signal=baseline_data,
+            fs=baseline_info.sampling_rate,
+            rpm=rpm,
+            signal_id=baseline_signal_id,
+            bearing_id=bearing_id,
+            machine_group=machine_group,
+            support_type=support_type,
+            signal_unit=baseline_info.signal_unit,
+        )
+
+    advisory = build_advisory(diagnosis, baseline_diagnosis)
+    figure = _envelope_figure(signal_data, info.sampling_rate, diagnosis)
+
+    files: list[dict[str, Any]] = []
+    html_result = save_integrated_diagnostic_report(advisory, figure)
+    if "html" in requested:
+        files.append(
+            {
+                "format": "html",
+                "file_path": html_result["file_path"],
+                "file_name": html_result["file_name"],
+                "file_size_kb": html_result["file_size_kb"],
+            }
+        )
+    else:
+        Path(html_result["file_path"]).unlink(missing_ok=True)
+
+    if "pdf" in requested:
+        from ..report_generator import save_integrated_diagnostic_report_pdf
+
+        pdf_result = save_integrated_diagnostic_report_pdf(advisory, figure)
+        files.append(
+            {
+                "format": "pdf",
+                "file_path": pdf_result["file_path"],
+                "file_name": pdf_result["file_name"],
+                "file_size_kb": pdf_result["file_size_kb"],
+            }
+        )
+
+    if ctx:
+        for entry in files:
+            await ctx.info(f"{entry['format'].upper()} report: {entry['file_name']}")
+
+    return {
+        "signal_id": signal_id,
+        "verdict": advisory["verdict"]["statement"],
+        "fault_canonical": advisory["verdict"]["fault_canonical"],
+        "evidence_strength": advisory["evidence"]["strength"],
+        "evidence_strength_note": advisory["evidence"]["strength_explanation"],
+        "statements": html_result["statements"],
+        "recommendations": advisory["recommendations"],
+        "provenance": advisory["provenance"],
+        "files": files,
+        "authorship_note": (
+            "These statements were authored by the server. Reuse them "
+            "verbatim; do not introduce standard names, machine classes, "
+            "zones, or confidence levels that do not appear here."
+        ),
+    }
+
+
 def register(mcp: MCPServer) -> None:
     """Register report generation and visualization tools with the MCP server."""
+    mcp.tool()(generate_diagnostic_report)
     mcp.tool()(generate_diagnostic_report_docx)
     mcp.tool()(plot_signal)
     mcp.tool()(generate_fft_report)

--- a/src/mcp_tools/report_tools.py
+++ b/src/mcp_tools/report_tools.py
@@ -1158,32 +1158,8 @@ async def generate_diagnostic_report(
     advisory = build_advisory(diagnosis, baseline_diagnosis)
     figure = _envelope_figure(signal_data, info.sampling_rate, diagnosis)
 
-    files: list[dict[str, Any]] = []
-    html_result = save_integrated_diagnostic_report(advisory, figure)
-    if "html" in requested:
-        files.append(
-            {
-                "format": "html",
-                "file_path": html_result["file_path"],
-                "file_name": html_result["file_name"],
-                "file_size_kb": html_result["file_size_kb"],
-            }
-        )
-    else:
-        Path(html_result["file_path"]).unlink(missing_ok=True)
-
-    if "pdf" in requested:
-        from ..report_generator import save_integrated_diagnostic_report_pdf
-
-        pdf_result = save_integrated_diagnostic_report_pdf(advisory, figure)
-        files.append(
-            {
-                "format": "pdf",
-                "file_path": pdf_result["file_path"],
-                "file_name": pdf_result["file_name"],
-                "file_size_kb": pdf_result["file_size_kb"],
-            }
-        )
+    saved = save_integrated_diagnostic_report(advisory, figure, formats=requested)
+    files = saved["files"]
 
     if ctx:
         for entry in files:
@@ -1195,7 +1171,7 @@ async def generate_diagnostic_report(
         "fault_canonical": advisory["verdict"]["fault_canonical"],
         "evidence_strength": advisory["evidence"]["strength"],
         "evidence_strength_note": advisory["evidence"]["strength_explanation"],
-        "statements": html_result["statements"],
+        "statements": saved["statements"],
         "recommendations": advisory["recommendations"],
         "provenance": advisory["provenance"],
         "files": files,

--- a/src/report_generator.py
+++ b/src/report_generator.py
@@ -363,6 +363,65 @@ def save_iso_report(
     }
 
 
+def save_integrated_diagnostic_report(
+    advisory: Dict[str, Any],
+    figure: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """
+    Save the integrated diagnostic report as a self-contained HTML document.
+
+    Unlike the per-analysis reports, this one covers the whole case in a
+    single document and takes no caller-supplied content: every evaluative
+    sentence comes from the advisory payload, which the server authored.
+
+    Args:
+        advisory: Payload from ``decision_support.advisory.build_advisory``.
+        figure: Optional figure description from
+            ``figures.build_annotated_envelope_figure``.
+
+    Returns:
+        Dictionary with file path, the authored statements the document
+        renders, and report metadata.
+    """
+    from .decision_support.advisory import collect_statements
+    from .integrated_report import create_integrated_diagnostic_report
+
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    html = create_integrated_diagnostic_report(
+        advisory, figure, generated_at=generated_at
+    )
+
+    # safe_resolve is belt-and-braces: timestamped_report_name already
+    # flattens path separators out of the label, so a traversal-shaped signal
+    # id cannot steer the write. Both guards are cheap.
+    file_name = timestamped_report_name(
+        "diagnostic_report", str(advisory.get("signal_id", "signal"))
+    )
+    output_file = safe_resolve(REPORTS_DIR, file_name)
+    output_file.write_text(html, encoding="utf-8")
+
+    statements = collect_statements(advisory)
+    verdict = advisory["verdict"]
+
+    logger.info(f"Integrated diagnostic report saved: {output_file.name}")
+
+    return {
+        "file_path": str(output_file.absolute()),
+        "file_name": output_file.name,
+        "file_size_kb": output_file.stat().st_size / 1024,
+        "report_type": "integrated_diagnostic",
+        "signal_id": advisory.get("signal_id"),
+        "verdict": verdict["statement"],
+        "fault_canonical": verdict.get("fault_canonical"),
+        "evidence_strength": advisory["evidence"]["strength"],
+        "generated_at": generated_at,
+        "statements": statements,
+        "message": (
+            f"Integrated diagnostic report saved: {output_file.name}"
+        ),
+    }
+
+
 def read_report_metadata(file_name: str) -> Dict[str, Any]:
     """
     Read metadata from HTML report without loading entire file.

--- a/src/report_generator.py
+++ b/src/report_generator.py
@@ -12,7 +12,7 @@ import itertools
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, Sequence
 import json
 
 import numpy as np
@@ -38,6 +38,14 @@ try:
     HAS_DOCX = True
 except ImportError:
     HAS_DOCX = False
+
+# Optional PDF support. The PDF rendering converts the SAME HTML document the
+# HTML rendering writes, so the two cannot diverge in what they claim.
+try:
+    from weasyprint import HTML as WeasyHTML
+    HAS_PDF = True
+except ImportError:  # pragma: no cover - exercised by the missing-dep path
+    HAS_PDF = False
 
 
 #: Process-local sequence for report filenames — the Windows clock can
@@ -365,59 +373,97 @@ def save_iso_report(
 
 def save_integrated_diagnostic_report(
     advisory: Dict[str, Any],
-    figure: Optional[Dict[str, Any]] = None
+    figure: Optional[Dict[str, Any]] = None,
+    formats: Sequence[str] = ("html",)
 ) -> Dict[str, Any]:
     """
-    Save the integrated diagnostic report as a self-contained HTML document.
+    Save the integrated diagnostic report in one or more renderings.
 
     Unlike the per-analysis reports, this one covers the whole case in a
     single document and takes no caller-supplied content: every evaluative
     sentence comes from the advisory payload, which the server authored.
 
+    Both renderings come from ONE rendered HTML string. That is why the two
+    files cannot claim different things — the PDF is a rendering of the same
+    document rather than a second layout of the same data, so there is no
+    second code path in which a statement could be dropped or reworded.
+
     Args:
         advisory: Payload from ``decision_support.advisory.build_advisory``.
         figure: Optional figure description from
             ``figures.build_annotated_envelope_figure``.
+        formats: Renderings to write — any of 'html', 'pdf'.
 
     Returns:
-        Dictionary with file path, the authored statements the document
-        renders, and report metadata.
+        Dictionary with ``files`` (one entry per rendering), the authored
+        statements the document renders, and report metadata. ``file_path``
+        and ``file_name`` name the first rendering, for symmetry with the
+        other save_* functions.
+
+    Raises:
+        ValueError: If a format is unknown, or if 'pdf' is requested and the
+            optional PDF dependency is not installed.
     """
     from .decision_support.advisory import collect_statements
     from .integrated_report import create_integrated_diagnostic_report
+
+    requested = [fmt.lower() for fmt in formats]
+    unknown = [fmt for fmt in requested if fmt not in ("html", "pdf")]
+    if unknown:
+        raise ValueError(
+            f"Unknown report format(s) {unknown} — choose from ['html', 'pdf']."
+        )
+    if "pdf" in requested and not HAS_PDF:
+        raise ValueError(
+            "PDF rendering requires the optional dependency: "
+            "pip install predictive-maintenance-mcp[pdf]. The HTML rendering "
+            "needs nothing extra."
+        )
 
     generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     html = create_integrated_diagnostic_report(
         advisory, figure, generated_at=generated_at
     )
+    label = str(advisory.get("signal_id", "signal"))
 
-    # safe_resolve is belt-and-braces: timestamped_report_name already
-    # flattens path separators out of the label, so a traversal-shaped signal
-    # id cannot steer the write. Both guards are cheap.
-    file_name = timestamped_report_name(
-        "diagnostic_report", str(advisory.get("signal_id", "signal"))
-    )
-    output_file = safe_resolve(REPORTS_DIR, file_name)
-    output_file.write_text(html, encoding="utf-8")
+    files: List[Dict[str, Any]] = []
+    for fmt in requested:
+        # safe_resolve is belt-and-braces: timestamped_report_name already
+        # flattens path separators out of the label, so a traversal-shaped
+        # signal id cannot steer the write. Both guards are cheap.
+        output_file = safe_resolve(
+            REPORTS_DIR, timestamped_report_name("diagnostic_report", label, fmt)
+        )
+        if fmt == "html":
+            output_file.write_text(html, encoding="utf-8")
+        else:
+            WeasyHTML(string=html).write_pdf(target=str(output_file))
+        files.append({
+            "format": fmt,
+            "file_path": str(output_file.absolute()),
+            "file_name": output_file.name,
+            "file_size_kb": output_file.stat().st_size / 1024,
+        })
+        logger.info(f"Integrated diagnostic report saved: {output_file.name}")
 
-    statements = collect_statements(advisory)
     verdict = advisory["verdict"]
-
-    logger.info(f"Integrated diagnostic report saved: {output_file.name}")
+    primary = files[0]
 
     return {
-        "file_path": str(output_file.absolute()),
-        "file_name": output_file.name,
-        "file_size_kb": output_file.stat().st_size / 1024,
+        "file_path": primary["file_path"],
+        "file_name": primary["file_name"],
+        "file_size_kb": primary["file_size_kb"],
+        "files": files,
         "report_type": "integrated_diagnostic",
         "signal_id": advisory.get("signal_id"),
         "verdict": verdict["statement"],
         "fault_canonical": verdict.get("fault_canonical"),
         "evidence_strength": advisory["evidence"]["strength"],
         "generated_at": generated_at,
-        "statements": statements,
+        "statements": collect_statements(advisory),
         "message": (
-            f"Integrated diagnostic report saved: {output_file.name}"
+            f"Integrated diagnostic report saved: "
+            f"{', '.join(f['file_name'] for f in files)}"
         ),
     }
 

--- a/src/server.py
+++ b/src/server.py
@@ -65,6 +65,23 @@ mcp = MCPServer(
     5) Always cite which analyses and thresholds support each conclusion. If data or parameters are missing, ask for them instead of guessing.
     6) NEVER suggest parameters, thresholds, or recommendations not explicitly provided in tool outputs or prompt workflows. Do NOT invent frequency ranges, filter settings, or maintenance actions. Only use guidance from STEP 6 of diagnostic prompts.
 
+    Report authorship policy (who is allowed to assert):
+    - generate_diagnostic_report returns a 'statements' list containing every
+      evaluative sentence the server wrote. Reuse those sentences verbatim
+      when presenting the result. You may lay them out, reorder them for
+      reading, and add visual emphasis; you may not rewrite what they claim.
+    - Do NOT coin standard names, editions, machine classes, or severity
+      zones. The severity verdict carries its own standard citation and a
+      mandatory provenance caveat; reproduce both, and never paraphrase or
+      drop the caveat.
+    - This server publishes NO confidence score and NO probability of
+      correctness. 'evidence_strength' is a count of independent
+      corroborating findings, not a confidence — render it as such, and never
+      convert it into a percentage, a probability, or a "confidence: high"
+      style label.
+    - If a question is not answered by the returned statements, say the
+      analysis does not answer it. Do not fill the gap.
+
     Signal unit policy (CRITICAL - declared units only, never guessed):
     - ISO 20816-3 severity verdicts on stored signals require a DECLARED unit:
       1. Explicit parameter: load_signal(signal_unit='g'|'m/s2'|'mm/s'|'m/s')

--- a/src/signal_processing/spectral.py
+++ b/src/signal_processing/spectral.py
@@ -186,6 +186,100 @@ def validate_bandpass_band(
         )
 
 
+def resolve_envelope_band(
+    fs: float, frequency_range: Optional[tuple[float, float]] = None
+) -> tuple[float, float]:
+    """Resolve and validate the envelope bandpass band.
+
+    Args:
+        fs: Sampling frequency (Hz).
+        frequency_range: Explicit band, or ``None`` for the fs-aware default.
+
+    Returns:
+        The (low, high) band edges in Hz.
+
+    Raises:
+        ValueError: If the band is invalid for this sampling rate.
+    """
+    nyquist = fs / 2.0
+    if frequency_range is None:
+        # fs-AWARE DEFAULT. Cap the upper edge just below Nyquist so the
+        # band never exceeds a low-fs signal's Nyquist. This clamp is a
+        # NO-OP at fs=10000 Hz (5000 -> nyquist-1 = 4999), the exact edge
+        # the historical (500, 5000) default already resolved to.
+        band_low, band_high = 500.0, min(5000.0, nyquist - 1.0)
+    else:
+        # An EXPLICIT band is honored verbatim (fail loud, never clamp).
+        band_low, band_high = float(frequency_range[0]), float(frequency_range[1])
+
+    # Single validation path. The explicit band is checked as requested (an
+    # upper edge above Nyquist is a hard error); the default is pre-capped,
+    # so it only trips when the band is genuinely unusable (low >= high at
+    # a very low fs).
+    validate_bandpass_band(band_low, band_high, fs)
+    return band_low, band_high
+
+
+def envelope_spectrum_arrays(
+    signal: np.ndarray,
+    fs: float,
+    frequency_range: Optional[tuple[float, float]] = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute the envelope spectrum and return its full arrays.
+
+    Extracted so that anything drawing the envelope spectrum draws the SAME
+    one the bearing fault matching consumed. A figure computed by a second,
+    subtly different route can show a peak the verdict never saw — and a
+    figure that disagrees with the verdict it illustrates is worse than no
+    figure at all.
+
+    Args:
+        signal: 1D time-domain signal.
+        fs: Sampling frequency (Hz).
+        frequency_range: Bandpass band (low, high) in Hz. ``None`` resolves
+            to the fs-aware default described in
+            :func:`compute_envelope_spectrum`.
+
+    Returns:
+        Tuple of (positive frequencies, magnitudes) — full arrays, not a
+        summary. Callers returning data to an LLM must summarise first.
+
+    Raises:
+        ValueError: If the requested or resolved band is invalid for this
+            sampling rate.
+    """
+    nyquist = fs / 2.0
+    band_low, band_high = resolve_envelope_band(fs, frequency_range)
+
+    low = band_low / nyquist
+    # A digital filter corner cannot sit exactly AT Nyquist: an upper edge
+    # equal to Nyquist is realized 1 Hz below it (same realization the
+    # pre-U9 code used). Edges ABOVE Nyquist were already rejected — this
+    # is filter realizability, not a band clamp.
+    high = min(band_high, nyquist - 1.0) / nyquist
+
+    # Bandpass filter (Butterworth, 4th order, SOS for numerical stability)
+    sos = butter(4, [low, high], btype="band", output="sos")
+    filtered = sosfiltfilt(sos, signal)
+
+    # Hilbert transform -> envelope
+    analytic = hilbert(filtered)
+    envelope = np.abs(analytic)
+
+    # INTENTIONAL CHANGE (U9, audit 2.8): subtract the envelope mean and
+    # apply a Hann window BEFORE the FFT. The envelope is strictly
+    # positive, so its mean is a large DC component whose leakage skirt
+    # (rectangular window) buried exactly the low-frequency FTF zone.
+    N = len(envelope)
+    envelope_ac = (envelope - np.mean(envelope)) * np.hanning(N)
+
+    env_fft = fft(envelope_ac)
+    env_freqs = fftfreq(N, 1 / fs)
+
+    pos_mask = env_freqs > 0
+    return env_freqs[pos_mask], np.abs(env_fft[pos_mask])
+
+
 def compute_envelope_spectrum(
     signal: np.ndarray,
     fs: float,
@@ -221,53 +315,9 @@ def compute_envelope_spectrum(
             sampling rate, or the fs-aware default is unusable (fs so low
             the 500 Hz lower edge meets the clamped upper edge).
     """
-    nyquist = fs / 2.0
-
-    if frequency_range is None:
-        # fs-AWARE DEFAULT. Cap the upper edge just below Nyquist so the
-        # band never exceeds a low-fs signal's Nyquist. This clamp is a
-        # NO-OP at fs=10000 Hz (5000 -> nyquist-1 = 4999), the exact edge
-        # the historical (500, 5000) default already resolved to.
-        band_low, band_high = 500.0, min(5000.0, nyquist - 1.0)
-    else:
-        # An EXPLICIT band is honored verbatim (fail loud, never clamp).
-        band_low, band_high = float(frequency_range[0]), float(frequency_range[1])
-
-    # Single validation path. The explicit band is checked as requested (an
-    # upper edge above Nyquist is a hard error); the default is pre-capped,
-    # so it only trips when the band is genuinely unusable (low >= high at
-    # a very low fs).
-    validate_bandpass_band(band_low, band_high, fs)
-
-    low = band_low / nyquist
-    # A digital filter corner cannot sit exactly AT Nyquist: an upper edge
-    # equal to Nyquist is realized 1 Hz below it (same realization the
-    # pre-U9 code used). Edges ABOVE Nyquist were already rejected — this
-    # is filter realizability, not a band clamp.
-    high = min(band_high, nyquist - 1.0) / nyquist
-
-    # Bandpass filter (Butterworth, 4th order, SOS for numerical stability)
-    sos = butter(4, [low, high], btype="band", output="sos")
-    filtered = sosfiltfilt(sos, signal)
-
-    # Hilbert transform -> envelope
-    analytic = hilbert(filtered)
-    envelope = np.abs(analytic)
-
-    # INTENTIONAL CHANGE (U9, audit 2.8): subtract the envelope mean and
-    # apply a Hann window BEFORE the FFT. The envelope is strictly
-    # positive, so its mean is a large DC component whose leakage skirt
-    # (rectangular window) buried exactly the low-frequency FTF zone.
-    N = len(envelope)
-    envelope_ac = (envelope - np.mean(envelope)) * np.hanning(N)
-
-    # Envelope spectrum
-    env_fft = fft(envelope_ac)
-    env_freqs = fftfreq(N, 1 / fs)
-
-    pos_mask = env_freqs > 0
-    env_freqs = env_freqs[pos_mask]
-    env_mags = np.abs(env_fft[pos_mask])
+    band_low, band_high = resolve_envelope_band(fs, frequency_range)
+    env_freqs, env_mags = envelope_spectrum_arrays(signal, fs, (band_low, band_high))
+    N = len(signal)
 
     # Peak detection
     max_mag = float(np.max(env_mags)) if len(env_mags) > 0 else 1e-12

--- a/tests/fixtures/tool_inventory.json
+++ b/tests/fixtures/tool_inventory.json
@@ -671,6 +671,85 @@
         "type": "object"
       }
     },
+    "generate_diagnostic_report": {
+      "context_kwarg": "ctx",
+      "is_async": true,
+      "parameters": {
+        "properties": {
+          "baseline_signal_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Baseline Signal Id"
+          },
+          "bearing_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Bearing Id"
+          },
+          "formats": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Formats"
+          },
+          "machine_group": {
+            "default": 2,
+            "enum": [
+              1,
+              2
+            ],
+            "title": "Machine Group",
+            "type": "integer"
+          },
+          "rpm": {
+            "title": "Rpm",
+            "type": "number"
+          },
+          "signal_id": {
+            "title": "Signal Id",
+            "type": "string"
+          },
+          "support_type": {
+            "default": "rigid",
+            "enum": [
+              "rigid",
+              "flexible"
+            ],
+            "title": "Support Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "signal_id",
+          "rpm"
+        ],
+        "title": "generate_diagnostic_reportArguments",
+        "type": "object"
+      }
+    },
     "generate_diagnostic_report_docx": {
       "context_kwarg": "ctx",
       "is_async": true,

--- a/tests/test_advisory.py
+++ b/tests/test_advisory.py
@@ -340,6 +340,105 @@ class TestAuthoredAbsences:
 
 
 # ---------------------------------------------------------------------------
+# R8 — baseline comparison
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineComparison:
+    def test_faulted_against_healthy_yields_a_directional_rms_delta(self):
+        advisory = build_advisory(
+            _diagnosis(
+                iso=_iso_assessed(zone="C", rms=5.0),
+                bearing_faults=_bearing_faults(),
+                anomaly=_anomaly(ratio=1.0),
+            ),
+            baseline_diagnosis=_diagnosis(
+                iso=_iso_assessed(zone="A", rms=1.0),
+                bearing_faults=_bearing_faults(detected=False),
+                anomaly=_anomaly(health="Healthy", ratio=0.0),
+                evidence_strength="none",
+            ),
+        )
+        block = advisory["baseline_comparison"]
+        assert block["status"] == ASSESSED
+        rms = next(d for d in block["deltas"] if d["indicator"] == "rms_velocity")
+        assert rms["direction"] == "higher"
+        assert rms["delta"] == pytest.approx(4.0)
+        assert "5.00" in rms["statement"] and "1.00" in rms["statement"]
+
+    def test_anomaly_ratio_delta_is_expressed_in_percentage_points(self):
+        advisory = build_advisory(
+            _diagnosis(anomaly=_anomaly(ratio=1.0)),
+            baseline_diagnosis=_diagnosis(
+                anomaly=_anomaly(health="Healthy", ratio=0.0)
+            ),
+        )
+        block = advisory["baseline_comparison"]
+        ratio = next(d for d in block["deltas"] if d["indicator"] == "anomaly_ratio")
+        assert ratio["delta"] == pytest.approx(100.0)
+        assert "percentage point" in ratio["statement"]
+
+    def test_missing_baseline_states_the_unavailable_conclusion(self):
+        """Covers AE2."""
+        advisory = build_advisory(_diagnosis(anomaly=_anomaly()))
+        block = advisory["baseline_comparison"]
+        assert block["status"] == ABSENT
+        assert block["deltas"] == []
+        assert "worsening" in block["statement"].lower()
+        assert block["remedy"]
+
+    def test_mismatched_declared_unit_refuses_rather_than_computing(self):
+        baseline = _diagnosis(anomaly=_anomaly(health="Healthy", ratio=0.0))
+        baseline["iso_severity"]["original_unit"] = "mm/s"
+        advisory = build_advisory(
+            _diagnosis(anomaly=_anomaly()), baseline_diagnosis=baseline
+        )
+        block = advisory["baseline_comparison"]
+        assert block["status"] == REFUSED
+        assert block["deltas"] == []
+        assert "mm/s" in block["statement"] and "g" in block["statement"]
+
+    def test_mismatched_bearing_refuses(self):
+        baseline = _diagnosis(bearing_faults=_bearing_faults(detected=False))
+        baseline["bearing_id"] = "6208"
+        advisory = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults()),
+            baseline_diagnosis=baseline,
+        )
+        assert advisory["baseline_comparison"]["status"] == REFUSED
+
+    def test_identical_baseline_reports_no_change_rather_than_an_empty_block(self):
+        diagnosis = _diagnosis(
+            bearing_faults=_bearing_faults(), anomaly=_anomaly(ratio=1.0)
+        )
+        advisory = build_advisory(diagnosis, baseline_diagnosis=diagnosis)
+        block = advisory["baseline_comparison"]
+        assert block["status"] == ASSESSED
+        assert block["deltas"], "an unchanged comparison is still a comparison"
+        assert "no measurable change" in block["statement"].lower()
+
+    def test_baseline_deltas_appear_in_the_collected_statements(self):
+        advisory = build_advisory(
+            _diagnosis(iso=_iso_assessed(zone="C", rms=5.0), anomaly=_anomaly()),
+            baseline_diagnosis=_diagnosis(
+                iso=_iso_assessed(zone="A", rms=1.0),
+                anomaly=_anomaly(health="Healthy", ratio=0.0),
+            ),
+        )
+        statements = collect_statements(advisory)
+        for delta in advisory["baseline_comparison"]["deltas"]:
+            assert delta["statement"] in statements
+
+    def test_refused_baseline_never_reports_a_delta_number(self):
+        baseline = _diagnosis(anomaly=_anomaly(health="Healthy", ratio=0.0))
+        baseline["iso_severity"]["original_unit"] = "mm/s"
+        advisory = build_advisory(
+            _diagnosis(anomaly=_anomaly()), baseline_diagnosis=baseline
+        )
+        assert advisory["baseline_comparison"]["deltas"] == []
+
+
+# ---------------------------------------------------------------------------
 # R7 — recommendations carry motivation and evidence
 # ---------------------------------------------------------------------------
 

--- a/tests/test_advisory.py
+++ b/tests/test_advisory.py
@@ -421,6 +421,34 @@ class TestBaselineComparison:
         assert block["deltas"], "an unchanged comparison is still a comparison"
         assert "no measurable change" in block["statement"].lower()
 
+    def test_headline_delta_is_chosen_by_meaning_not_by_magnitude(self):
+        """The three deltas are in dB, mm/s and percentage points.
+
+        Ranking them by absolute value would rank them by unit scale: a
+        1-point move in anomaly ratio would outrank a 0.5 mm/s rise in RMS
+        velocity for no reason other than the axis it sits on.
+        """
+        advisory = build_advisory(
+            _diagnosis(
+                iso=_iso_assessed(zone="C", rms=5.5),
+                bearing_faults=_bearing_faults(),
+                anomaly=_anomaly(ratio=1.0),
+            ),
+            baseline_diagnosis=_diagnosis(
+                iso=_iso_assessed(zone="A", rms=5.0),
+                bearing_faults=_bearing_faults(detected=False),
+                anomaly=_anomaly(health="Healthy", ratio=0.0),
+            ),
+        )
+        block = advisory["baseline_comparison"]
+        anomaly_delta = next(
+            d for d in block["deltas"] if d["indicator"] == "anomaly_ratio"
+        )
+        assert abs(anomaly_delta["delta"]) == 100.0
+        # The anomaly ratio has by far the largest number and is still not
+        # the headline: RMS velocity is the more specific movement here.
+        assert "RMS velocity" in block["statement"]
+
     def test_baseline_deltas_appear_in_the_collected_statements(self):
         advisory = build_advisory(
             _diagnosis(iso=_iso_assessed(zone="C", rms=5.0), anomaly=_anomaly()),

--- a/tests/test_advisory.py
+++ b/tests/test_advisory.py
@@ -1,0 +1,415 @@
+"""Tests for the server-authored advisory layer.
+
+The advisory layer exists because report content was previously authored by
+whoever called the report tool. When that caller is an LLM, faithful numbers
+arrive under invented labels: a superseded standard name, a machine-class
+vocabulary this codebase does not use, and a "confidence" grade the codebase
+deliberately refuses to produce.
+
+These tests are therefore assertions about *who wrote the words*, not only
+about whether the numbers are right.
+"""
+
+import pytest
+
+from predictive_maintenance_mcp.decision_support.advisory import (
+    ABSENT,
+    ASSESSED,
+    REFUSED,
+    build_advisory,
+    collect_statements,
+)
+from predictive_maintenance_mcp.diagnostics.iso20816 import THRESHOLD_PROVENANCE
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — diagnose_vibration-shaped results, built explicitly so each test
+# states the condition it exercises rather than hiding it in a factory.
+# ---------------------------------------------------------------------------
+
+
+def _iso_assessed(zone="C", rms=5.0):
+    return {
+        "status": "assessed",
+        "signal_id": "sig",
+        "rms_velocity_mm_s": rms,
+        "machine_group": 2,
+        "support_type": "rigid",
+        "zone": zone,
+        "zone_description": "Unsatisfactory for long-term operation.",
+        "severity_level": "Unsatisfactory",
+        "color_code": "orange",
+        "boundaries": {"A/B": 1.4, "B/C": 2.8, "C/D": 4.5},
+        "frequency_range": "10-1000 Hz",
+        "unit_conversion_performed": True,
+        "original_unit": "g",
+        "operating_speed_rpm": 1500.0,
+        "machine_power_kw": None,
+        "threshold_provenance": THRESHOLD_PROVENANCE,
+    }
+
+
+def _iso_refused():
+    return {
+        "status": "refused",
+        "signal_id": "sig",
+        "reason": "Signal unit not declared — ISO 20816-3 severity requires ...",
+        "remedy": "Re-load the signal with load_signal(signal_unit='g') ...",
+    }
+
+
+def _bearing_faults(detected=True):
+    return {
+        "signal_id": "sig",
+        "bearing_id": "6205",
+        "rpm": 1500.0,
+        "shaft_frequency_hz": 25.0,
+        "bearing_frequencies": {
+            "BPFO": 81.125,
+            "BPFI": 118.875,
+            "BSF": 63.91,
+            "FTF": 14.84,
+            "shaft_freq_hz": 25.0,
+        },
+        "fault_checks": [
+            {
+                "signal_id": "sig",
+                "bearing_id": "6205",
+                "fault_type": "BPFO",
+                "fault_type_canonical": "outer_race",
+                "expected_frequency_hz": 81.125,
+                "detected": detected,
+                "detected_frequency_hz": 80.5 if detected else None,
+                "magnitude": 0.0516 if detected else None,
+                "deviation_pct": 0.77 if detected else None,
+                "harmonics_detected": [{"expected_hz": 162.25}] if detected else [],
+                "evidence_strength": "high" if detected else "none",
+            },
+            {
+                "signal_id": "sig",
+                "bearing_id": "6205",
+                "fault_type": "BPFI",
+                "fault_type_canonical": "inner_race",
+                "expected_frequency_hz": 118.875,
+                "detected": False,
+                "detected_frequency_hz": None,
+                "magnitude": None,
+                "deviation_pct": None,
+                "harmonics_detected": [],
+                "evidence_strength": "none",
+            },
+        ],
+        "overall_assessment": "Outer race fault indicated.",
+        "most_likely_fault": "BPFO" if detected else None,
+        "most_likely_fault_canonical": "outer_race" if detected else None,
+    }
+
+
+def _anomaly(health="Faulty", ratio=1.0):
+    return {
+        "overall_health": health,
+        "anomaly_ratio": ratio,
+        "num_segments": 119,
+        "model_name": "bearing_health_model",
+    }
+
+
+def _diagnosis(
+    iso=None,
+    bearing_faults=None,
+    anomaly=None,
+    evidence_strength="strong",
+    recommendations=None,
+):
+    return {
+        "signal_id": "sig",
+        "rpm": 1500.0,
+        "bearing_id": "6205" if bearing_faults else None,
+        "machine_group": 2,
+        "support_type": "rigid",
+        "fft_summary": {"peak_frequency_hz": 1850.83, "peak_magnitude": 0.0422},
+        "psd_summary": {"total_power": 0.507, "top_peaks": [], "freq_resolution": 1.0},
+        "stft_summary": {
+            "max_power_freq_hz": 5200.0,
+            "max_power_time_s": 1.2,
+            "energy_per_band": {
+                "0-500 Hz": 12.0,
+                "500-2000 Hz": 38.0,
+                "2000-5000 Hz": 87.5,
+                "5000+ Hz": 446.2,
+            },
+            "num_time_bins": 100,
+        },
+        "bearing_faults": bearing_faults,
+        "iso_severity": iso if iso is not None else _iso_assessed(),
+        "anomaly_detection": anomaly,
+        "overall_diagnosis": "ISO Severity: Zone C ...",
+        "evidence_strength": evidence_strength,
+        "recommendations": recommendations or ["Schedule maintenance."],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Verdict, evidence, and the standards caveat
+# ---------------------------------------------------------------------------
+
+
+class TestVerdictAndEvidence:
+    def test_detected_fault_produces_verdict_naming_the_fault(self):
+        advisory = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults(), anomaly=_anomaly())
+        )
+        assert "outer race" in advisory["verdict"]["statement"].lower()
+        assert advisory["verdict"]["fault_canonical"] == "outer_race"
+
+    def test_evidence_lists_the_frequency_match_and_its_deviation(self):
+        advisory = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults(), anomaly=_anomaly())
+        )
+        joined = " ".join(advisory["evidence"]["statements"])
+        assert "80.5" in joined
+        assert "81.1" in joined or "81.12" in joined
+        assert "0.77" in joined or "0.8" in joined
+
+    def test_iso_statement_carries_the_provenance_caveat_verbatim(self):
+        advisory = build_advisory(_diagnosis())
+        assert advisory["iso"]["standard_note"] == THRESHOLD_PROVENANCE
+
+    def test_iso_statement_names_iso_20816_3_not_the_superseded_edition_alone(self):
+        advisory = build_advisory(_diagnosis())
+        assert "ISO 20816-3" in advisory["iso"]["statement"]
+
+    def test_clean_signal_yields_no_fault_verdict_and_monitoring_action(self):
+        advisory = build_advisory(
+            _diagnosis(
+                iso=_iso_assessed(zone="A", rms=0.8),
+                bearing_faults=_bearing_faults(detected=False),
+                anomaly=_anomaly(health="Healthy", ratio=0.0),
+                evidence_strength="none",
+            )
+        )
+        assert advisory["verdict"]["fault_canonical"] is None
+        actions = [r["action"] for r in advisory["recommendations"]]
+        assert any("monitor" in a.lower() for a in actions)
+
+
+# ---------------------------------------------------------------------------
+# R2 — no confidence, anywhere
+# ---------------------------------------------------------------------------
+
+
+class TestNoConfidenceLabel:
+    def test_strong_evidence_exposes_no_confidence_shaped_field(self):
+        """Covers AE6."""
+        advisory = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults(), anomaly=_anomaly())
+        )
+
+        def walk(node, path=""):
+            if isinstance(node, dict):
+                for key, value in node.items():
+                    assert "confidence" not in key.lower(), (
+                        f"confidence-shaped key at {path}.{key}"
+                    )
+                    assert "probability" not in key.lower(), (
+                        f"probability-shaped key at {path}.{key}"
+                    )
+                    walk(value, f"{path}.{key}")
+            elif isinstance(node, list):
+                for i, value in enumerate(node):
+                    walk(value, f"{path}[{i}]")
+
+        walk(advisory)
+
+    def test_evidence_strength_is_accompanied_by_what_it_counts(self):
+        """Covers AE6.
+
+        'strong' on its own invites a reader to hear a probability. The
+        explanation is what stops that reading.
+        """
+        advisory = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults(), anomaly=_anomaly())
+        )
+        assert advisory["evidence"]["strength"] == "strong"
+        explanation = advisory["evidence"]["strength_explanation"]
+        assert "corroborat" in explanation.lower()
+        assert "not a" in explanation.lower()
+
+    def test_confidence_appears_only_where_it_is_being_denied(self):
+        """The word is allowed to say 'this is not one'. Nothing else."""
+        advisory = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults(), anomaly=_anomaly())
+        )
+        for statement in collect_statements(advisory):
+            lowered = statement.lower()
+            if "confidence" not in lowered:
+                continue
+            assert "not a confidence" in lowered, (
+                f"statement asserts a confidence rather than denying one: "
+                f"{statement}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# R6 — indicator disagreement
+# ---------------------------------------------------------------------------
+
+
+class TestIndicatorDisagreement:
+    def test_acceptable_zone_with_full_anomaly_ratio_is_reconciled(self):
+        """Covers AE1."""
+        advisory = build_advisory(
+            _diagnosis(
+                iso=_iso_assessed(zone="B", rms=1.64),
+                bearing_faults=_bearing_faults(),
+                anomaly=_anomaly(health="Faulty", ratio=1.0),
+            )
+        )
+        assert advisory["disagreements"], "expected a reconciliation statement"
+        entry = advisory["disagreements"][0]
+        assert "Zone B" in entry["statement"]
+        assert entry["governing_indicator"]
+        assert entry["governing_indicator"].lower() != "iso"
+
+    def test_agreeing_indicators_produce_no_disagreement_entry(self):
+        advisory = build_advisory(
+            _diagnosis(
+                iso=_iso_assessed(zone="D", rms=12.0),
+                bearing_faults=_bearing_faults(),
+                anomaly=_anomaly(health="Faulty", ratio=1.0),
+            )
+        )
+        assert advisory["disagreements"] == []
+
+    def test_quiet_zone_with_healthy_anomaly_produces_no_disagreement(self):
+        advisory = build_advisory(
+            _diagnosis(
+                iso=_iso_assessed(zone="A", rms=0.9),
+                bearing_faults=_bearing_faults(detected=False),
+                anomaly=_anomaly(health="Healthy", ratio=0.0),
+                evidence_strength="none",
+            )
+        )
+        assert advisory["disagreements"] == []
+
+
+# ---------------------------------------------------------------------------
+# R9 — missing inputs are stated, never silently omitted
+# ---------------------------------------------------------------------------
+
+
+class TestAuthoredAbsences:
+    def test_missing_bearing_metadata_states_why_matching_was_not_attempted(self):
+        """Covers AE3."""
+        advisory = build_advisory(_diagnosis(bearing_faults=None, anomaly=_anomaly()))
+        block = advisory["bearing_match"]
+        assert block["status"] == ABSENT
+        assert block["statement"]
+        assert "bearing" in block["statement"].lower()
+        assert block["remedy"]
+
+    def test_refused_iso_block_carries_reason_and_remedy_verbatim(self):
+        refusal = _iso_refused()
+        advisory = build_advisory(_diagnosis(iso=refusal, anomaly=_anomaly()))
+        assert advisory["iso"]["status"] == REFUSED
+        assert refusal["reason"] in advisory["iso"]["statement"]
+        assert advisory["iso"]["remedy"] == refusal["remedy"]
+
+    def test_missing_anomaly_model_states_the_unavailable_conclusion(self):
+        advisory = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults(), anomaly=None)
+        )
+        block = advisory["anomaly"]
+        assert block["status"] == ABSENT
+        assert block["statement"]
+
+    def test_refused_iso_does_not_produce_a_disagreement_entry(self):
+        """A refusal is not an indicator — it cannot disagree with one."""
+        advisory = build_advisory(
+            _diagnosis(iso=_iso_refused(), anomaly=_anomaly(ratio=1.0))
+        )
+        assert advisory["disagreements"] == []
+
+    def test_every_block_is_present_even_when_its_input_is_missing(self):
+        advisory = build_advisory(
+            _diagnosis(iso=_iso_refused(), bearing_faults=None, anomaly=None)
+        )
+        for key in ("iso", "bearing_match", "anomaly", "baseline_comparison"):
+            assert key in advisory
+            assert advisory[key]["statement"], f"{key} rendered an empty statement"
+
+
+# ---------------------------------------------------------------------------
+# R7 — recommendations carry motivation and evidence
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendations:
+    def test_each_recommendation_carries_a_motivation_and_its_evidence(self):
+        advisory = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults(), anomaly=_anomaly())
+        )
+        assert advisory["recommendations"]
+        for rec in advisory["recommendations"]:
+            assert rec["action"]
+            assert rec["urgency"]
+            assert rec["motivation"], f"{rec['action']} has no motivation"
+            assert rec["evidence"], f"{rec['action']} names no evidence"
+
+    def test_fault_specific_action_appears_when_a_fault_is_detected(self):
+        advisory = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults(), anomaly=_anomaly())
+        )
+        actions = " ".join(r["action"].lower() for r in advisory["recommendations"])
+        assert "bearing" in actions
+
+    def test_refused_iso_still_produces_the_remedy_as_an_action(self):
+        advisory = build_advisory(_diagnosis(iso=_iso_refused(), anomaly=_anomaly()))
+        actions = " ".join(r["action"] for r in advisory["recommendations"])
+        assert "load_signal" in actions or "re-load" in actions.lower()
+
+
+# ---------------------------------------------------------------------------
+# Payload shape — provenance and the flat statement list U7 asserts on
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadShape:
+    def test_provenance_names_signal_parameters_and_server_version(self):
+        advisory = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults(), anomaly=_anomaly())
+        )
+        prov = advisory["provenance"]
+        assert prov["signal_id"] == "sig"
+        assert prov["rpm"] == 1500.0
+        assert prov["bearing_id"] == "6205"
+        assert prov["machine_group"] == 2
+        assert prov["support_type"] == "rigid"
+        assert prov["server_version"]
+
+    def test_collect_statements_returns_every_authored_string(self):
+        advisory = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults(), anomaly=_anomaly())
+        )
+        statements = collect_statements(advisory)
+        assert advisory["verdict"]["statement"] in statements
+        assert advisory["iso"]["statement"] in statements
+        for rec in advisory["recommendations"]:
+            assert rec["action"] in statements
+        assert len(statements) == len(set(statements)), "statements must be unique"
+
+    def test_advisory_is_deterministic_for_the_same_input(self):
+        """Covers AE5 at the payload level."""
+        diagnosis = _diagnosis(bearing_faults=_bearing_faults(), anomaly=_anomaly())
+        assert build_advisory(diagnosis) == build_advisory(diagnosis)
+
+    def test_status_constants_are_the_only_status_vocabulary(self):
+        advisory = build_advisory(
+            _diagnosis(iso=_iso_refused(), bearing_faults=None, anomaly=None)
+        )
+        for key in ("iso", "bearing_match", "anomaly", "baseline_comparison"):
+            assert advisory[key]["status"] in (ASSESSED, REFUSED, ABSENT)
+
+    def test_unknown_diagnosis_shape_raises_rather_than_guessing(self):
+        with pytest.raises(ValueError):
+            build_advisory({"signal_id": "sig"})

--- a/tests/test_advisory.py
+++ b/tests/test_advisory.py
@@ -132,12 +132,16 @@ def _diagnosis(
         "stft_summary": {
             "max_power_freq_hz": 5200.0,
             "max_power_time_s": 1.2,
-            "energy_per_band": {
-                "0-500 Hz": 12.0,
-                "500-2000 Hz": 38.0,
-                "2000-5000 Hz": 87.5,
-                "5000+ Hz": 446.2,
-            },
+            # Shape mirrors compute_stft_spectrogram exactly: a list of
+            # {"band", "energy"} entries, not a mapping. A fixture that
+            # invents a friendlier shape hides a real integration failure.
+            "energy_per_band": [
+                {"band": "0-100 Hz", "energy": 4.0},
+                {"band": "100-500 Hz", "energy": 8.0},
+                {"band": "500-2000 Hz", "energy": 38.0},
+                {"band": "2000-5000 Hz", "energy": 87.5},
+                {"band": "5000+ Hz", "energy": 446.2},
+            ],
             "num_time_bins": 100,
         },
         "bearing_faults": bearing_faults,

--- a/tests/test_figures.py
+++ b/tests/test_figures.py
@@ -160,3 +160,34 @@ class TestAxesAndScaling:
         first = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
         second = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
         assert first == second
+
+
+class TestTraceDecimation:
+    def test_long_spectrum_is_capped(self):
+        freqs, mags = _spectrum(n=200_000)
+        figure = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        assert len(figure["x"]) <= 2400
+        assert len(figure["x"]) == len(figure["y"])
+
+    def test_decimation_keeps_the_peak_rather_than_dropping_it(self):
+        """Plain decimation drops exactly the narrow peaks the figure exists
+        to show. The dominant peak must survive at its own frequency."""
+        freqs, mags = _spectrum(peak_hz=80.5, n=200_000)
+        figure = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        peak_index = max(range(len(figure["y"])), key=lambda i: figure["y"][i])
+        assert figure["x"][peak_index] == pytest.approx(80.5, abs=0.5)
+        assert max(figure["y"]) == pytest.approx(0.0, abs=1e-9)
+
+    def test_short_spectrum_is_untouched(self):
+        freqs, mags = _spectrum(n=500)
+        figure = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        capped = build_annotated_envelope_figure(
+            freqs, mags, BEARING_FREQS, max_points=10_000
+        )
+        assert figure["x"] == capped["x"]
+
+    def test_decimation_is_deterministic(self):
+        freqs, mags = _spectrum(n=200_000)
+        first = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        second = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        assert first == second

--- a/tests/test_figures.py
+++ b/tests/test_figures.py
@@ -1,0 +1,162 @@
+"""Tests for the explanatory figure builder.
+
+The annotated envelope spectrum is not decoration. It is the place a reader
+*sees* that the dominant peak falls inside one characteristic-frequency band
+and outside the other three — the same tolerance the verdict used, drawn.
+
+A figure that only carries its argument when you can hover it is a figure that
+loses its argument in the PDF rendering, so these tests assert the annotation
+is in the figure data itself.
+"""
+
+import numpy as np
+import pytest
+
+from predictive_maintenance_mcp.figures import (
+    ANNOTATED_ENVELOPE,
+    build_annotated_envelope_figure,
+)
+
+BEARING_FREQS = {
+    "BPFO": 81.125,
+    "BPFI": 118.875,
+    "BSF": 63.91,
+    "FTF": 14.84,
+    "shaft_freq_hz": 25.0,
+}
+
+
+def _spectrum(peak_hz=80.5, span_hz=500.0, n=2000):
+    """A synthetic envelope spectrum with one dominant peak."""
+    freqs = np.linspace(0.0, span_hz, n)
+    mags = 0.001 + 0.05 * np.exp(-(((freqs - peak_hz) / 0.8) ** 2))
+    return freqs, mags
+
+
+class TestCharacteristicFrequencyBands:
+    def test_one_band_per_characteristic_frequency(self):
+        freqs, mags = _spectrum()
+        figure = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        labels = [band["label"] for band in figure["bands"]]
+        assert labels == ["FTF", "BSF", "BPFO", "BPFI"]
+
+    def test_shaft_frequency_is_not_drawn_as_a_fault_band(self):
+        """shaft_freq_hz rides along in the same dict but is not a defect."""
+        freqs, mags = _spectrum()
+        figure = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        assert all(band["label"] != "shaft_freq_hz" for band in figure["bands"])
+
+    def test_band_width_matches_the_matching_tolerance(self):
+        freqs, mags = _spectrum()
+        figure = build_annotated_envelope_figure(
+            freqs, mags, BEARING_FREQS, tolerance_pct=5.0
+        )
+        bpfo = next(b for b in figure["bands"] if b["label"] == "BPFO")
+        expected_width = 81.125 * 2 * 0.05
+        assert bpfo["high_hz"] - bpfo["low_hz"] == pytest.approx(expected_width)
+        assert bpfo["center_hz"] == pytest.approx(81.125)
+
+    def test_a_different_tolerance_produces_a_different_band_width(self):
+        freqs, mags = _spectrum()
+        narrow = build_annotated_envelope_figure(
+            freqs, mags, BEARING_FREQS, tolerance_pct=2.0
+        )
+        band = next(b for b in narrow["bands"] if b["label"] == "BPFO")
+        assert band["high_hz"] - band["low_hz"] == pytest.approx(81.125 * 2 * 0.02)
+
+    def test_characteristic_frequency_beyond_the_axis_is_omitted(self):
+        freqs, mags = _spectrum()
+        figure = build_annotated_envelope_figure(
+            freqs, mags, BEARING_FREQS, max_freq=100.0
+        )
+        labels = [band["label"] for band in figure["bands"]]
+        assert "BPFI" not in labels, "118.875 Hz cannot be drawn on a 100 Hz axis"
+        assert "BPFO" in labels
+        assert figure["omitted_labels"] == ["BPFI"]
+
+
+class TestMatchAnnotation:
+    def test_matched_annotation_carries_calculated_and_measured_values(self):
+        freqs, mags = _spectrum()
+        figure = build_annotated_envelope_figure(
+            freqs,
+            mags,
+            BEARING_FREQS,
+            matched={"fault_type": "BPFO", "measured_hz": 80.5, "deviation_pct": 0.77},
+        )
+        annotation = next(a for a in figure["annotations"] if a["matched"])
+        assert "81.12" in annotation["text"] or "81.13" in annotation["text"]
+        assert "80.5" in annotation["text"]
+        assert "BPFO" in annotation["text"]
+
+    def test_only_the_matched_band_is_flagged_as_matched(self):
+        freqs, mags = _spectrum()
+        figure = build_annotated_envelope_figure(
+            freqs, mags, BEARING_FREQS, matched={"fault_type": "BPFO", "measured_hz": 80.5}
+        )
+        matched = [b for b in figure["bands"] if b["matched"]]
+        assert [b["label"] for b in matched] == ["BPFO"]
+
+    def test_no_match_leaves_every_band_unmatched(self):
+        freqs, mags = _spectrum()
+        figure = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        assert all(not band["matched"] for band in figure["bands"])
+        assert all(not ann["matched"] for ann in figure["annotations"])
+
+
+class TestDegradation:
+    def test_absent_bearing_metadata_still_produces_a_figure(self):
+        freqs, mags = _spectrum()
+        figure = build_annotated_envelope_figure(freqs, mags, None)
+        assert figure["kind"] == ANNOTATED_ENVELOPE
+        assert figure["bands"] == []
+        assert figure["annotations"] == []
+        assert len(figure["x"]) > 0
+
+    def test_caption_states_what_the_figure_shows_in_both_cases(self):
+        freqs, mags = _spectrum()
+        with_meta = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        without = build_annotated_envelope_figure(freqs, mags, None)
+        assert "tolerance" in with_meta["caption"].lower()
+        assert without["caption"]
+        assert "no bearing" in without["caption"].lower()
+
+    def test_empty_spectrum_raises_rather_than_drawing_nothing(self):
+        with pytest.raises(ValueError):
+            build_annotated_envelope_figure(np.array([]), np.array([]), None)
+
+    def test_mismatched_array_lengths_raise(self):
+        with pytest.raises(ValueError):
+            build_annotated_envelope_figure(
+                np.linspace(0, 100, 50), np.zeros(20), None
+            )
+
+
+class TestAxesAndScaling:
+    def test_magnitudes_are_normalised_to_decibels_below_the_peak(self):
+        freqs, mags = _spectrum()
+        figure = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        assert max(figure["y"]) == pytest.approx(0.0, abs=1e-9)
+        assert min(figure["y"]) < 0.0
+        assert "dB" in figure["y_label"]
+
+    def test_axis_extends_far_enough_to_show_every_characteristic_band(self):
+        freqs, mags = _spectrum(span_hz=1000.0)
+        figure = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        assert max(figure["x"]) >= 118.875 * 1.05
+
+    def test_figure_data_is_json_serialisable(self):
+        """Both renderings serialise this; numpy scalars would break one."""
+        import json
+
+        freqs, mags = _spectrum()
+        figure = build_annotated_envelope_figure(
+            freqs, mags, BEARING_FREQS, matched={"fault_type": "BPFO", "measured_hz": 80.5}
+        )
+        json.dumps(figure)
+
+    def test_figure_is_deterministic_for_the_same_input(self):
+        freqs, mags = _spectrum()
+        first = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        second = build_annotated_envelope_figure(freqs, mags, BEARING_FREQS)
+        assert first == second

--- a/tests/test_integrated_report.py
+++ b/tests/test_integrated_report.py
@@ -22,6 +22,7 @@ from predictive_maintenance_mcp.integrated_report import (
     create_integrated_diagnostic_report,
 )
 from predictive_maintenance_mcp.report_generator import (
+    HAS_PDF,
     REPORTS_DIR,
     save_integrated_diagnostic_report,
 )
@@ -205,3 +206,116 @@ class TestSaving:
         assert result["statements"] == collect_statements(advisory)
         assert result["report_type"] == "integrated_diagnostic"
         Path(result["file_path"]).unlink()
+
+
+# ---------------------------------------------------------------------------
+# PDF rendering and cross-rendering parity
+#
+# The parity guarantee is what makes "two renderings, one authored source"
+# a property rather than an intention. Both files are produced from the same
+# rendered HTML string, so this test would only fail if that stopped being
+# true — which is exactly when someone needs to hear about it.
+# ---------------------------------------------------------------------------
+
+
+def _normalise(text):
+    """Collapse whitespace so line breaks introduced by PDF layout do not
+    make an identical sentence look different."""
+    return " ".join(text.split())
+
+
+def _pdf_text(path):
+    from pypdf import PdfReader
+
+    reader = PdfReader(str(path))
+    return _normalise(" ".join(page.extract_text() or "" for page in reader.pages))
+
+
+@pytest.mark.skipif(not HAS_PDF, reason="PDF extra not installed")
+class TestPdfRendering:
+    def test_pdf_is_written_and_non_empty(self, advisory, figure):
+        result = save_integrated_diagnostic_report(advisory, figure, formats=["pdf"])
+        written = Path(result["files"][0]["file_path"])
+        assert written.exists()
+        assert written.read_bytes()[:5] == b"%PDF-"
+        assert result["files"][0]["file_size_kb"] > 0
+        written.unlink()
+
+    def test_both_renderings_are_produced_from_one_request(self, advisory, figure):
+        result = save_integrated_diagnostic_report(
+            advisory, figure, formats=["html", "pdf"]
+        )
+        assert [f["format"] for f in result["files"]] == ["html", "pdf"]
+        for entry in result["files"]:
+            path = Path(entry["file_path"])
+            assert path.exists()
+            path.unlink()
+
+    def test_every_authored_statement_survives_into_the_pdf(self, advisory, figure):
+        """Covers AE5 across renderings."""
+        result = save_integrated_diagnostic_report(advisory, figure, formats=["pdf"])
+        path = Path(result["files"][0]["file_path"])
+        try:
+            extracted = _pdf_text(path)
+            missing = [
+                s for s in collect_statements(advisory)
+                if _normalise(s) not in extracted
+            ]
+            assert missing == [], f"PDF dropped authored statements: {missing}"
+        finally:
+            path.unlink()
+
+    def test_the_iso_caveat_survives_into_the_pdf(self, advisory, figure):
+        """The caveat is the single sentence most likely to be lost in a
+        rendering that silently truncates."""
+        result = save_integrated_diagnostic_report(advisory, figure, formats=["pdf"])
+        path = Path(result["files"][0]["file_path"])
+        try:
+            assert _normalise(THRESHOLD_PROVENANCE) in _pdf_text(path)
+        finally:
+            path.unlink()
+
+    def test_pdf_and_html_agree_on_every_statement(self, advisory, figure):
+        result = save_integrated_diagnostic_report(
+            advisory, figure, formats=["html", "pdf"]
+        )
+        html_path = Path(result["files"][0]["file_path"])
+        pdf_path = Path(result["files"][1]["file_path"])
+        try:
+            rendered_html = html_path.read_text(encoding="utf-8")
+            extracted_pdf = _pdf_text(pdf_path)
+            for statement in collect_statements(advisory):
+                in_html = html.escape(statement) in rendered_html
+                in_pdf = _normalise(statement) in extracted_pdf
+                assert in_html == in_pdf is True, (
+                    f"statement present in one rendering only: {statement}"
+                )
+        finally:
+            html_path.unlink()
+            pdf_path.unlink()
+
+
+class TestFormatValidation:
+    def test_unknown_format_raises(self, advisory, figure):
+        with pytest.raises(ValueError, match="Unknown report format"):
+            save_integrated_diagnostic_report(advisory, figure, formats=["docx"])
+
+    @pytest.mark.skipif(HAS_PDF, reason="PDF extra installed")
+    def test_missing_pdf_dependency_raises_with_an_install_hint(
+        self, advisory, figure
+    ):
+        with pytest.raises(ValueError, match=r"\[pdf\]"):
+            save_integrated_diagnostic_report(advisory, figure, formats=["pdf"])
+
+    def test_missing_pdf_dependency_message_names_the_extra(self, advisory, figure):
+        """Exercised regardless of whether the extra is installed locally."""
+        import predictive_maintenance_mcp.report_generator as rg
+
+        original = rg.HAS_PDF
+        rg.HAS_PDF = False
+        try:
+            with pytest.raises(ValueError) as excinfo:
+                save_integrated_diagnostic_report(advisory, figure, formats=["pdf"])
+            assert "[pdf]" in str(excinfo.value)
+        finally:
+            rg.HAS_PDF = original

--- a/tests/test_integrated_report.py
+++ b/tests/test_integrated_report.py
@@ -1,0 +1,207 @@
+"""Tests for the integrated diagnostic report rendering.
+
+The rendering layer places strings; it never composes them. These tests are
+the enforcement of that: every evaluative sentence in the rendered document
+must be findable, verbatim, in the advisory payload that produced it.
+"""
+
+import html
+import json
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from predictive_maintenance_mcp.decision_support.advisory import (
+    build_advisory,
+    collect_statements,
+)
+from predictive_maintenance_mcp.figures import build_annotated_envelope_figure
+from predictive_maintenance_mcp.integrated_report import (
+    create_integrated_diagnostic_report,
+)
+from predictive_maintenance_mcp.report_generator import (
+    REPORTS_DIR,
+    save_integrated_diagnostic_report,
+)
+from predictive_maintenance_mcp.diagnostics.iso20816 import THRESHOLD_PROVENANCE
+
+from tests.test_advisory import (
+    _anomaly,
+    _bearing_faults,
+    _diagnosis,
+    _iso_assessed,
+    _iso_refused,
+)
+
+
+@pytest.fixture
+def advisory():
+    return build_advisory(
+        _diagnosis(
+            iso=_iso_assessed(zone="B", rms=1.64),
+            bearing_faults=_bearing_faults(),
+            anomaly=_anomaly(health="Faulty", ratio=1.0),
+        )
+    )
+
+
+@pytest.fixture
+def figure():
+    freqs = np.linspace(0.0, 500.0, 1500)
+    mags = 0.001 + 0.05 * np.exp(-(((freqs - 80.5) / 0.8) ** 2))
+    return build_annotated_envelope_figure(
+        freqs,
+        mags,
+        {"BPFO": 81.125, "BPFI": 118.875, "BSF": 63.91, "FTF": 14.84},
+        matched={"fault_type": "BPFO", "measured_hz": 80.5, "deviation_pct": 0.77},
+    )
+
+
+class TestRenderedContent:
+    def test_document_carries_the_verdict_and_the_iso_caveat(self, advisory, figure):
+        rendered = create_integrated_diagnostic_report(advisory, figure)
+        assert html.escape(advisory["verdict"]["statement"]) in rendered
+        assert html.escape(THRESHOLD_PROVENANCE) in rendered
+
+    def test_every_authored_statement_appears_verbatim(self, advisory, figure):
+        """Covers AE4."""
+        rendered = create_integrated_diagnostic_report(advisory, figure)
+        missing = [
+            statement
+            for statement in collect_statements(advisory)
+            if html.escape(statement) not in rendered
+        ]
+        assert missing == [], f"rendering dropped authored statements: {missing}"
+
+    def test_disagreement_statement_is_rendered(self, advisory, figure):
+        rendered = create_integrated_diagnostic_report(advisory, figure)
+        assert advisory["disagreements"], "fixture should produce a disagreement"
+        assert html.escape(advisory["disagreements"][0]["statement"]) in rendered
+
+    def test_every_recommendation_is_rendered_with_its_motivation(
+        self, advisory, figure
+    ):
+        rendered = create_integrated_diagnostic_report(advisory, figure)
+        for rec in advisory["recommendations"]:
+            assert html.escape(rec["action"]) in rendered
+            assert html.escape(rec["motivation"]) in rendered
+
+    def test_absence_statements_render_as_sections_not_omissions(self, figure):
+        sparse = build_advisory(
+            _diagnosis(iso=_iso_refused(), bearing_faults=None, anomaly=None)
+        )
+        rendered = create_integrated_diagnostic_report(sparse, None)
+        for key in ("iso", "bearing_match", "anomaly", "baseline_comparison"):
+            assert html.escape(sparse[key]["statement"]) in rendered
+
+    def test_rendering_escapes_content_rather_than_interpolating_it_raw(self, figure):
+        hostile = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults(), anomaly=_anomaly())
+        )
+        hostile["signal_id"] = "<script>alert(1)</script>"
+        hostile["provenance"]["signal_id"] = "<script>alert(1)</script>"
+        rendered = create_integrated_diagnostic_report(hostile, figure)
+        assert "<script>alert(1)</script>" not in rendered
+        assert "&lt;script&gt;" in rendered
+
+    def test_metadata_block_cannot_be_closed_early_by_signal_content(self, figure):
+        """The embedded JSON is tokenised as HTML before it is parsed as JSON."""
+        hostile = build_advisory(
+            _diagnosis(bearing_faults=_bearing_faults(), anomaly=_anomaly())
+        )
+        hostile["provenance"]["signal_id"] = "</script><script>alert(1)</script>"
+        rendered = create_integrated_diagnostic_report(hostile, figure)
+        _, _, tail = rendered.partition(
+            '<script type="application/json" id="report-metadata">'
+        )
+        json_block, closed, _ = tail.partition("</script>")
+
+        # The block survives to its own closing tag rather than being cut
+        # short by the payload, and what it holds is still valid JSON
+        # carrying the hostile string inertly as data.
+        assert closed, "metadata block was never closed"
+        assert "</script>" not in json_block
+        parsed = json.loads(json_block.replace("<\\/", "</"))
+        assert parsed["provenance"]["signal_id"] == (
+            "</script><script>alert(1)</script>"
+        )
+
+    def test_figure_caption_is_rendered(self, advisory, figure):
+        rendered = create_integrated_diagnostic_report(advisory, figure)
+        assert html.escape(figure["caption"]) in rendered
+
+    def test_missing_figure_states_the_absence(self, advisory):
+        rendered = create_integrated_diagnostic_report(advisory, None)
+        assert "no envelope spectrum" in rendered.lower()
+
+
+class TestProvenanceAndDeterminism:
+    def test_provenance_names_signal_parameters_and_version(self, advisory, figure):
+        rendered = create_integrated_diagnostic_report(advisory, figure)
+        prov = advisory["provenance"]
+        assert html.escape(str(prov["signal_id"])) in rendered
+        assert str(prov["rpm"]) in rendered
+        assert html.escape(str(prov["bearing_id"])) in rendered
+        assert html.escape(prov["server_version"]) in rendered
+
+    def test_same_payload_and_timestamp_render_identically(self, advisory, figure):
+        """Covers AE5."""
+        first = create_integrated_diagnostic_report(
+            advisory, figure, generated_at="2026-08-06T10:00:00Z"
+        )
+        second = create_integrated_diagnostic_report(
+            advisory, figure, generated_at="2026-08-06T10:00:00Z"
+        )
+        assert first == second
+
+    def test_two_renders_differ_only_in_the_generation_timestamp(
+        self, advisory, figure
+    ):
+        """Covers AE5.
+
+        Determinism is a claim about content, not filenames — report names
+        carry a timestamp and a sequence on purpose so a re-run never
+        overwrites its predecessor.
+        """
+        first = create_integrated_diagnostic_report(
+            advisory, figure, generated_at="2026-08-06T10:00:00Z"
+        )
+        second = create_integrated_diagnostic_report(
+            advisory, figure, generated_at="2027-01-01T23:59:59Z"
+        )
+        strip = lambda doc: re.sub(r"20\d\d-\d\d-\d\dT[\d:]+Z", "", doc)  # noqa: E731
+        assert strip(first) == strip(second)
+
+
+class TestSaving:
+    def test_report_is_written_under_the_reports_directory(self, advisory, figure):
+        result = save_integrated_diagnostic_report(advisory, figure)
+        written = Path(result["file_path"])
+        assert written.exists()
+        assert written.parent.resolve() == REPORTS_DIR.resolve()
+        written.unlink()
+
+    def test_traversal_shaped_signal_id_cannot_escape_the_reports_directory(
+        self, advisory, figure
+    ):
+        advisory["signal_id"] = "../../../etc/passwd"
+        advisory["provenance"]["signal_id"] = "../../../etc/passwd"
+        result = save_integrated_diagnostic_report(advisory, figure)
+        written = Path(result["file_path"])
+        assert written.parent.resolve() == REPORTS_DIR.resolve()
+        written.unlink()
+
+    def test_consecutive_saves_never_overwrite(self, advisory, figure):
+        first = save_integrated_diagnostic_report(advisory, figure)
+        second = save_integrated_diagnostic_report(advisory, figure)
+        assert first["file_name"] != second["file_name"]
+        Path(first["file_path"]).unlink()
+        Path(second["file_path"]).unlink()
+
+    def test_result_carries_the_authored_statements(self, advisory, figure):
+        result = save_integrated_diagnostic_report(advisory, figure)
+        assert result["statements"] == collect_statements(advisory)
+        assert result["report_type"] == "integrated_diagnostic"
+        Path(result["file_path"]).unlink()

--- a/tests/test_integrated_report.py
+++ b/tests/test_integrated_report.py
@@ -28,7 +28,10 @@ from predictive_maintenance_mcp.report_generator import (
 )
 from predictive_maintenance_mcp.diagnostics.iso20816 import THRESHOLD_PROVENANCE
 
-from tests.test_advisory import (
+# Sibling-module import, not `from tests.…`: pytest puts the tests directory
+# on sys.path, but only `python -m pytest` also puts the repo root there. CI
+# invokes the console script, where the packaged form would not resolve.
+from test_advisory import (  # noqa: E402
     _anomaly,
     _bearing_faults,
     _diagnosis,

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -761,5 +761,130 @@ class TestToolRegistration:
             "generate_pca_visualization_report",
             "generate_feature_comparison_report",
             "generate_diagnostic_report_docx",
+            "generate_diagnostic_report",
         }
         assert set(tools) == expected
+
+
+# ---------------------------------------------------------------------------
+# generate_diagnostic_report — the integrated, server-authored report
+#
+# The point of this tool is that the caller supplies inputs, not wording.
+# These tests hold that line.
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateDiagnosticReport:
+    @pytest.mark.asyncio
+    async def test_returns_statements_and_one_file_per_format(
+        self, tools, repo, reports_dir, mock_ctx
+    ):
+        result = await tools["generate_diagnostic_report"](
+            signal_id="report_test", rpm=1500.0, ctx=mock_ctx
+        )
+        assert result["statements"], "no authored statements returned"
+        assert [f["format"] for f in result["files"]] == ["html"]
+        assert Path(result["files"][0]["file_path"]).exists()
+
+    @pytest.mark.asyncio
+    async def test_statements_match_what_the_document_renders(
+        self, tools, repo, reports_dir, mock_ctx
+    ):
+        """Covers AE4."""
+        import html as _html
+
+        result = await tools["generate_diagnostic_report"](
+            signal_id="report_test", rpm=1500.0, ctx=mock_ctx
+        )
+        rendered = Path(result["files"][0]["file_path"]).read_text(encoding="utf-8")
+        missing = [s for s in result["statements"] if _html.escape(s) not in rendered]
+        assert missing == [], f"returned but not rendered: {missing}"
+
+    @pytest.mark.asyncio
+    async def test_unknown_signal_raises_rather_than_returning_an_error_dict(
+        self, tools, repo, reports_dir, mock_ctx
+    ):
+        with pytest.raises(ValueError):
+            await tools["generate_diagnostic_report"](
+                signal_id="nope", rpm=1500.0, ctx=mock_ctx
+            )
+
+    @pytest.mark.asyncio
+    async def test_unsupported_format_raises_before_any_analysis(
+        self, tools, repo, reports_dir, mock_ctx
+    ):
+        with pytest.raises(ValueError, match="Unsupported report format"):
+            await tools["generate_diagnostic_report"](
+                signal_id="report_test", rpm=1500.0, formats=["docx"], ctx=mock_ctx
+            )
+
+    @pytest.mark.asyncio
+    async def test_no_confidence_field_reaches_the_caller(
+        self, tools, repo, reports_dir, mock_ctx
+    ):
+        """Covers AE6 at the tool boundary — the surface an LLM actually reads."""
+        result = await tools["generate_diagnostic_report"](
+            signal_id="report_test", rpm=1500.0, ctx=mock_ctx
+        )
+
+        def walk(node, path=""):
+            if isinstance(node, dict):
+                for key, value in node.items():
+                    assert "confidence" not in key.lower(), f"{path}.{key}"
+                    walk(value, f"{path}.{key}")
+            elif isinstance(node, list):
+                for i, value in enumerate(node):
+                    walk(value, f"{path}[{i}]")
+
+        walk(result)
+        assert "not a confidence" in result["evidence_strength_note"].lower()
+
+    @pytest.mark.asyncio
+    async def test_baseline_signal_produces_a_comparison(
+        self, tools, repo, data_dir, reports_dir, mock_ctx
+    ):
+        _load_extra_signal(repo, data_dir, "report_baseline.csv")
+        result = await tools["generate_diagnostic_report"](
+            signal_id="report_test",
+            rpm=1500.0,
+            baseline_signal_id="report_baseline",
+            ctx=mock_ctx,
+        )
+        joined = " ".join(result["statements"]).lower()
+        assert "baseline" in joined
+
+    @pytest.mark.asyncio
+    async def test_absent_baseline_states_the_absence(
+        self, tools, repo, reports_dir, mock_ctx
+    ):
+        result = await tools["generate_diagnostic_report"](
+            signal_id="report_test", rpm=1500.0, ctx=mock_ctx
+        )
+        joined = " ".join(result["statements"]).lower()
+        assert "no healthy baseline was supplied" in joined
+
+    @pytest.mark.asyncio
+    async def test_recommendations_carry_motivation(
+        self, tools, repo, reports_dir, mock_ctx
+    ):
+        result = await tools["generate_diagnostic_report"](
+            signal_id="report_test", rpm=1500.0, ctx=mock_ctx
+        )
+        assert result["recommendations"]
+        for rec in result["recommendations"]:
+            assert rec["motivation"]
+
+    def test_docstring_states_the_caller_authorship_prohibition(self, tools):
+        """The docstring is what a model reads before deciding how to render."""
+        doc = tools["generate_diagnostic_report"].__doc__ or ""
+        lowered = doc.lower()
+        assert "authorship contract" in lowered
+        assert "verbatim" in lowered
+        assert "confidence" in lowered
+
+    def test_server_instructions_carry_the_same_rule(self):
+        from predictive_maintenance_mcp.server import mcp as server
+
+        instructions = (server.instructions or "").lower()
+        assert "report authorship policy" in instructions
+        assert "no confidence score" in instructions

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -9,7 +9,8 @@ was consolidated to the target surface of 33 tools + 0 resources +
 - its destination is a registered endpoint of the NEW surface (kept name,
   renamed name, or the absorbing tool), or ``None`` with a motivation
   string for outright drops;
-- the new surface counts exactly 33/0/3;
+- the new surface counts exactly 33 migrated tools plus the declared
+  post-consolidation additions in POST_U9_ADDITIONS, 0 resources, 3 prompts;
 - naming hygiene: no ``_tool`` suffixes, and the retired duplicate-concept
   parameter names (shaft_speed_rpm, rotation_freq, ...) are absent from
   every tool signature and prompt argument list.
@@ -30,6 +31,24 @@ from predictive_maintenance_mcp.mcp_tools import register_all
 # destination is the NEW endpoint the functionality lives in, or None for
 # an outright drop (note then carries the motivation).
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Tools added deliberately AFTER the v0.9.0 consolidation. The migration table
+# below describes where the old surface went; it cannot describe a capability
+# that did not exist then. Adding a tool is permitted in a minor version (see
+# the backward-compatibility invariant in CLAUDE.md) — declaring it here is
+# what keeps "no orphan tools" meaningful, since anything registered but
+# neither migrated nor declared appeared by accident.
+# ---------------------------------------------------------------------------
+
+POST_U9_ADDITIONS: dict[str, str] = {
+    "generate_diagnostic_report": (
+        "v0.10 — integrated, server-authored diagnostic report. New concept: "
+        "generate_diagnostic_report_docx takes its content sections from the "
+        "caller, this one authors them."
+    ),
+}
+
 
 OLD_TO_NEW: dict[str, tuple[str | None, str]] = {
     # ----- lifecycle -------------------------------------------------------
@@ -255,15 +274,35 @@ class TestDestinationsExist:
                 f"{old} -> {destination}: destination prompt not registered"
             )
 
-    def test_every_current_tool_descends_from_the_old_surface(self, registered):
-        """No orphan tools: the new surface is exactly the set of destinations."""
+    def test_every_current_tool_is_migrated_or_declared(self, registered):
+        """No orphan tools.
+
+        Every registered tool either descends from the v0.8.x surface via
+        OLD_TO_NEW, or is a deliberate post-consolidation addition declared
+        in POST_U9_ADDITIONS. A tool that is neither appeared by accident.
+        """
         tools, _, _ = registered
         destinations = {
             dest
             for old, (dest, _) in OLD_TO_NEW.items()
             if dest is not None and old not in OLD_PROMPTS
         }
-        assert destinations == set(tools)
+        assert destinations | set(POST_U9_ADDITIONS) == set(tools)
+
+    def test_declared_additions_are_actually_registered(self, registered):
+        """A stale entry in the additions register is as bad as a silent one."""
+        tools, _, _ = registered
+        missing = [name for name in POST_U9_ADDITIONS if name not in tools]
+        assert missing == [], f"declared but not registered: {missing}"
+
+    def test_additions_do_not_shadow_a_migrated_tool(self, registered):
+        """An addition must be a new concept, not a second name for an old one."""
+        destinations = {
+            dest
+            for old, (dest, _) in OLD_TO_NEW.items()
+            if dest is not None and old not in OLD_PROMPTS
+        }
+        assert set(POST_U9_ADDITIONS).isdisjoint(destinations)
 
 
 # ---------------------------------------------------------------------------
@@ -272,9 +311,11 @@ class TestDestinationsExist:
 
 
 class TestFinalSurface:
-    def test_counts_exactly_33_0_3(self, registered):
+    def test_counts_are_the_migrated_surface_plus_declared_additions(
+        self, registered
+    ):
         tools, resources, prompts = registered
-        assert len(tools) == 33
+        assert len(tools) == 33 + len(POST_U9_ADDITIONS)
         assert resources == []
         assert len(prompts) == 3
 

--- a/tests/test_tool_inventory.py
+++ b/tests/test_tool_inventory.py
@@ -38,6 +38,12 @@ Fixture history:
   concept sweep (rpm, file_name, bearing_id); typed vocabularies
   (fault_types, severity_zone, scope). Full old->new mapping asserted in
   tests/test_surface_parity.py.
+- v0.10: regenerated intentionally — ADDITIVE. generate_diagnostic_report
+  joins the surface (33 -> 34 tools; resources/prompts unchanged at 0/3).
+  It is the first tool that is not a migration destination, so it is
+  declared in tests/test_surface_parity.py POST_U9_ADDITIONS; the parity
+  test's "no orphan tools" property now reads "migrated or declared".
+  No existing tool signature changed.
 
 Snapshot recipe (run from the repo root):
     python -c "from tests.test_tool_inventory import build_inventory, \\
@@ -114,8 +120,14 @@ class TestInventoryCharacterization:
         assert inventory["prompts"] == reference["prompts"]
 
     def test_expected_counts(self, inventory):
-        """FINAL U9 target surface: 33 tools + 0 resources + 3 prompts."""
-        assert len(inventory["tools"]) == 33
+        """U9 target surface (33/0/3) plus declared post-U9 additions.
+
+        The additions register lives in tests/test_surface_parity.py so
+        there is one place to declare a new tool, not two.
+        """
+        from tests.test_surface_parity import POST_U9_ADDITIONS
+
+        assert len(inventory["tools"]) == 33 + len(POST_U9_ADDITIONS)
         assert len(inventory["resources"]) == 0
         assert len(inventory["prompts"]) == 3
 

--- a/tests/test_tool_inventory.py
+++ b/tests/test_tool_inventory.py
@@ -125,7 +125,9 @@ class TestInventoryCharacterization:
         The additions register lives in tests/test_surface_parity.py so
         there is one place to declare a new tool, not two.
         """
-        from tests.test_surface_parity import POST_U9_ADDITIONS
+        # Sibling-module import: CI runs the pytest console script, which
+        # does not put the repo root on sys.path.
+        from test_surface_parity import POST_U9_ADDITIONS
 
         assert len(inventory["tools"]) == 33 + len(POST_U9_ADDITIONS)
         assert len(inventory["resources"]) == 0

--- a/tests/test_version_alignment.py
+++ b/tests/test_version_alignment.py
@@ -208,13 +208,16 @@ class TestEndpointCountClaims:
             )
 
     def test_expected_final_surface(self, surface_counts):
-        """The U9 target surface, restated here so a surface change makes
-        BOTH the inventory test and the doc guards go red together."""
+        """The current surface, restated here so a surface change makes
+        BOTH the inventory test and the doc guards go red together.
+
+        v0.10 added generate_diagnostic_report (33 -> 34 tools). The
+        additions register lives in tests/test_surface_parity.py."""
         assert surface_counts == {
-            "tools": 33,
+            "tools": 34,
             "resources": 0,
             "prompts": 3,
-            "endpoints": 36,
+            "endpoints": 37,
         }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version < '3.12'",
 ]
 
@@ -88,6 +89,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/63/d45ef97ada84111e330b2b2d45e1dd163e90bd116f00ac55927fb6bf8adb/black-25.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bd4a22a0b37401c8e492e994bce79e614f91b14d9ea911f44f36e262195fdda", size = 1680571, upload-time = "2025-11-10T01:57:04.239Z" },
     { url = "https://files.pythonhosted.org/packages/ff/4b/5604710d61cdff613584028b4cb4607e56e148801ed9b38ee7970799dab6/black-25.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:aa211411e94fdf86519996b7f5f05e71ba34835d8f0c0f03c00a26271da02664", size = 1382599, upload-time = "2025-11-10T01:57:57.427Z" },
     { url = "https://files.pythonhosted.org/packages/00/5d/aed32636ed30a6e7f9efd6ad14e2a0b0d687ae7c8c7ec4e4a557174b895c/black-25.11.0-py3-none-any.whl", hash = "sha256:e3f562da087791e96cefcd9dda058380a442ab322a02e222add53736451f604b", size = 204918, upload-time = "2025-11-10T01:53:48.917Z" },
+]
+
+[[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ef/f285668811a9e1ddb47a18cb0b437d5fc2760d537a2fe8a57875ad6f8448/brotli-1.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:15b33fe93cedc4caaff8a0bd1eb7e3dab1c61bb22a0bf5bdfdfd97cd7da79744", size = 863110, upload-time = "2025-11-05T18:38:12.978Z" },
+    { url = "https://files.pythonhosted.org/packages/50/62/a3b77593587010c789a9d6eaa527c79e0848b7b860402cc64bc0bc28a86c/brotli-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:898be2be399c221d2671d29eed26b6b2713a02c2119168ed914e7d00ceadb56f", size = 445438, upload-time = "2025-11-05T18:38:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e1/7fadd47f40ce5549dc44493877db40292277db373da5053aff181656e16e/brotli-1.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:350c8348f0e76fff0a0fd6c26755d2653863279d086d3aa2c290a6a7251135dd", size = 1534420, upload-time = "2025-11-05T18:38:15.111Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8b/1ed2f64054a5a008a4ccd2f271dbba7a5fb1a3067a99f5ceadedd4c1d5a7/brotli-1.2.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e1ad3fda65ae0d93fec742a128d72e145c9c7a99ee2fcd667785d99eb25a7fe", size = 1632619, upload-time = "2025-11-05T18:38:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5a/7071a621eb2d052d64efd5da2ef55ecdac7c3b0c6e4f9d519e9c66d987ef/brotli-1.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:40d918bce2b427a0c4ba189df7a006ac0c7277c180aee4617d99e9ccaaf59e6a", size = 1426014, upload-time = "2025-11-05T18:38:17.177Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6d/0971a8ea435af5156acaaccec1a505f981c9c80227633851f2810abd252a/brotli-1.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2a7f1d03727130fc875448b65b127a9ec5d06d19d0148e7554384229706f9d1b", size = 1489661, upload-time = "2025-11-05T18:38:18.41Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/75/c1baca8b4ec6c96a03ef8230fab2a785e35297632f402ebb1e78a1e39116/brotli-1.2.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9c79f57faa25d97900bfb119480806d783fba83cd09ee0b33c17623935b05fa3", size = 1599150, upload-time = "2025-11-05T18:38:19.792Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1a/23fcfee1c324fd48a63d7ebf4bac3a4115bdb1b00e600f80f727d850b1ae/brotli-1.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:844a8ceb8483fefafc412f85c14f2aae2fb69567bf2a0de53cdb88b73e7c43ae", size = 1493505, upload-time = "2025-11-05T18:38:20.913Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e5/12904bbd36afeef53d45a84881a4810ae8810ad7e328a971ebbfd760a0b3/brotli-1.2.0-cp311-cp311-win32.whl", hash = "sha256:aa47441fa3026543513139cb8926a92a8e305ee9c71a6209ef7a97d91640ea03", size = 334451, upload-time = "2025-11-05T18:38:21.94Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8b/ecb5761b989629a4758c394b9301607a5880de61ee2ee5fe104b87149ebc/brotli-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:022426c9e99fd65d9475dce5c195526f04bb8be8907607e27e747893f6ee3e24", size = 369035, upload-time = "2025-11-05T18:38:22.941Z" },
+    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d4/4ad5432ac98c73096159d9ce7ffeb82d151c2ac84adcc6168e476bb54674/brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab", size = 861523, upload-time = "2025-11-05T18:38:34.67Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/9cc5bd03ee68a85dc4bc89114f7067c056a3c14b3d95f171918c088bf88d/brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c", size = 444289, upload-time = "2025-11-05T18:38:35.6Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/fe84227c56a865d16a6614e2c4722864b380cb14b13f3e6bef441e73a85a/brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f", size = 1528076, upload-time = "2025-11-05T18:38:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/55/de/de4ae0aaca06c790371cf6e7ee93a024f6b4bb0568727da8c3de112e726c/brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6", size = 1626880, upload-time = "2025-11-05T18:38:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/16/a1b22cbea436642e071adcaf8d4b350a2ad02f5e0ad0da879a1be16188a0/brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c", size = 1419737, upload-time = "2025-11-05T18:38:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/c968a97cbb3bdbf7f974ef5a6ab467a2879b82afbc5ffb65b8acbb744f95/brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48", size = 1484440, upload-time = "2025-11-05T18:38:39.916Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/102c67ea5c9fc171f423e8399e585dabea29b5bc79b05572891e70013cdd/brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18", size = 1593313, upload-time = "2025-11-05T18:38:41.24Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/9526d14fa6b87bc827ba1755a8440e214ff90de03095cacd78a64abe2b7d/brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5", size = 1487945, upload-time = "2025-11-05T18:38:42.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e8/3fe1ffed70cbef83c5236166acaed7bb9c766509b157854c80e2f766b38c/brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a", size = 334368, upload-time = "2025-11-05T18:38:43.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/e739587be970a113b37b821eae8097aac5a48e5f0eca438c22e4c7dd8648/brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8", size = 369116, upload-time = "2025-11-05T18:38:44.609Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
+name = "brotlicffi"
+version = "1.2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/b6/017dc5f852ed9b8735af77774509271acbf1de02d238377667145fcee01d/brotlicffi-1.2.0.1.tar.gz", hash = "sha256:c20d5c596278307ad06414a6d95a892377ea274a5c6b790c2548c009385d621c", size = 478156, upload-time = "2026-03-05T19:54:11.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/f9/dfa56316837fa798eac19358351e974de8e1e2ca9475af4cb90293cd6576/brotlicffi-1.2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c85e65913cf2b79c57a3fdd05b98d9731d9255dc0cb696b09376cc091b9cddd", size = 433046, upload-time = "2026-03-05T19:53:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f5/f8f492158c76b0d940388801f04f747028971ad5774287bded5f1e53f08d/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:535f2d05d0273408abc13fc0eebb467afac17b0ad85090c8913690d40207dac5", size = 1541126, upload-time = "2026-03-05T19:53:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e1/ff87af10ac419600c63e9287a0649c673673ae6b4f2bcf48e96cb2f89f60/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce17eb798ca59ecec67a9bb3fd7a4304e120d1cd02953ce522d959b9a84d58ac", size = 1541983, upload-time = "2026-03-05T19:53:50.317Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c0/80ecd9bd45776109fab14040e478bf63e456967c9ddee2353d8330ed8de1/brotlicffi-1.2.0.1-cp314-cp314t-win32.whl", hash = "sha256:3c9544f83cb715d95d7eab3af4adbbef8b2093ad6382288a83b3a25feb1a57ec", size = 349047, upload-time = "2026-03-05T19:53:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/98/13e5b250236a281b6cd9e92a01ee1ae231029fa78faee932ef3766e1cb24/brotlicffi-1.2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:625f8115d32ae9c0740d01ea51518437c3fbaa3e78d41cb18459f6f7ac326000", size = 385652, upload-time = "2026-03-05T19:53:53.892Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9f/b98dcd4af47994cee97aebac866996a006a2e5fc1fd1e2b82a8ad95cf09c/brotlicffi-1.2.0.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:91ba5f0ccc040f6ff8f7efaf839f797723d03ed46acb8ae9408f99ffd2572cf4", size = 432608, upload-time = "2026-03-05T19:53:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/7a/ac4ee56595a061e3718a6d1ea7e921f4df156894acffb28ed88a1fd52022/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9a670c6811af30a4bd42d7116dc5895d3b41beaa8ed8a89050447a0181f5ce", size = 1534257, upload-time = "2026-03-05T19:53:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/e7410db7f6f56de57744ea52a115084ceb2735f4d44973f349bb92136586/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3314a3476f59e5443f9f72a6dff16edc0c3463c9b318feaef04ae3e4683f5a", size = 1536838, upload-time = "2026-03-05T19:54:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/75/6e7977d1935fc3fbb201cbd619be8f2c7aea25d40a096967132854b34708/brotlicffi-1.2.0.1-cp38-abi3-win32.whl", hash = "sha256:82ea52e2b5d3145b6c406ebd3efb0d55db718b7ad996bd70c62cec0439de1187", size = 343337, upload-time = "2026-03-05T19:54:02.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ef/e7e485ce5e4ba3843a0a92feb767c7b6098fd6e65ce752918074d175ae71/brotlicffi-1.2.0.1-cp38-abi3-win_amd64.whl", hash = "sha256:da2e82a08e7778b8bc539d27ca03cdd684113e81394bfaaad8d0dfc6a17ddede", size = 379026, upload-time = "2026-03-05T19:54:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/53/6262c2256513e6f530d81642477cb19367270922063eaa2d7b781d8c723d/brotlicffi-1.2.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:e015af99584c6db1490a69a210c765953e473e63adc2d891ac3062a737c9e851", size = 402265, upload-time = "2026-03-05T19:54:05.858Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d9/d5340b43cf5fbe7fe5a083d237e5338cc1caa73bea523be1c5e452c26290/brotlicffi-1.2.0.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37cb587d32bf7168e2218c455e22e409ad1f3157c6c71945879a311f3e6b6abf", size = 406710, upload-time = "2026-03-05T19:54:07.272Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/82/dbced4c1e0792efdf23fd90ff6d2a320c64ff4dfef7aacc85c04fde9ddd2/brotlicffi-1.2.0.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d6ba65dd528892b4d9960beba2ae011a753620bcfc66cf6fa3cee18d7b0baa4", size = 402787, upload-time = "2026-03-05T19:54:08.73Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/6f/534205ba7590c9a8716a614f270c5c2ec419b5b7079b3f9cd31b7b5580de/brotlicffi-1.2.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2a5575653b0672638ba039b82fda56854934d7a6a24d4b8b5033f73ab43cbc1", size = 375108, upload-time = "2026-03-05T19:54:10.079Z" },
 ]
 
 [[package]]
@@ -441,6 +515,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cssselect2"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tinycss2" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/20/92eaa6b0aec7189fa4b75c890640e076e9e793095721db69c5c81142c2e1/cssselect2-0.9.0.tar.gz", hash = "sha256:759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb", size = 35595, upload-time = "2026-02-12T17:16:39.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl", hash = "sha256:6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563", size = 15453, upload-time = "2026-02-12T17:16:38.317Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -568,6 +655,62 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/2b/a7f1545bdf5da69c4bda0cea2a5781f0ad2a6623e0277267672db43c5fe6/fonttools-4.63.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2b8ae05d9eacf6081414d759c0a352769ac28ce31280d6bb8e77b03f9e3c449f", size = 2881793, upload-time = "2026-05-14T12:02:56.645Z" },
+    { url = "https://files.pythonhosted.org/packages/49/50/965308c703f085f225db2886813b27e015b8b3438c350b22dd65b52c2a2c/fonttools-4.63.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:79cdc9f567aec74a72918fd060283911406750cbc9fd28c1316023deb6ce31a9", size = 2428130, upload-time = "2026-05-14T12:02:58.891Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/38/6937fbd7f2dc3a6b48725851bc2c15ec949b9af14d9bbcb5fe83cdf9bdf9/fonttools-4.63.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c14b4fd138c4bafcca294765c547914e1aa431ae1ca94ab99d8db08c958bd3b", size = 5111952, upload-time = "2026-05-14T12:03:01.263Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/a81f20050a3115b57d62c8e781446949512eac36690dc384ccea65ff4cc1/fonttools-4.63.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76ac49f929aecaf82d83250b8347e099d7aecba0f4726c1d9b6df3b8bb5fe18", size = 5082308, upload-time = "2026-05-14T12:03:03.211Z" },
+    { url = "https://files.pythonhosted.org/packages/67/00/cdd9d4944ca6ae280d01e69cc37bde3bf663630b837a6fc6d2cd65d80e0e/fonttools-4.63.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dcf076a4474fe0d7367e5bbf5b052c7284fa1feca729c04176ce513521afd8a0", size = 5087932, upload-time = "2026-05-14T12:03:05.147Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f1/0aa0dbea778c75adbef223c42019fd47d22262b905974d62d829545d485f/fonttools-4.63.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7dd683fef0663e9f0f45cf541d788d24caa3ec9db50796b588e1757d8b3bc007", size = 5213271, upload-time = "2026-05-14T12:03:07.238Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/253e4056e1f0e67b9390125a154b73b5eb73ad521bece95c004858fdeec2/fonttools-4.63.0-cp311-cp311-win32.whl", hash = "sha256:afefc1ed0a59785a7fb06ea7e1678e849c193e1e387db783579bc7b3056fcfcb", size = 2304473, upload-time = "2026-05-14T12:03:09.271Z" },
+    { url = "https://files.pythonhosted.org/packages/08/60/defa5e69641db890a63be281f41345f4c33b157824eaf0b9fad3e08b0dcb/fonttools-4.63.0-cp311-cp311-win_amd64.whl", hash = "sha256:063e08bd17bd5a90127a14123de0d6a952dbc847695fd98b63c043d58057f90c", size = 2356389, upload-time = "2026-05-14T12:03:11.53Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ef/b3c6b9b5be2f82416d73fe2ed2e96e2793cd80e7510bd6a17ca79cdd88ec/fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02", size = 2881131, upload-time = "2026-05-14T12:03:13.386Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/c815bea63117fa63e4e1c01f8a1110d2112fa003f838e6467094ec2432ce/fonttools-4.63.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a9faff9e0c1f76f9fd55899d2ce785832efebab37eb8ae13995853aef178bef0", size = 2426704, upload-time = "2026-05-14T12:03:15.801Z" },
+    { url = "https://files.pythonhosted.org/packages/44/04/0b91d8e916e92ad1fac9e4624760baf0fd5ff2ead614c2f68fb21373f03f/fonttools-4.63.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef3048ef05dbb552b89817713d9cac912e00d0fde4a3105c00d29e52e10c89af", size = 5044298, upload-time = "2026-05-14T12:03:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58dc6bb86a78d782f00f9190ca02c119cf5bbe2807536e361e18d42019f877d8", size = 4999800, upload-time = "2026-05-14T12:03:20.161Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/6d/67fe16c48d7ce050979b33f47e0d28a318f02da030602e944c34f7a16ef3/fonttools-4.63.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee08ebfa58f6e1aeff5697ab9582105bb620008c1caafb681e4c557e7483027b", size = 4982666, upload-time = "2026-05-14T12:03:22.87Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/3bbab338c07c71fa56269953845e92c951a61457bbbb0f1022551ea266d9/fonttools-4.63.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:27fdc65af8da6f88b9c6121c47a464cbe359fcfff7ff6fc2d37a1f395d755b78", size = 5133598, upload-time = "2026-05-14T12:03:25.168Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/aa27c7f98db5b064883dadcc5283947e81e034de42e22a33675878d98b54/fonttools-4.63.0-cp312-cp312-win32.whl", hash = "sha256:af2fd1664d00a397d75f806985ddb36282091c2131a73a6485c23b4a34722263", size = 2292575, upload-time = "2026-05-14T12:03:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/87/36/cccb9bc2a6ab63d1b2980374f0dca72ce95ae267c9b4cfe77455bb70d0d4/fonttools-4.63.0-cp312-cp312-win_amd64.whl", hash = "sha256:59ac449f8cca9b4ffa08d2e7bbadad87ce710d69d1eda5c3c1ce579baa987272", size = 2343211, upload-time = "2026-05-14T12:03:30.057Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8d/d8fec3dcde2963f8c908fb315e5ff2cd0ac34f82394bbbf73a2aa5145ce3/fonttools-4.63.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd7e9857e5e63738b9d9fd707bc1f59c8b09e5177726d23664db393c59bb08bd", size = 2876062, upload-time = "2026-05-14T12:03:32.554Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/71/d935dc54e4ff121bfdd11e08702db63a7e6f25af21d8a3d7b7212df53641/fonttools-4.63.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2a2a42198b696a6f48fad91709afb55176e66a5e566131219dba372fb7f8c59", size = 2424594, upload-time = "2026-05-14T12:03:34.86Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/40/e76320afa1df918e146155ef239b1719ee266092e96f5423bfd075affba1/fonttools-4.63.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e874792a8212b44583ea02189d9e693906b2f78b261f372f95d6c563210ac1d", size = 5024840, upload-time = "2026-05-14T12:03:36.745Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/36/0b805d8c485f872f65a509cbe3b58a5d0d17bee855333b54a150c79d3061/fonttools-4.63.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22135da48a348785c5e2d5d2d9d6bec5ed44adacbaeb9db12d9493bf6c6bfa68", size = 4975801, upload-time = "2026-05-14T12:03:38.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/26/2cee03d0aa083ab022da5c07aff9ed3f689da1defb81ad6917c9627896da/fonttools-4.63.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ccf41f2efdf56994d22d73bef4ced1052161958169428d06ba9724ea9e9a64be", size = 4965009, upload-time = "2026-05-14T12:03:41.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/48/cc4b66d9058c0d0982c833fad10127c4b0e9324606aafa41382295ca4102/fonttools-4.63.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9ced0bd02ac751dd6319b0da88aaef24414e3b0dbc32bb4f24944821a3741a27", size = 5105892, upload-time = "2026-05-14T12:03:43.525Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1f/a98a30a814b9ddef3a2e706025f90b9e0bc94890e6cb15254bc86547d11a/fonttools-4.63.0-cp313-cp313-win32.whl", hash = "sha256:85be818f5506e8a7753153def2c9550178f0ecae6a47b5e0e8dbb23f7cc90380", size = 2291313, upload-time = "2026-05-14T12:03:45.594Z" },
+    { url = "https://files.pythonhosted.org/packages/92/46/5177b01f3b4abfdd4409f31cca4ab279c9343a26efbe9ec78c97fc612e02/fonttools-4.63.0-cp313-cp313-win_amd64.whl", hash = "sha256:ba04cb5891d4c0c21b6da95eda8d7b090021508a294fff33464fc7d241e0856b", size = 2342299, upload-time = "2026-05-14T12:03:47.414Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d2/23d25e3f247b328be58d04a4c9f894178a0d1eda7d42867cfb388adaf416/fonttools-4.63.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd1e3094f42d806d3d7c79162fc59e5910fcbe3a7360c385b8da969bc4493745", size = 2875338, upload-time = "2026-05-14T12:03:50.052Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/58/7dfa0c761cb3b2964e2a84c4dc986c926a87de0cb9fb60d5b28ded3f2914/fonttools-4.63.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6e528da43bc3791085f8cb6141b1d13e459226790240340fcbb4625649238b03", size = 2422661, upload-time = "2026-05-14T12:03:52.154Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/87/64cfa18a7a1621d17b7f4502b2b0ed8a135a90c3db51ea590ee99043e76b/fonttools-4.63.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b2248c5decb223562f7902ff6325077a073f608ee8e33e88ad88db734eb9f49", size = 5010526, upload-time = "2026-05-14T12:03:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e1/a8933a72c45a87177fbde2696e0d0755c8c9062f8c077a961c6215fa27b1/fonttools-4.63.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:308f957cdeaf8abe4e5f2f124902ef405448af92c90f80e302a3b771c2e6116b", size = 4923946, upload-time = "2026-05-14T12:03:56.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/872e6e233b8c5e8b41413796ff18b7fe479661bd40147e071b450dfad7a1/fonttools-4.63.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bf00f21eb5fb721dbaf73d1e9da6d02a1af7768f2ebcf9798be98beab8ba90f6", size = 4962489, upload-time = "2026-05-14T12:03:59.443Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c4/83c24f2ec38b90cfda84bf4b1a1f49df80e84a1db4e7ac6e0d41bf23bc39/fonttools-4.63.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c1aaa4b9c75798400ac043ce04d74e7830376c85095a5a6ed7cba2f17a266bf4", size = 5071870, upload-time = "2026-05-14T12:04:02.122Z" },
+    { url = "https://files.pythonhosted.org/packages/de/40/3ae22b60ff1d41ce0bd044b31238cdc72cef99f28b976f1e128ebd618c9b/fonttools-4.63.0-cp314-cp314-win32.whl", hash = "sha256:22693918177bd9ceabec4736d338045f357769416fc6b0b2508eefef75b08616", size = 2295026, upload-time = "2026-05-14T12:04:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d4/98078064ccc76b45cb0f6c002452011e93c4bd26f6850344f0951cc1fe89/fonttools-4.63.0-cp314-cp314-win_amd64.whl", hash = "sha256:7d782fac32985914c351556f68ac0855391572bcd87de50e05970d3cd4c96fc5", size = 2347454, upload-time = "2026-05-14T12:04:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4e/652d1580c5f4e39f7d103b0c793e4773129ad633dce4addd0cf4dfebde02/fonttools-4.63.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6db5140a60a5d731d21ec076745b40a310607731b0a565b50776393188649001", size = 2958152, upload-time = "2026-05-14T12:04:08.706Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/55/ad864c9a9b219f552eb46b32cd7906c466e5a578ba0c3abfcc0fe7413eb6/fonttools-4.63.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d76edbff9014094dbf03bd2d074709dfa6ec7aba13d838c937a2b33d2d6a86e", size = 2460809, upload-time = "2026-05-14T12:04:10.783Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2b/0aa8db70f18cf52e49b4ed5ecec68547f981160bf5ded3b5aed6faa0a6f9/fonttools-4.63.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0eac00b9118c3c2f87d272e45341871c5b3066baa3c86897fa634a7c3fb59096", size = 5148649, upload-time = "2026-05-14T12:04:12.747Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/63/18e4369c25043096f1048e0c9915951adc4f842bd81c6b18155824d6fa99/fonttools-4.63.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51394295f1a51de8b5f30bdb1e1b9a4231536c7064ef5c6e211eec19fa36036f", size = 4932147, upload-time = "2026-05-14T12:04:14.806Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/3f/67f3eac2ffd8a98446c5022f8ed3864eac878a5ff7af8df4c8286dba16cc/fonttools-4.63.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9e12f105d2b6342c559c298afb674006bb2893afc7102dcf8a1b55b0486b4e40", size = 5027237, upload-time = "2026-05-14T12:04:17.675Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ba/4e6214cb38a7b04779e97bb7636de9a5c7f20af7018d03dee0b64c08510a/fonttools-4.63.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:796f27556dbe094c4824f75ca85267e4df776c79036c8441469a4df37038c196", size = 5053933, upload-time = "2026-05-14T12:04:20.818Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3b/214dcc19ee31d3d38fb5ad2755c11ef0514e5dc300bbaf41c0b69f393799/fonttools-4.63.0-cp314-cp314t-win32.whl", hash = "sha256:948428a275741f0b64b113c955425a953314f4b9ab9997f73a72c83e68e569c8", size = 2359326, upload-time = "2026-05-14T12:04:24.22Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1e/3ff1a9b523058c2eeb6a9d50f5574e2a738200d0d94107d5bc4105e8da3f/fonttools-4.63.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d4741eb179121cab9eea4cb2393d24492373a260d7945006358c08cfbf45419", size = 2425829, upload-time = "2026-05-14T12:04:26.829Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
+]
+
+[package.optional-dependencies]
+woff = [
+    { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
+    { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
+    { name = "zopfli" },
 ]
 
 [[package]]
@@ -1535,7 +1678,7 @@ wheels = [
 
 [[package]]
 name = "predictive-maintenance-mcp"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -1585,6 +1728,7 @@ full = [
     { name = "sphinx-autodoc-typehints", version = "3.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-rtd-theme" },
     { name = "uvicorn" },
+    { name = "weasyprint" },
 ]
 ml = [
     { name = "scikit-learn" },
@@ -1593,6 +1737,9 @@ ocr = [
     { name = "pdf2image" },
     { name = "pillow" },
     { name = "pytesseract" },
+]
+pdf = [
+    { name = "weasyprint" },
 ]
 sse = [
     { name = "uvicorn" },
@@ -1618,7 +1765,7 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'ocr'", specifier = ">=10.0" },
     { name = "plotly", specifier = ">=5.24.0" },
     { name = "plotly", marker = "extra == 'viz'", specifier = ">=5.20" },
-    { name = "predictive-maintenance-mcp", extras = ["docs", "ml", "viz", "vector-search", "ocr", "docx", "sse"], marker = "extra == 'full'" },
+    { name = "predictive-maintenance-mcp", extras = ["docs", "ml", "viz", "vector-search", "ocr", "docx", "pdf", "sse"], marker = "extra == 'full'" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pypdf", specifier = ">=4.0" },
     { name = "pypdf", marker = "extra == 'docs'", specifier = ">=4.0" },
@@ -1636,8 +1783,9 @@ requires-dist = [
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=2.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
     { name = "uvicorn", marker = "extra == 'sse'", specifier = ">=0.30" },
+    { name = "weasyprint", marker = "extra == 'pdf'", specifier = ">=60.0" },
 ]
-provides-extras = ["docs", "ml", "viz", "vector-search", "ocr", "docx", "sse", "full", "dev"]
+provides-extras = ["docs", "ml", "viz", "vector-search", "ocr", "docx", "pdf", "sse", "full", "dev"]
 
 [[package]]
 name = "pycodestyle"
@@ -1762,6 +1910,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pydyf"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/ee/fb410c5c854b6a081a49077912a9765aeffd8e07cbb0663cfda310b01fb4/pydyf-0.12.1.tar.gz", hash = "sha256:fbd7e759541ac725c29c506612003de393249b94310ea78ae44cb1d04b220095", size = 17716, upload-time = "2025-12-02T14:52:14.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/11/47efe2f66ba848a107adfd490b508f5c0cedc82127950553dca44d29e6c4/pydyf-0.12.1-py3-none-any.whl", hash = "sha256:ea25b4e1fe7911195cb57067560daaa266639184e8335365cc3ee5214e7eaadc", size = 8028, upload-time = "2025-12-02T14:52:12.938Z" },
+]
+
+[[package]]
 name = "pyflakes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1800,6 +1957,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
+]
+
+[[package]]
+name = "pyphen"
+version = "0.17.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/56/e4d7e1bd70d997713649c5ce530b2d15a5fc2245a74ca820fc2d51d89d4d/pyphen-0.17.2.tar.gz", hash = "sha256:f60647a9c9b30ec6c59910097af82bc5dd2d36576b918e44148d8b07ef3b4aa3", size = 2079470, upload-time = "2025-01-20T13:18:36.296Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/1f/c2142d2edf833a90728e5cdeb10bdbdc094dde8dbac078cee0cf33f5e11b/pyphen-0.17.2-py3-none-any.whl", hash = "sha256:3a07fb017cb2341e1d9ff31b8634efb1ae4dc4b130468c7c39dd3d32e7c3affd", size = 2079358, upload-time = "2025-01-20T13:18:29.629Z" },
 ]
 
 [[package]]
@@ -2492,7 +2658,8 @@ version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
 ]
 dependencies = [
     { name = "alabaster", marker = "python_full_version >= '3.12'" },
@@ -2539,7 +2706,8 @@ version = "3.13.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
 ]
 dependencies = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -2675,6 +2843,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
+name = "tinyhtml5"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/1f/cfe2f6b30557c92b3f31d41707e09cef5c1efbd87392bc6c0430c46b0e4d/tinyhtml5-2.1.0.tar.gz", hash = "sha256:60a50ec3d938a37e491efa01af895853060943dcebb5627de5b10d188b338a67", size = 179242, upload-time = "2026-03-05T17:06:30.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/48/01695a036b695f83fea7aef6955d735db0f517b1c8e25ddb399ac0bdbcbf/tinyhtml5-2.1.0-py3-none-any.whl", hash = "sha256:6e11cfff38515834268daf89d5f85bbde0b6dd02e8d9e212d1385c2289b89f0a", size = 39686, upload-time = "2026-03-05T17:06:28.498Z" },
 ]
 
 [[package]]
@@ -2930,4 +3122,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/57/1616c8274c3442d802621abf5deb230771c7a0fec9414cb6763900eb3868/uvicorn-0.37.0.tar.gz", hash = "sha256:4115c8add6d3fd536c8ee77f0e14a7fd2ebba939fed9b02583a97f80648f9e13", size = 80367, upload-time = "2025-09-23T13:33:47.486Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/cd/584a2ceb5532af99dd09e50919e3615ba99aa127e9850eafe5f31ddfdb9a/uvicorn-0.37.0-py3-none-any.whl", hash = "sha256:913b2b88672343739927ce381ff9e2ad62541f9f8289664fa1d1d3803fa2ce6c", size = 67976, upload-time = "2025-09-23T13:33:45.842Z" },
+]
+
+[[package]]
+name = "weasyprint"
+version = "69.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "cssselect2" },
+    { name = "fonttools", extra = ["woff"] },
+    { name = "pillow" },
+    { name = "pydyf" },
+    { name = "pyphen" },
+    { name = "tinycss2" },
+    { name = "tinyhtml5" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/53/dcc3885c2f7a47faa45f6b8b801412f5f9e055173a52801ef01c09943c5a/weasyprint-69.0.tar.gz", hash = "sha256:a7a32f39ca16bd82ef11de99c92ea4b5f14951c9033af035e451ce4f4ee0a88c", size = 1549834, upload-time = "2026-06-02T14:42:17.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/cb/208525c6bd5033d7b2589b55e07bec23d9c61bb00703cbaf20ef52c3811f/weasyprint-69.0-py3-none-any.whl", hash = "sha256:475951cfd917014de6d4d005caff48c6aa867e7e42b80cd5b16a0484a1609ee6", size = 322872, upload-time = "2026-06-02T14:42:15.871Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "zopfli"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/21/3b6af43a663b22b00e738bb0642931a2579e15da6852613d56c6aa535d28/zopfli-0.4.3.tar.gz", hash = "sha256:d3a50f91a13cea9bafe025de8fd87a005eb26de02a4f0c193127ddbf23ac8ebe", size = 179156, upload-time = "2026-06-10T09:10:19.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/5f/b7d81b670daf990e15a0f7551da96c3c0700f69ae6d96b0245d6a19f51f3/zopfli-0.4.3-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:88f4fbe429aad72bc206275d81fab11a097e0f951a5848d1f51083c37ea73073", size = 291492, upload-time = "2026-06-10T09:10:06.621Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c8/d8d8d731e0b192024567b7198fb77b748821d355f3c8bf0109de27191f43/zopfli-0.4.3-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:769875152d0625c46707bcca57d4b2233fe653482067acd55fbf6ec525cb9bdc", size = 829354, upload-time = "2026-06-10T09:10:07.909Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2b/fbe8ba2ec40f5986b8983a4752f7a32672a80a10ea6e68213324a7055469/zopfli-0.4.3-cp310-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0c9c1d40a8cb1d58762d7e57290ccb753e0828c4d01be8acb59aae5d0ca206", size = 818436, upload-time = "2026-06-10T09:10:09.063Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/63568c54c8b68b9135f3456c5add83797a5528d596657f0e4f4910173b08/zopfli-0.4.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7fa3c35193475290e3f007bbcdebdbae64ba2f012d75c632da0d727e1da50d5e", size = 1778931, upload-time = "2026-06-10T09:10:10.282Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/05/8f3aac10a858e89c2146d3a1f6ce33634c3db757365b4148fef1b85784d2/zopfli-0.4.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:47604eee5c6704bdf0e94d8391fe3b74ddb2abd84128fbcfdc3ee0fc265feaef", size = 1864132, upload-time = "2026-06-10T09:10:11.595Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/20/9ca59d14b91f9fbc631793b4b085b309777edadaca496aa518a180817827/zopfli-0.4.3-cp310-abi3-win32.whl", hash = "sha256:628c3e941752880b3491db8d44163d0aedb221944e22a17187ff7fc549b050f6", size = 271715, upload-time = "2026-06-10T09:10:12.7Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/3a/4ff4fdead77ef30f5832b38a47eb7a1283e98b3c678576b83f8fdfff53eb/zopfli-0.4.3-cp310-abi3-win_amd64.whl", hash = "sha256:921c2c9907f4364963848da5ad194b46d68865e07fdb975d04fd09bc42d47357", size = 288550, upload-time = "2026-06-10T09:10:13.639Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/44/6264f929057236fde72dd6d271f54612b4811ce37288e002f5d5339d696a/zopfli-0.4.3-cp310-abi3-win_arm64.whl", hash = "sha256:7e9703ca6e7ef66c8d05e0826b6f558b680c9db8206f84f05a3ee93430a12e42", size = 451343, upload-time = "2026-06-10T09:10:14.72Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/bf/403da5a753731d9a4e4d65a494c4a9ae5a0fe62e7afffe5ab49915adc9a3/zopfli-0.4.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0087c9a6f0c8a052be0f6d1a9bb71b6caffdd3e10201d6d6166e28d482cebe6d", size = 147045, upload-time = "2026-06-10T09:10:15.883Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/5f/afaa18db62ab44da01a3fc39b6cb110478d26cd2287baa83461c6454ed45/zopfli-0.4.3-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f2e0adcf7d36c6fd0dd36cc771ef7f0c5803a05666feafcd90d7170174a4148e", size = 127265, upload-time = "2026-06-10T09:10:16.911Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/76bdfd8b35300391666b090357d059ce4c555b9d9ce9878dd551a9ad63a0/zopfli-0.4.3-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4f51dd1ab5312e837e2091284e0d9f1a138188f2e65812f9a5799dc02c45f94", size = 124288, upload-time = "2026-06-10T09:10:17.891Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/95/5781bfb29782c39918686070dbf2ad1425c21384c3223f5c6bd911a806f8/zopfli-0.4.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:62248dbf8dbcbd588ee194b210e5be9fa80bce29641f55599d6d394bd2a9d8a3", size = 304624, upload-time = "2026-06-10T09:10:18.944Z" },
 ]


### PR DESCRIPTION
## Why

The HTML reports were one per analysis tool, and the only output that synthesised across tools was DOCX — which takes its content sections from **the caller**, including a free-text `diagnosis` string. When the caller is a language model, the numbers survive the trip and the labels do not.

That is not hypothetical. A rendered report produced this way was reviewed before this work started, and it carried:

- the severity block titled with the bare, edition-less standard number plus "Machine Class II" — a taxonomy this codebase does not use, in place of the `(machine_group, support_type)` vocabulary it does
- the mandatory threshold-provenance caveat from `iso20816.py` silently dropped
- a **"Confidence: high"** chip — a label `recommendations.py:40`, `diagnostics_tools.py:958` and `models.py:516` each go out of their way to refuse

Every displayed number was correct. The two readers this output is meant for — a technician deciding whether to act, and a stakeholder judging whether the tool is credible — receive it detached from the conversation and cannot check any of it.

## What changed

**The server writes the words.** A new `decision_support.advisory` layer turns a `diagnose_vibration` result into authored statements: verdict, evidence, per-indicator blocks, recommendations with their motivation. Renderers place these strings; a test asserts every one of them appears verbatim in the rendered document.

**Missing inputs are stated, not omitted.** No baseline, no bearing metadata, a refused ISO block — each renders a section saying what is missing and which conclusion that costs. A silently absent section reads as "nothing to report", which is a different claim.

**Disagreeing indicators are reconciled.** When the ISO zone reads acceptable while the fault pattern does not, the report says so and names which indicator governs the action.

**The figure carries its own argument.** The annotated envelope spectrum draws the four characteristic-frequency bands at the tolerance the diagnosis actually used, as inline SVG — no CDN script, no hover-only labels. It survives a static export, and it is computed from the same spectrum the bearing matching consumed rather than by a second route.

**Two renderings, one document.** The PDF is a rendering of the same HTML, not a second layout, so parity is structural. A test extracts every authored statement from both and asserts each is in both.

**`evidence_strength` travels with a sentence saying what it counts.** It is a count of independent corroborating findings. On its own, `strong` invites a reader — or a model — to hear a probability; that is almost certainly where the observed confidence chip came from.

## Surface change

Additive: 33 → 34 tools (36 → 37 endpoints). No existing signature changes.

`test_surface_parity.py` previously required every registered tool to be a migration destination of the v0.8.x surface, which forbade adding **any** new capability. It now requires each tool to be migrated **or** declared in `POST_U9_ADDITIONS`, so "no orphan tools" still holds while intentional additions are possible and visible.

## Fixed along the way

- The shared HTML base template interpolated the report title — which carries a user-supplied signal id — unescaped, and embedded its metadata JSON such that a `</script>` in any value could close the block early. Both affected **every** report family.
- The trace was uncapped; a long acquisition at 97 kHz put tens of thousands of points into a document meant to be emailed. Capped with peak-preserving decimation, because plain decimation drops exactly the narrow peaks the figure exists to show.
- The baseline headline delta was picked by absolute magnitude across dB, mm/s and percentage points — so the anomaly ratio won almost every time purely for living on a 0-100 scale.
- Fault-specific recommendations were identified by matching a prose prefix; rewording that sentence would have silently mislabelled every recommendation.

## One unrelated fix, because it blocked this branch

The first CI run on this PR went red across **all six** test jobs with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` — in every test module, including ones this branch never touches.

Cause: `mcp[cli]>=1.16.0` had no upper bound, and mcp **2.0.0** was published after the last CI run on `main` (2026-07-13). 2.0 removed `mcp.server.fastmcp`, which every tool module and every test imports, so a fresh install stopped importing the package at all. `main` is in the same state; this PR is simply the first run to see it.

Repaired by constraining to `<2.0`. Migrating to the 2.x server API is real work and belongs in its own PR.

## Verification

- 984 tests pass, 9 skipped; coverage 92.96% against an 85% gate.
- Verified under the **console-script** pytest invocation CI uses, not just `python -m pytest`. That caught a `from tests.X import Y` that resolved locally and would have failed at collection on CI.
- `flake8 --select=E9,F63,F7,F82` (the blocking CI lint) clean.
- PDF is behind an optional `[pdf]` extra; CI installs `.[dev]` only, so those tests skip there. The missing-dependency error path is tested regardless.

## Notes for review

- The plan is at `docs/plans/2026-08-06-001-feat-integrated-diagnostic-report-plan.md`, the requirements at `docs/brainstorms/2026-08-06-diagnostic-report-value-and-authorship.md`.
- `generate_diagnostic_report_docx` is **unchanged**. Its caller-authored `sections` contract is the pattern this PR moves away from, but changing it is a breaking change and belongs in a separate major-version PR.
- Code review for this branch was done inline by the authoring agent, not by the independent multi-persona review — worth a human pass on the authorship boundary in particular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Rebased onto the mcp 2.x migration

`main` now carries [#36](https://github.com/LGDiMaggio/predictive-maintenance-mcp/pull/36). This branch was rebased on top of it and the emergency `mcp<2.0` pin it carried was **dropped** — #36 replaced the stopgap with the real fix, so that commit was skipped rather than merged.

One conflict, in `src/mcp_tools/report_tools.py`, where both branches touched the import and `register()` — resolved by keeping the new tool and taking `MCPServer` for the annotation.

Released as **0.11.0**: adding a tool is additive, which this project's semver puts on the MINOR axis. 0.10.0 already tells the migration's story and folding an unrelated feature into it would blur both. Surface goes 33 → 34 tools, 36 → 37 endpoints.

Also repairs a mistake shipped in #36: that changelog edit was anchored to the first `### Fixed` in the file, which belongs to the **0.9.1** section. Four entries describing 0.10.0 behaviour landed under a July patch release; they are moved back.

**Verified: 979 passed, 18 skipped against a real mcp 2.0.0 install with the `pdf` extra**, so the HTML↔PDF statement-parity tests actually ran rather than skipping. Run in a venv created for this checkout — which also sidesteps the resolution trap that had several sessions testing the wrong source tree.
