### PR TITLE
ci(format): make the Black check blocking, and guard every job against going decorative

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,7 +119,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install black
 
+    # Blocking. It was `continue-on-error: true` from the start, so it sat
+    # green over a tree where 70 of 91 files would have been reformatted --
+    # the same decorative-check defect removed from the mypy job above.
+    #
+    # line-length comes from [tool.black] in pyproject.toml rather than this
+    # command line, so a bare `black src tests` locally and this job agree.
     - name: Check code formatting
       run: |
-        black --check --line-length=88 src tests
-      continue-on-error: true
+        black --check src tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,13 @@ dev = [
     # `python tools/check_mypy_baseline.py --update`.
     "mypy>=2.3,<2.4",
     "types-requests>=2.31.0",
+    # tests/test_ci_gates.py parses .github/workflows/tests.yml to assert that
+    # no check is decorative. It reads the workflow with a real YAML parser
+    # rather than string matching precisely because it is a guard: a hand-rolled
+    # scan that stopped matching would report "every job blocks" on a workflow
+    # full of `continue-on-error`. Not importable via pytest.importorskip for
+    # the same reason -- a skip is a green tick that checked nothing.
+    "pyyaml>=6.0",
 ]
 
 [tool.black]

--- a/src/decision_support/advisory.py
+++ b/src/decision_support/advisory.py
@@ -86,9 +86,7 @@ def _build_iso_block(iso: dict) -> dict:
     if iso.get("status") == "refused":
         return {
             "status": REFUSED,
-            "statement": (
-                f"ISO severity was not assessed. {iso['reason']}"
-            ),
+            "statement": (f"ISO severity was not assessed. {iso['reason']}"),
             "reason": iso["reason"],
             "remedy": iso["remedy"],
             "standard_note": None,
@@ -279,9 +277,7 @@ def _build_energy_block(stft_summary: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _build_verdict(
-    bearing_block: dict, iso_block: dict, anomaly_block: dict
-) -> dict:
+def _build_verdict(bearing_block: dict, iso_block: dict, anomaly_block: dict) -> dict:
     """Author the headline verdict from the blocks that reached one."""
     matched = [r for r in bearing_block.get("rows", []) if r["matched"]]
     if matched:
@@ -364,9 +360,7 @@ def _build_evidence(
 
     peak = diagnosis.get("fft_summary", {}).get("peak_frequency_hz")
     if peak is not None:
-        statements.append(
-            f"Dominant frequency in the raw spectrum: {peak:.1f} Hz."
-        )
+        statements.append(f"Dominant frequency in the raw spectrum: {peak:.1f} Hz.")
 
     return {
         "strength": diagnosis.get("evidence_strength", "none"),
@@ -449,8 +443,7 @@ def _build_recommendations(
                 "action": iso_block["remedy"],
                 "urgency": "medium",
                 "description": (
-                    "The severity verdict is unavailable until this is "
-                    "resolved."
+                    "The severity verdict is unavailable until this is " "resolved."
                 ),
                 "motivation": iso_block["reason"],
                 "evidence": [iso_block["statement"]],
@@ -500,9 +493,7 @@ def _build_recommendations(
         recommendations.insert(
             0,
             {
-                "action": (
-                    "Treat this as actionable despite the acceptable ISO zone"
-                ),
+                "action": ("Treat this as actionable despite the acceptable ISO zone"),
                 "urgency": "medium",
                 "description": (
                     "Fault-pattern evidence and the severity zone describe "
@@ -630,7 +621,10 @@ def _baseline_incompatibility(diagnosis: dict, baseline: dict) -> str:
     """Return a reason the two signals cannot be compared, or an empty string."""
     signal_iso = diagnosis.get("iso_severity", {})
     baseline_iso = baseline.get("iso_severity", {})
-    if signal_iso.get("status") == "assessed" and baseline_iso.get("status") == "assessed":
+    if (
+        signal_iso.get("status") == "assessed"
+        and baseline_iso.get("status") == "assessed"
+    ):
         signal_unit = signal_iso.get("original_unit")
         baseline_unit = baseline_iso.get("original_unit")
         if signal_unit != baseline_unit:
@@ -659,7 +653,10 @@ def _direction(delta: float, tolerance: float) -> str:
 def _rms_delta(diagnosis: dict, baseline: dict) -> Optional[dict]:
     signal_iso = diagnosis.get("iso_severity", {})
     baseline_iso = baseline.get("iso_severity", {})
-    if signal_iso.get("status") != "assessed" or baseline_iso.get("status") != "assessed":
+    if (
+        signal_iso.get("status") != "assessed"
+        or baseline_iso.get("status") != "assessed"
+    ):
         return None
 
     now = signal_iso["rms_velocity_mm_s"]

--- a/src/decision_support/alerts.py
+++ b/src/decision_support/alerts.py
@@ -55,8 +55,7 @@ def check_alert_thresholds(
         "A": "Vibration within normal limits (Zone A).",
         "B": f"Vibration exceeds {bounds['AB']} mm/s — elevated level (Zone B).",
         "C": (
-            f"Vibration exceeds {bounds['BC']} mm/s — "
-            "unsatisfactory level (Zone C)."
+            f"Vibration exceeds {bounds['BC']} mm/s — " "unsatisfactory level (Zone C)."
         ),
         "D": (
             f"Vibration exceeds {bounds['CD']} mm/s — "
@@ -110,6 +109,7 @@ def check_custom_alert(rms_velocity: float, thresholds: dict) -> dict:
 
 # ---- internal helper -------------------------------------------------------
 
+
 def _classify_custom(
     rms_velocity: float,
     a_upper: float,
@@ -130,8 +130,7 @@ def _classify_custom(
             "zone": "B",
             "exceeded_threshold": a_upper,
             "message": (
-                f"Vibration exceeds {a_upper} mm/s — "
-                "elevated level (Zone B)."
+                f"Vibration exceeds {a_upper} mm/s — " "elevated level (Zone B)."
             ),
         }
     if rms_velocity <= c_upper:
@@ -140,8 +139,7 @@ def _classify_custom(
             "zone": "C",
             "exceeded_threshold": b_upper,
             "message": (
-                f"Vibration exceeds {b_upper} mm/s — "
-                "unsatisfactory level (Zone C)."
+                f"Vibration exceeds {b_upper} mm/s — " "unsatisfactory level (Zone C)."
             ),
         }
     return {

--- a/src/decision_support/diagnosis_pipeline.py
+++ b/src/decision_support/diagnosis_pipeline.py
@@ -22,7 +22,9 @@ from scipy.fft import fft, fftfreq
 from ..config import MODELS_DIR
 from ..path_safety import resolve_model_paths
 from ..signal_processing.spectral import compute_psd, compute_stft_spectrogram
-from ..signal_processing.features import extract_time_domain_features as _extract_time_domain_features
+from ..signal_processing.features import (
+    extract_time_domain_features as _extract_time_domain_features,
+)
 from ..signal_acquisition.repository import VALID_SIGNAL_UNITS, normalize_signal_unit
 from ..diagnostics.bearing_analyzer import check_all_bearing_faults
 from ..diagnostics.iso20816 import assess_severity_with_axis
@@ -68,7 +70,10 @@ def _compute_fft_summary(
     # Top peaks
     order = np.argsort(mags)[::-1][:num_peaks]
     top_peaks = [
-        {"frequency_hz": round(float(freqs[i]), 2), "magnitude": round(float(mags[i]), 6)}
+        {
+            "frequency_hz": round(float(freqs[i]), 2),
+            "magnitude": round(float(mags[i]), 6),
+        }
         for i in np.sort(order)
     ]
 
@@ -163,7 +168,9 @@ def _run_anomaly_detection(
             "anomaly_count": anomaly_count,
             "num_segments": len(predictions),
             "overall_health": health,
-            "anomaly_score": round(anomaly_score, 4) if anomaly_score is not None else None,
+            "anomaly_score": (
+                round(anomaly_score, 4) if anomaly_score is not None else None
+            ),
         }
 
     except Exception as e:
@@ -431,7 +438,8 @@ def _synthesize_diagnosis(
         most_likely = bearing_faults.get("most_likely_fault")
         if most_likely:
             detected = [
-                c for c in bearing_faults["fault_checks"]
+                c
+                for c in bearing_faults["fault_checks"]
                 if c["detected"] and c["evidence_strength"] != "none"
             ]
             fault_text = ", ".join(
@@ -455,15 +463,16 @@ def _synthesize_diagnosis(
                     f"monitor closely, confirm with additional measurements."
                 )
         else:
-            lines.append("No bearing fault frequencies detected — bearing appears healthy.")
+            lines.append(
+                "No bearing fault frequencies detected — bearing appears healthy."
+            )
 
     # Anomaly detection
     if anomaly:
         health = anomaly["overall_health"]
         ratio = anomaly["anomaly_ratio"]
         lines.append(
-            f"Anomaly detection: {health} "
-            f"({ratio * 100:.1f}% anomalous segments)."
+            f"Anomaly detection: {health} " f"({ratio * 100:.1f}% anomalous segments)."
         )
         if health == "Faulty":
             evidence_points += 1.0

--- a/src/decision_support/recommendations.py
+++ b/src/decision_support/recommendations.py
@@ -23,9 +23,9 @@ _FAULT_RECOMMENDATIONS: dict[str, str] = {
 
 # The bearing part of the vocabulary MUST mirror the canonical fault types
 # produced by check_bearing_faults / diagnose_vibration.
-assert set(FAULT_TYPE_CANONICAL.values()) <= set(_FAULT_RECOMMENDATIONS), (
-    "recommendation vocabulary out of sync with FAULT_TYPE_CANONICAL"
-)
+assert set(FAULT_TYPE_CANONICAL.values()) <= set(
+    _FAULT_RECOMMENDATIONS
+), "recommendation vocabulary out of sync with FAULT_TYPE_CANONICAL"
 
 #: Closed fault-type vocabulary accepted by generate_recommendations.
 VALID_FAULT_TYPES: tuple[str, ...] = tuple(sorted(_FAULT_RECOMMENDATIONS))
@@ -58,9 +58,7 @@ def generate_recommendations(
             (e.g. 'BPFO' instead of 'outer_race').
     """
     if fault_types:
-        unknown = [
-            f for f in fault_types if f.lower() not in _FAULT_RECOMMENDATIONS
-        ]
+        unknown = [f for f in fault_types if f.lower() not in _FAULT_RECOMMENDATIONS]
         if unknown:
             raise ValueError(
                 f"Unknown fault type(s) {unknown} — allowed values: "

--- a/src/diagnostics/bearing_analyzer.py
+++ b/src/diagnostics/bearing_analyzer.py
@@ -86,12 +86,14 @@ def check_bearing_fault_peak(
         harmonic_tol = harmonic_freq * tolerance_pct / 100.0
         for p in peaks:
             if abs(p["frequency_hz"] - harmonic_freq) <= harmonic_tol:
-                harmonics.append({
-                    "harmonic": h,
-                    "expected_hz": round(harmonic_freq, 2),
-                    "detected_hz": round(p["frequency_hz"], 2),
-                    "magnitude": round(p["magnitude"], 6),
-                })
+                harmonics.append(
+                    {
+                        "harmonic": h,
+                        "expected_hz": round(harmonic_freq, 2),
+                        "detected_hz": round(p["frequency_hz"], 2),
+                        "magnitude": round(p["magnitude"], 6),
+                    }
+                )
                 break
 
     # Evidence-strength rating from detected fundamental + harmonics.

--- a/src/diagnostics/iso20816.py
+++ b/src/diagnostics/iso20816.py
@@ -113,9 +113,7 @@ def describe_zone(zone: Literal["A", "B", "C", "D"]) -> dict:
         ValueError: If zone is not one of 'A', 'B', 'C', 'D'.
     """
     if zone not in _ZONE_INFO:
-        raise ValueError(
-            f"Unknown zone '{zone}' — valid zones are A, B, C, D."
-        )
+        raise ValueError(f"Unknown zone '{zone}' — valid zones are A, B, C, D.")
     desc, severity, color = _ZONE_INFO[zone]
     return {
         "zone_description": desc,
@@ -353,9 +351,7 @@ def assess_severity_raw(
     freq_range_desc = f"{low_hz:g}-{high_hz:g} Hz ({speed_note})"
 
     # Bandpass filter (zero-phase)
-    sos = butter(
-        4, [low_hz / nyquist, high_hz / nyquist], btype="band", output="sos"
-    )
+    sos = butter(4, [low_hz / nyquist, high_hz / nyquist], btype="band", output="sos")
     velocity_filtered = sosfiltfilt(sos, velocity_mm_s)
 
     # RMS velocity

--- a/src/document_reader.py
+++ b/src/document_reader.py
@@ -28,6 +28,7 @@ import logging
 # PDF processing
 try:
     import pypdf
+
     HAS_PDF = True
 except ImportError:
     HAS_PDF = False
@@ -37,6 +38,7 @@ except ImportError:
 try:
     from PIL import Image
     import pytesseract
+
     HAS_OCR = True
 except ImportError:
     HAS_OCR = False
@@ -53,50 +55,53 @@ logger = logging.getLogger(__name__)
 # PDF TEXT EXTRACTION
 # ============================================================================
 
+
 def extract_text_from_pdf(pdf_path: Path, max_pages: Optional[int] = None) -> str:
     """
     Extract text from PDF file.
-    
+
     Falls back to OCR (pytesseract) for scanned/image-based pages when
     the standard text layer is empty or nearly empty.
-    
+
     Args:
         pdf_path: Path to PDF file
         max_pages: Maximum number of pages to extract (None = all pages)
-    
+
     Returns:
         Extracted text content
     """
     if not HAS_PDF:
-        raise ImportError("pypdf required for PDF reading. Install with: pip install pypdf")
-    
+        raise ImportError(
+            "pypdf required for PDF reading. Install with: pip install pypdf"
+        )
+
     if not pdf_path.exists():
         raise FileNotFoundError(f"PDF not found: {pdf_path}")
-    
+
     text_parts = []
     ocr_used = False
-    
-    with open(pdf_path, 'rb') as file:
+
+    with open(pdf_path, "rb") as file:
         pdf_reader = pypdf.PdfReader(file)
         total_pages = len(pdf_reader.pages)
         pages_to_read = min(max_pages, total_pages) if max_pages else total_pages
-        
+
         for page_num in range(pages_to_read):
             page = pdf_reader.pages[page_num]
             page_text = page.extract_text() or ""
-            
+
             # If text layer is empty/minimal, try OCR
             if len(page_text.strip()) < 20 and HAS_OCR:
                 ocr_text = _ocr_pdf_page(pdf_path, page_num)
                 if ocr_text:
                     page_text = ocr_text
                     ocr_used = True
-            
+
             text_parts.append(page_text)
-    
+
     if ocr_used:
         logger.info("OCR was used for some pages of %s", pdf_path.name)
-    
+
     return "\n\n".join(text_parts)
 
 
@@ -112,6 +117,7 @@ def _ocr_pdf_page(pdf_path: Path, page_num: int) -> str:
         return ""
     try:
         from pdf2image import convert_from_path
+
         images = convert_from_path(
             str(pdf_path),
             first_page=page_num + 1,
@@ -121,7 +127,11 @@ def _ocr_pdf_page(pdf_path: Path, page_num: int) -> str:
         if images:
             return pytesseract.image_to_string(images[0])
     except ImportError:
-        logger.debug("pdf2image not installed – skipping OCR for %s p.%d", pdf_path.name, page_num)
+        logger.debug(
+            "pdf2image not installed – skipping OCR for %s p.%d",
+            pdf_path.name,
+            page_num,
+        )
     except Exception as exc:
         logger.debug("OCR failed for %s p.%d: %s", pdf_path.name, page_num, exc)
     return ""
@@ -131,12 +141,13 @@ def _ocr_pdf_page(pdf_path: Path, page_num: int) -> str:
 # BEARING FREQUENCY CALCULATIONS
 # ============================================================================
 
+
 def calculate_bearing_frequencies(
     num_balls: int,
     ball_diameter_mm: float,
     pitch_diameter_mm: float,
     contact_angle_deg: float = 0.0,
-    shaft_speed_rpm: float = 1500.0
+    shaft_speed_rpm: float = 1500.0,
 ) -> Dict[str, float]:
     """
     Calculate bearing characteristic frequencies from geometry.
@@ -171,30 +182,33 @@ def calculate_bearing_frequencies(
     """
     # Convert to radians
     alpha = math.radians(contact_angle_deg)
-    
+
     # Shaft rotation frequency (Hz)
     f_shaft = shaft_speed_rpm / 60.0
-    
+
     # Diameter ratio
     d_ratio = ball_diameter_mm / pitch_diameter_mm
-    
+
     # Ball Pass Frequency Outer race (BPFO)
     # BPFO = (Z/2) * f_shaft * (1 - Bd/Pd * cos(α))
     BPFO = (num_balls / 2.0) * f_shaft * (1 - d_ratio * math.cos(alpha))
-    
+
     # Ball Pass Frequency Inner race (BPFI)
     # BPFI = (Z/2) * f_shaft * (1 + Bd/Pd * cos(α))
     BPFI = (num_balls / 2.0) * f_shaft * (1 + d_ratio * math.cos(alpha))
-    
+
     # Ball Spin Frequency (BSF)
     # BSF = (Pd/(2*Bd)) * f_shaft * (1 - (Bd/Pd * cos(α))²)
-    BSF = (pitch_diameter_mm / (2.0 * ball_diameter_mm)) * f_shaft * \
-          (1 - (d_ratio * math.cos(alpha))**2)
-    
+    BSF = (
+        (pitch_diameter_mm / (2.0 * ball_diameter_mm))
+        * f_shaft
+        * (1 - (d_ratio * math.cos(alpha)) ** 2)
+    )
+
     # Fundamental Train Frequency / Cage frequency (FTF)
     # FTF = (f_shaft/2) * (1 - Bd/Pd * cos(α))
     FTF = (f_shaft / 2.0) * (1 - d_ratio * math.cos(alpha))
-    
+
     return {
         "BPFO": round(BPFO, 2),
         "BPFI": round(BPFI, 2),
@@ -206,8 +220,8 @@ def calculate_bearing_frequencies(
             "ball_diameter_mm": ball_diameter_mm,
             "pitch_diameter_mm": pitch_diameter_mm,
             "contact_angle_deg": contact_angle_deg,
-            "shaft_speed_rpm": shaft_speed_rpm
-        }
+            "shaft_speed_rpm": shaft_speed_rpm,
+        },
     }
 
 
@@ -215,63 +229,63 @@ def calculate_bearing_frequencies(
 # STRUCTURED DATA EXTRACTION (REGEX-BASED)
 # ============================================================================
 
+
 def extract_bearing_designation(text: str) -> List[str]:
     """
     Extract bearing designations from text (e.g., 6205, SKF 6205-2RS).
-    
+
     Patterns:
     - ISO designation: 4-5 digits (6205, 16006)
     - With prefix: SKF 6205, FAG NU2205
     - With suffix: 6205-2RS, 6205-ZZ
     """
     patterns = [
-        r'\b(?:SKF|FAG|NSK|NTN|TIMKEN|INA|KOYO)?\s*(\d{4,5}(?:-\w+)?)\b',
-        r'\b([A-Z]{2,4}\s?\d{4,5})\b'  # NU2205, NJ306
+        r"\b(?:SKF|FAG|NSK|NTN|TIMKEN|INA|KOYO)?\s*(\d{4,5}(?:-\w+)?)\b",
+        r"\b([A-Z]{2,4}\s?\d{4,5})\b",  # NU2205, NJ306
     ]
-    
+
     bearings = set()
     for pattern in patterns:
         matches = re.findall(pattern, text, re.IGNORECASE)
         bearings.update(matches)
-    
+
     return sorted(list(bearings))
 
 
 def extract_rpm_values(text: str) -> List[float]:
     """
     Extract RPM values from text.
-    
+
     Examples: "1500 RPM", "operating speed: 3600 rpm", "750 r/min"
     """
     patterns = [
-        r'(\d+\.?\d*)\s*(?:RPM|rpm|r/min)',
-        r'(?:speed|rotation)[:\s]+(\d+\.?\d*)\s*(?:RPM|rpm)?'
+        r"(\d+\.?\d*)\s*(?:RPM|rpm|r/min)",
+        r"(?:speed|rotation)[:\s]+(\d+\.?\d*)\s*(?:RPM|rpm)?",
     ]
-    
+
     rpms = []
     for pattern in patterns:
         matches = re.findall(pattern, text)
         rpms.extend([float(m) for m in matches])
-    
+
     return sorted(list(set(rpms)))
 
 
 def extract_power_ratings(text: str) -> List[Dict[str, Any]]:
     """
     Extract power ratings (kW, HP, MW).
-    
+
     Examples: "300 kW", "500 HP", "1.5 MW"
     """
-    pattern = r'(\d+\.?\d*)\s*(kW|HP|MW|hp|kilowatt)'
+    pattern = r"(\d+\.?\d*)\s*(kW|HP|MW|hp|kilowatt)"
     matches = re.findall(pattern, text, re.IGNORECASE)
-    
+
     ratings = []
     for value, unit in matches:
-        ratings.append({
-            "value": float(value),
-            "unit": unit.upper().replace("KILOWATT", "kW")
-        })
-    
+        ratings.append(
+            {"value": float(value), "unit": unit.upper().replace("KILOWATT", "kW")}
+        )
+
     return ratings
 
 
@@ -378,41 +392,42 @@ def lookup_bearing_in_catalog(bearing_designation: str) -> Optional[Dict]:
 # CACHING SYSTEM
 # ============================================================================
 
+
 def get_cached_extraction(manual_file: str) -> Optional[Dict]:
     """
     Get cached extraction results for manual.
-    
+
     Args:
         manual_file: Manual filename
-    
+
     Returns:
         Cached data or None if not cached
     """
     cache_file = CACHE_DIR / f"{Path(manual_file).stem}_extraction.json"
-    
+
     if cache_file.exists():
         try:
-            with open(cache_file, 'r') as f:
+            with open(cache_file, "r") as f:
                 return json.load(f)
         except Exception as e:
             logger.error(f"Failed to load cache: {e}")
             return None
-    
+
     return None
 
 
 def save_extraction_cache(manual_file: str, data: Dict):
     """
     Save extraction results to cache.
-    
+
     Args:
         manual_file: Manual filename
         data: Extracted data to cache
     """
     cache_file = CACHE_DIR / f"{Path(manual_file).stem}_extraction.json"
-    
+
     try:
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(data, f, indent=2)
         logger.info(f"Saved extraction cache: {cache_file}")
     except Exception as e:
@@ -423,44 +438,47 @@ def save_extraction_cache(manual_file: str, data: Dict):
 # HIGH-LEVEL EXTRACTION FUNCTION
 # ============================================================================
 
+
 def extract_machine_specs(manual_path: Path, use_cache: bool = True) -> Dict:
     """
     Extract machine specifications from manual (PDF or TXT).
-    
+
     Extracts:
     - Bearing designations
     - Operating speeds (RPM)
     - Power ratings
     - Machine type hints
-    
+
     Args:
         manual_path: Path to manual file (PDF or TXT)
         use_cache: Use cached results if available
-    
+
     Returns:
         Dictionary with extracted specifications
     """
     manual_name = manual_path.stem
-    
+
     # Check cache
     if use_cache:
         cached = get_cached_extraction(manual_name)
         if cached:
             logger.info(f"Using cached extraction for: {manual_name}")
             return cached
-    
+
     # Extract text based on file type
     logger.info(f"Extracting text from: {manual_path.name}")
-    if manual_path.suffix.lower() == '.txt':
+    if manual_path.suffix.lower() == ".txt":
         # Read text file directly
-        with open(manual_path, 'r', encoding='utf-8') as f:
+        with open(manual_path, "r", encoding="utf-8") as f:
             text = f.read()
         pages_analyzed = 1
     else:
         # Extract from PDF
-        text = extract_text_from_pdf(manual_path, max_pages=50)  # Limit to first 50 pages
-        pages_analyzed = min(50, len(text.split('\n\n')))
-    
+        text = extract_text_from_pdf(
+            manual_path, max_pages=50
+        )  # Limit to first 50 pages
+        pages_analyzed = min(50, len(text.split("\n\n")))
+
     # Extract structured data
     specs = {
         "manual_file": manual_path.name,
@@ -469,13 +487,13 @@ def extract_machine_specs(manual_path: Path, use_cache: bool = True) -> Dict:
         "power_ratings": extract_power_ratings(text),
         "text_excerpt": text[:2000],  # First 2000 chars for LLM context
         "extraction_date": datetime.now().isoformat(),
-        "pages_analyzed": pages_analyzed
+        "pages_analyzed": pages_analyzed,
     }
-    
+
     # Save to cache
     if use_cache:
         save_extraction_cache(manual_name, specs)
-    
+
     return specs
 
 
@@ -487,7 +505,7 @@ if __name__ == "__main__":
     print("=" * 80)
     print("MACHINE DOCUMENTATION READER - EXAMPLES")
     print("=" * 80)
-    
+
     # Example 1: Calculate bearing frequencies
     print("\n1. CALCULATE BEARING FREQUENCIES FROM GEOMETRY")
     print("-" * 80)
@@ -501,7 +519,7 @@ if __name__ == "__main__":
         ball_diameter_mm=demo_specs["ball_diameter_mm"],
         pitch_diameter_mm=demo_specs["pitch_diameter_mm"],
         contact_angle_deg=demo_specs["contact_angle_deg"],
-        shaft_speed_rpm=1797
+        shaft_speed_rpm=1797,
     )
     print(
         f"Input (6205 from catalog): {demo_specs['num_balls']} balls, "
@@ -514,7 +532,7 @@ if __name__ == "__main__":
         if isinstance(value, dict):
             continue
         print(f"  {key:15s}: {value:>8.2f} Hz")
-    
+
     # Example 2: Extract structured data from text
     print("\n2. EXTRACT STRUCTURED DATA (REGEX FALLBACK)")
     print("-" * 80)
@@ -534,24 +552,24 @@ if __name__ == "__main__":
     Seals: Mechanical seal type 21, carbon/ceramic faces
     Impeller: Bronze, 5 vanes, closed type
     """
-    
+
     bearings = extract_bearing_designation(sample_text)
     rpms = extract_rpm_values(sample_text)
     power = extract_power_ratings(sample_text)
-    
+
     print("Extracted data:")
     print(f"  Bearings found: {bearings}")
     print(f"  RPM values: {rpms}")
     print(f"  Power ratings: {power}")
     print()
     print("Note: Multiple RPMs are OK - LLM can interpret context (rated vs max)")
-    
+
     # Example 3: Bearing catalog lookup
     print("\n3. BEARING CATALOG LOOKUP (FALLBACK)")
     print("-" * 80)
     print("Use case: Manual lists bearing designation but not geometry")
     print()
-    
+
     bearing_specs = lookup_bearing_in_catalog("6205")
     if bearing_specs:
         print(f"Found bearing: {bearing_specs['designation']}")
@@ -559,25 +577,25 @@ if __name__ == "__main__":
         print(f"  Ball diameter: {bearing_specs['ball_diameter_mm']} mm")
         print(f"  Pitch diameter: {bearing_specs['pitch_diameter_mm']} mm")
         print(f"  Source: {bearing_specs['source']}")
-        
+
         # Auto-calculate frequencies
         print("\n  Auto-calculating frequencies at 1500 RPM:")
         freqs = calculate_bearing_frequencies(
-            num_balls=bearing_specs['num_balls'],
-            ball_diameter_mm=bearing_specs['ball_diameter_mm'],
-            pitch_diameter_mm=bearing_specs['pitch_diameter_mm'],
-            contact_angle_deg=bearing_specs['contact_angle_deg'],
-            shaft_speed_rpm=1500
+            num_balls=bearing_specs["num_balls"],
+            ball_diameter_mm=bearing_specs["ball_diameter_mm"],
+            pitch_diameter_mm=bearing_specs["pitch_diameter_mm"],
+            contact_angle_deg=bearing_specs["contact_angle_deg"],
+            shaft_speed_rpm=1500,
         )
         for key in ["BPFO", "BPFI", "BSF", "FTF"]:
             print(f"    {key}: {freqs[key]:.2f} Hz")
-    
+
     # Example 4: Real-world workflow simulation
     print("\n4. REAL-WORLD WORKFLOW SIMULATION")
     print("-" * 80)
     print("Scenario: Diagnose pump vibration with partial manual information")
     print()
-    
+
     # Simulate manual excerpt
     manual_excerpt = """
     PUMP SPECIFICATIONS - MODEL XYZ-300
@@ -594,36 +612,38 @@ if __name__ == "__main__":
     Impeller: Bronze, closed type, 5 vanes
     Shaft: Stainless steel 316
     """
-    
+
     print("Step 1: Extract bearings from manual")
     bearings_found = extract_bearing_designation(manual_excerpt)
     print(f"  → Found: {bearings_found}")
-    
+
     print("\nStep 2: Lookup bearing geometry from catalog")
     for bearing in bearings_found[:2]:  # First 2 bearings
         specs = lookup_bearing_in_catalog(bearing)
         if specs:
-            print(f"  → {bearing}: {specs['num_balls']} balls, "
-                  f"Bd={specs['ball_diameter_mm']}mm, "
-                  f"Pd={specs['pitch_diameter_mm']}mm")
-    
+            print(
+                f"  → {bearing}: {specs['num_balls']} balls, "
+                f"Bd={specs['ball_diameter_mm']}mm, "
+                f"Pd={specs['pitch_diameter_mm']}mm"
+            )
+
     print("\nStep 3: Calculate fault frequencies for diagnosis")
     rpm_values = extract_rpm_values(manual_excerpt)
     nominal_rpm = 1475  # From manual context
-    
+
     bearing_6205_specs = lookup_bearing_in_catalog("6205")
     if bearing_6205_specs:
         freqs = calculate_bearing_frequencies(
-            num_balls=bearing_6205_specs['num_balls'],
-            ball_diameter_mm=bearing_6205_specs['ball_diameter_mm'],
-            pitch_diameter_mm=bearing_6205_specs['pitch_diameter_mm'],
+            num_balls=bearing_6205_specs["num_balls"],
+            ball_diameter_mm=bearing_6205_specs["ball_diameter_mm"],
+            pitch_diameter_mm=bearing_6205_specs["pitch_diameter_mm"],
             contact_angle_deg=0.0,
-            shaft_speed_rpm=nominal_rpm
+            shaft_speed_rpm=nominal_rpm,
         )
         print(f"  → SKF 6205 at {nominal_rpm} RPM:")
         print(f"     BPFO: {freqs['BPFO']:.2f} Hz (outer race fault)")
         print(f"     BPFI: {freqs['BPFI']:.2f} Hz (inner race fault)")
-    
+
     print("\nStep 4: LLM can now answer complex questions:")
     print("  ❓ 'What type of mechanical seal is used?'")
     print("     → Type 21, carbon/ceramic faces")
@@ -631,7 +651,7 @@ if __name__ == "__main__":
     print("     → 5 vanes, closed type, bronze material")
     print("  ❓ 'What are the expected bearing fault frequencies?'")
     print("     → BPFO/BPFI computed from catalog geometry (see Step 3 output)")
-    
+
     print("\n" + "=" * 80)
     print("CONCLUSION: Hybrid approach works!")
     print("  ✅ MCP Resources → LLM reads full manual for ANY question")

--- a/src/figures.py
+++ b/src/figures.py
@@ -168,7 +168,9 @@ def build_annotated_envelope_figure(
                 "label": label,
                 "x": round(center, _BAND_PRECISION),
                 "y": _local_peak_db(x, y_db, center - half, center + half),
-                "text": _annotation_text(label, center, matched if is_matched else None),
+                "text": _annotation_text(
+                    label, center, matched if is_matched else None
+                ),
                 "matched": is_matched,
             }
         )
@@ -187,9 +189,7 @@ def build_annotated_envelope_figure(
     }
 
 
-def figure_to_svg(
-    figure: dict[str, Any], width: int = 900, height: int = 420
-) -> str:
+def figure_to_svg(figure: dict[str, Any], width: int = 900, height: int = 420) -> str:
     """Render a figure description as a standalone inline SVG.
 
     SVG rather than a charting library because the report must open with no
@@ -364,9 +364,7 @@ def _resolve_axis_max(
     return min(wanted, spectrum_max)
 
 
-def _local_peak_db(
-    x: np.ndarray, y_db: np.ndarray, low: float, high: float
-) -> float:
+def _local_peak_db(x: np.ndarray, y_db: np.ndarray, low: float, high: float) -> float:
     """Height at which to anchor a band's annotation."""
     window = (x >= low) & (x <= high)
     if not window.any():
@@ -417,7 +415,6 @@ def _caption(
         )
     if omitted:
         caption += (
-            f" {', '.join(omitted)} lies beyond the plotted range and is not "
-            f"shown."
+            f" {', '.join(omitted)} lies beyond the plotted range and is not " f"shown."
         )
     return caption

--- a/src/html_templates.py
+++ b/src/html_templates.py
@@ -12,7 +12,7 @@ def get_base_template(
     title: str,
     content: str,
     metadata: Optional[Dict[str, Any]] = None,
-    include_plotly: bool = True
+    include_plotly: bool = True,
 ) -> str:
     """
     Base HTML template with professional styling.
@@ -46,7 +46,7 @@ def get_base_template(
     plotly_tag = (
         '<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>'
         if include_plotly
-        else '<!-- self-contained: no external scripts -->'
+        else "<!-- self-contained: no external scripts -->"
     )
 
     return f"""<!DOCTYPE html>
@@ -254,11 +254,11 @@ def create_fft_report(
     frequencies: List[float],
     magnitudes_db: List[float],
     peaks: List[Dict[str, float]],
-    metadata: Dict[str, Any]
+    metadata: Dict[str, Any],
 ) -> str:
     """
     Create professional FFT spectrum report.
-    
+
     Args:
         signal_file: Signal filename
         sampling_rate: Sampling rate in Hz
@@ -266,7 +266,7 @@ def create_fft_report(
         magnitudes_db: Magnitude array in dB
         peaks: List of detected peaks with 'frequency' and 'magnitude_db'
         metadata: Additional metadata
-    
+
     Returns:
         Complete HTML report
     """
@@ -291,33 +291,37 @@ def create_fft_report(
         </div>
     </div>
     """
-    
+
     # Peaks table
     peaks_html = "<div class='card'><h3 class='card-title'>🎯 Detected Peaks</h3><table style='width:100%; border-collapse: collapse;'>"
     peaks_html += "<tr style='background: #f5f7fa; font-weight: 600;'><th style='padding: 0.75rem; text-align: left;'>Rank</th><th style='padding: 0.75rem; text-align: left;'>Frequency (Hz)</th><th style='padding: 0.75rem; text-align: left;'>Magnitude (dB)</th><th style='padding: 0.75rem; text-align: left;'>Note</th></tr>"
-    
+
     for i, peak in enumerate(peaks[:10], 1):
-        freq = peak['frequency']
-        mag_db = peak['magnitude_db']
-        note = peak.get('note', '')
-        
+        freq = peak["frequency"]
+        mag_db = peak["magnitude_db"]
+        note = peak.get("note", "")
+
         peaks_html += f"<tr style='border-bottom: 1px solid #e0e0e0;'>"
         peaks_html += f"<td style='padding: 0.75rem;'><strong>#{i}</strong></td>"
-        peaks_html += f"<td style='padding: 0.75rem; font-family: monospace;'>{freq:.2f}</td>"
-        peaks_html += f"<td style='padding: 0.75rem; font-family: monospace;'>{mag_db:.1f}</td>"
+        peaks_html += (
+            f"<td style='padding: 0.75rem; font-family: monospace;'>{freq:.2f}</td>"
+        )
+        peaks_html += (
+            f"<td style='padding: 0.75rem; font-family: monospace;'>{mag_db:.1f}</td>"
+        )
         peaks_html += f"<td style='padding: 0.75rem; color: #e74c3c;'>{note}</td>"
         peaks_html += "</tr>"
-    
+
     peaks_html += "</table></div>"
-    
+
     # Plotly chart
     chart_div = "<div class='chart-container'><div id='fft-chart'></div></div>"
-    
+
     # Plotly script
-    peak_freqs = [p['frequency'] for p in peaks[:10]]
-    peak_mags = [p['magnitude_db'] for p in peaks[:10]]
+    peak_freqs = [p["frequency"] for p in peaks[:10]]
+    peak_mags = [p["magnitude_db"] for p in peaks[:10]]
     peak_labels = [f"{p['frequency']:.1f}" for p in peaks[:10]]
-    
+
     plotly_script = f"""
     <script>
         var spectrum = {{
@@ -397,7 +401,7 @@ def create_fft_report(
         Plotly.newPlot('fft-chart', [spectrum, peaks], layout, config);
     </script>
     """
-    
+
     content = f"""
     <div class="header">
         <div class="header-content">
@@ -412,11 +416,9 @@ def create_fft_report(
     </div>
     {plotly_script}
     """
-    
+
     return get_base_template(
-        title=f"FFT Analysis - {signal_file}",
-        content=content,
-        metadata=metadata
+        title=f"FFT Analysis - {signal_file}", content=content, metadata=metadata
     )
 
 
@@ -431,11 +433,11 @@ def create_envelope_report(
     env_mag_db: List[float],
     peaks: List[Dict[str, float]],
     bearing_freqs: Optional[Dict[str, float]],
-    metadata: Dict[str, Any]
+    metadata: Dict[str, Any],
 ) -> str:
     """
     Create professional envelope analysis report.
-    
+
     Args:
         signal_file: Signal filename
         sampling_rate: Sampling rate
@@ -448,7 +450,7 @@ def create_envelope_report(
         peaks: Detected peaks
         bearing_freqs: Optional dict with BPFO, BPFI, BSF, FTF
         metadata: Additional metadata
-    
+
     Returns:
         Complete HTML report
     """
@@ -473,12 +475,17 @@ def create_envelope_report(
         </div>
     </div>
     """
-    
+
     # Bearing frequencies reference (if provided)
     bearing_ref = ""
     if bearing_freqs:
         bearing_ref = "<div class='card'><h3 class='card-title'>📌 Bearing Characteristic Frequencies</h3><div class='info-grid'>"
-        colors = {"BPFO": "#e74c3c", "BPFI": "#f39c12", "BSF": "#3498db", "FTF": "#2ecc71"}
+        colors = {
+            "BPFO": "#e74c3c",
+            "BPFI": "#f39c12",
+            "BSF": "#3498db",
+            "FTF": "#2ecc71",
+        }
         for name, freq in bearing_freqs.items():
             if freq:
                 color = colors.get(name, "#95a5a6")
@@ -489,38 +496,47 @@ def create_envelope_report(
                 </div>
                 """
         bearing_ref += "</div></div>"
-    
+
     # Peaks table
     peaks_html = "<div class='card'><h3 class='card-title'>🎯 Envelope Spectrum Peaks</h3><table style='width:100%; border-collapse: collapse;'>"
     peaks_html += "<tr style='background: #f5f7fa; font-weight: 600;'><th style='padding: 0.75rem; text-align: left;'>Rank</th><th style='padding: 0.75rem; text-align: left;'>Frequency (Hz)</th><th style='padding: 0.75rem; text-align: left;'>Magnitude (dB)</th><th style='padding: 0.75rem; text-align: left;'>Match</th></tr>"
-    
+
     for i, peak in enumerate(peaks[:10], 1):
-        freq = peak['frequency']
-        mag_db = peak['magnitude_db']
-        match = peak.get('match', '')
-        
+        freq = peak["frequency"]
+        mag_db = peak["magnitude_db"]
+        match = peak.get("match", "")
+
         peaks_html += f"<tr style='border-bottom: 1px solid #e0e0e0;'>"
         peaks_html += f"<td style='padding: 0.75rem;'><strong>#{i}</strong></td>"
-        peaks_html += f"<td style='padding: 0.75rem; font-family: monospace;'>{freq:.2f}</td>"
-        peaks_html += f"<td style='padding: 0.75rem; font-family: monospace;'>{mag_db:.1f}</td>"
+        peaks_html += (
+            f"<td style='padding: 0.75rem; font-family: monospace;'>{freq:.2f}</td>"
+        )
+        peaks_html += (
+            f"<td style='padding: 0.75rem; font-family: monospace;'>{mag_db:.1f}</td>"
+        )
         peaks_html += f"<td style='padding: 0.75rem; color: #e74c3c; font-weight: 600;'>{match}</td>"
         peaks_html += "</tr>"
-    
+
     peaks_html += "</table></div>"
-    
+
     # Charts
     charts_div = "<div class='chart-container'><div id='envelope-charts'></div></div>"
-    
+
     # Plotly script with subplots
-    peak_freqs = [p['frequency'] for p in peaks[:10]]
-    peak_mags = [p['magnitude_db'] for p in peaks[:10]]
-    
+    peak_freqs = [p["frequency"] for p in peaks[:10]]
+    peak_mags = [p["magnitude_db"] for p in peaks[:10]]
+
     # Bearing frequency markers
     bearing_markers_script = ""
     if bearing_freqs:
         for name, freq in bearing_freqs.items():
             if freq and freq <= max(env_freq):
-                colors = {"BPFO": "#e74c3c", "BPFI": "#f39c12", "BSF": "#3498db", "FTF": "#2ecc71"}
+                colors = {
+                    "BPFO": "#e74c3c",
+                    "BPFI": "#f39c12",
+                    "BSF": "#3498db",
+                    "FTF": "#2ecc71",
+                }
                 color = colors.get(name, "#95a5a6")
                 bearing_markers_script += f"""
         data.push({{
@@ -536,7 +552,7 @@ def create_envelope_report(
             hovertemplate: '{name}: {freq:.2f} Hz<extra></extra>'
         }});
         """
-    
+
     plotly_script = f"""
     <script>
         var filtered = {{
@@ -646,7 +662,7 @@ def create_envelope_report(
         Plotly.newPlot('envelope-charts', data, layout, config);
     </script>
     """
-    
+
     content = f"""
     <div class="header">
         <div class="header-content">
@@ -662,43 +678,39 @@ def create_envelope_report(
     </div>
     {plotly_script}
     """
-    
+
     return get_base_template(
-        title=f"Envelope Analysis - {signal_file}",
-        content=content,
-        metadata=metadata
+        title=f"Envelope Analysis - {signal_file}", content=content, metadata=metadata
     )
 
 
 def create_iso_report(
-    signal_file: str,
-    iso_result: Dict[str, Any],
-    metadata: Dict[str, Any]
+    signal_file: str, iso_result: Dict[str, Any], metadata: Dict[str, Any]
 ) -> str:
     """
     Create professional ISO 20816-3 evaluation report.
-    
+
     Args:
         signal_file: Signal filename
         iso_result: ISO evaluation result dict
         metadata: Additional metadata
-    
+
     Returns:
         Complete HTML report
     """
-    zone = iso_result['zone']
-    severity = iso_result['severity_level']
-    rms_velocity = iso_result['rms_velocity']
-    
+    zone = iso_result["zone"]
+    severity = iso_result["severity_level"]
+    rms_velocity = iso_result["rms_velocity"]
+
     # Zone color and icon
     zone_colors = {
         "A": ("#27ae60", "✓"),
         "B": ("#f39c12", "⚠"),
         "C": ("#e67e22", "⚠"),
-        "D": ("#c0392b", "🚨")
+        "D": ("#c0392b", "🚨"),
     }
     color, icon = zone_colors.get(zone, ("#95a5a6", "?"))
-    
+
     # Status badge
     status_badge = f"""
     <div style="text-align: center; margin: 2rem 0;">
@@ -707,7 +719,7 @@ def create_iso_report(
         </div>
     </div>
     """
-    
+
     # Info cards
     info_cards = f"""
     <div class="info-grid">
@@ -729,7 +741,7 @@ def create_iso_report(
         </div>
     </div>
     """
-    
+
     # Zone boundaries
     boundaries_card = f"""
     <div class="card">
@@ -750,7 +762,7 @@ def create_iso_report(
         </div>
     </div>
     """
-    
+
     # Interpretation
     interpretation_card = f"""
     <div class="card">
@@ -760,12 +772,18 @@ def create_iso_report(
         </p>
     </div>
     """
-    
+
     # Chart
     chart_div = "<div class='chart-container'><div id='iso-chart'></div></div>"
-    
-    boundaries = [0, iso_result['boundary_ab'], iso_result['boundary_bc'], iso_result['boundary_cd'], iso_result['boundary_cd'] * 1.3]
-    
+
+    boundaries = [
+        0,
+        iso_result["boundary_ab"],
+        iso_result["boundary_bc"],
+        iso_result["boundary_cd"],
+        iso_result["boundary_cd"] * 1.3,
+    ]
+
     plotly_script = f"""
     <script>
         var boundaries = {{
@@ -889,7 +907,7 @@ def create_iso_report(
         Plotly.newPlot('iso-chart', data, layout, config);
     </script>
     """
-    
+
     content = f"""
     <div class="header">
         <div class="header-content">
@@ -906,9 +924,7 @@ def create_iso_report(
     </div>
     {plotly_script}
     """
-    
+
     return get_base_template(
-        title=f"ISO 20816-3 - {signal_file}",
-        content=content,
-        metadata=metadata
+        title=f"ISO 20816-3 - {signal_file}", content=content, metadata=metadata
     )

--- a/src/mcp_tools/acquisition_tools.py
+++ b/src/mcp_tools/acquisition_tools.py
@@ -42,6 +42,7 @@ _test_signal_sequence = itertools.count()
 # TOOLS
 # ------------------------------------------------------------------
 
+
 async def list_signals(
     ctx: Context = None,
     scope: Literal["disk", "memory"] = "disk",
@@ -81,6 +82,7 @@ async def list_signals(
     files.sort()
     logger.info(f"{len(files)} signal file(s) on disk")
     return {"scope": "disk", "count": len(files), "files": files}
+
 
 async def generate_test_signal(
     signal_type: Literal[
@@ -138,7 +140,7 @@ async def generate_test_signal(
 
         # Convolution with impulse response
         impulse_response = np.exp(-50 * np.abs(t - t[len(t) // 2]))
-        signal_clean = np.convolve(impulses, impulse_response, mode='same')
+        signal_clean = np.convolve(impulses, impulse_response, mode="same")
 
         # Modulation with carrier
         signal_clean = signal_clean * np.sin(2 * np.pi * carrier_freq * t)
@@ -203,6 +205,7 @@ async def generate_test_signal(
 
     return StoredSignalInfo(**info)
 
+
 async def load_signal(
     ctx: Context,
     filepath: str | list[str],
@@ -213,50 +216,50 @@ async def load_signal(
 ) -> StoredSignalInfo | list[StoredSignalInfo]:
     """Load one signal — or a batch — into the in-memory repository.
 
-        Once loaded, reference the signal by its signal_id in every analysis,
-        diagnosis, report, and prognostics tool (the load -> analyze ->
-        diagnose -> report flow uses signal_id as the single handle).
+    Once loaded, reference the signal by its signal_id in every analysis,
+    diagnosis, report, and prognostics tool (the load -> analyze ->
+    diagnose -> report flow uses signal_id as the single handle).
 
-        Batch form: pass a LIST of file paths (e.g. for training sets). The
-        batch is fail-fast and atomic — all paths and derived ids are
-        validated up front, and on the first problem ONE error names the
-        offending entries and nothing is loaded. One declared sampling_rate/
-        signal_unit applies to all files; per-file metadata wins only when
-        the parameter is omitted. Custom signal_id is not allowed for a
-        batch (ids derive from each file's relative path).
+    Batch form: pass a LIST of file paths (e.g. for training sets). The
+    batch is fail-fast and atomic — all paths and derived ids are
+    validated up front, and on the first problem ONE error names the
+    offending entries and nothing is loaded. One declared sampling_rate/
+    signal_unit applies to all files; per-file metadata wins only when
+    the parameter is omitted. Custom signal_id is not allowed for a
+    batch (ids derive from each file's relative path).
 
-        signal_id default: the path relative to data/signals/ with separators
-        replaced by underscores — 'real_train/baseline_1.csv' loads as
-        'real_train_baseline_1', so same-named files in different folders
-        never collide silently. Re-loading a path whose id already exists is
-        an explicit error unless overwrite=True.
+    signal_id default: the path relative to data/signals/ with separators
+    replaced by underscores — 'real_train/baseline_1.csv' loads as
+    'real_train_baseline_1', so same-named files in different folders
+    never collide silently. Re-loading a path whose id already exists is
+    an explicit error unless overwrite=True.
 
-        Signal unit discipline: ISO 20816-3 severity verdicts require a
-        DECLARED unit — either via this parameter or a 'signal_unit' field in
-        the companion _metadata.json (explicit parameter wins). Units are
-        never guessed from signal amplitude; without a declared unit the ISO
-        severity block is refused with a structured reason and remedy.
+    Signal unit discipline: ISO 20816-3 severity verdicts require a
+    DECLARED unit — either via this parameter or a 'signal_unit' field in
+    the companion _metadata.json (explicit parameter wins). Units are
+    never guessed from signal amplitude; without a declared unit the ISO
+    severity block is refused with a structured reason and remedy.
 
-        Args:
-            filepath: Filename relative to data/signals/ or absolute path —
-                or a list of such paths for an atomic batch load.
-            signal_id: Custom ID (single-file loads only; default derives
-                from the relative path).
-            sampling_rate: Sampling rate in Hz (overrides metadata file).
-            signal_unit: Declared signal unit — 'g' or 'm/s2' (acceleration),
-                'mm/s' or 'm/s' (velocity). Overrides the metadata file.
-            overwrite: Replace existing entries on signal_id collision
-                instead of raising.
+    Args:
+        filepath: Filename relative to data/signals/ or absolute path —
+            or a list of such paths for an atomic batch load.
+        signal_id: Custom ID (single-file loads only; default derives
+            from the relative path).
+        sampling_rate: Sampling rate in Hz (overrides metadata file).
+        signal_unit: Declared signal unit — 'g' or 'm/s2' (acceleration),
+            'mm/s' or 'm/s' (velocity). Overrides the metadata file.
+        overwrite: Replace existing entries on signal_id collision
+            instead of raising.
 
-        Returns:
-            StoredSignalInfo for a single load; a list of StoredSignalInfo
-            (input order) for a batch.
+    Returns:
+        StoredSignalInfo for a single load; a list of StoredSignalInfo
+        (input order) for a batch.
 
-        Raises:
-            ValueError: If signal_unit is invalid, the signal data cannot be
-                loaded, a signal_id collides without overwrite=True, or a
-                batch contains any invalid entry (nothing is loaded).
-        """
+    Raises:
+        ValueError: If signal_unit is invalid, the signal data cannot be
+            loaded, a signal_id collides without overwrite=True, or a
+            batch contains any invalid entry (nothing is loaded).
+    """
     repo = get_repository()
 
     if isinstance(filepath, list):
@@ -274,14 +277,12 @@ async def load_signal(
         )
         ids = [i["signal_id"] for i in infos]
         logger.info(f"Loaded {len(infos)} signals: {ids}")
-        undeclared = [
-            i["signal_id"] for i in infos if not i.get("signal_unit")
-        ]
+        undeclared = [i["signal_id"] for i in infos if not i.get("signal_unit")]
         if undeclared:
             logger.info(
                 f"Signal unit not declared for {undeclared} — ISO "
-                    f"severity verdicts will be refused for these until "
-                    f"the unit is declared."
+                f"severity verdicts will be refused for these until "
+                f"the unit is declared."
             )
         return [StoredSignalInfo(**i) for i in infos]
 
@@ -292,16 +293,19 @@ async def load_signal(
         signal_unit=signal_unit,
         overwrite=overwrite,
     )
-    logger.info(f"Loaded signal '{info['signal_id']}': {info['num_samples']} samples, {info['size_bytes'] / 1024:.1f} KB")
+    logger.info(
+        f"Loaded signal '{info['signal_id']}': {info['num_samples']} samples, {info['size_bytes'] / 1024:.1f} KB"
+    )
     if info.get("signal_unit"):
         logger.info(f"Signal unit: '{info['signal_unit']}' (declared)")
     else:
         logger.info(
             "Signal unit: not declared — ISO severity verdicts will be "
-                "refused until the unit is declared "
-                "(load_signal(signal_unit=...) or metadata 'signal_unit')."
+            "refused until the unit is declared "
+            "(load_signal(signal_unit=...) or metadata 'signal_unit')."
         )
     return StoredSignalInfo(**info)
+
 
 async def get_signal_info(ctx: Context, signal_id: str) -> StoredSignalInfo:
     """Get metadata for a stored signal without loading the full array.
@@ -327,6 +331,7 @@ async def get_signal_info(ctx: Context, signal_id: str) -> StoredSignalInfo:
     except KeyError as exc:
         raise ValueError(str(exc.args[0])) from None
     return StoredSignalInfo(**info)
+
 
 async def clear_signals(
     ctx: Context, signal_id: Optional[str] = None

--- a/src/mcp_tools/analysis_tools.py
+++ b/src/mcp_tools/analysis_tools.py
@@ -26,8 +26,13 @@ from mcp.server.mcpserver import MCPServer, Context
 
 from ..signal_acquisition.loaders import extract_segment
 from ..models import (
-    FFTResult, SpectralPeak, EnvelopeResult, StatisticalResult,
-    FeatureExtractionResult, PSDResult, STFTResult,
+    FFTResult,
+    SpectralPeak,
+    EnvelopeResult,
+    StatisticalResult,
+    FeatureExtractionResult,
+    PSDResult,
+    STFTResult,
 )
 from ..signal_processing.spectral import (
     compute_psd as _compute_psd,
@@ -69,42 +74,43 @@ def _select_segment(
 # TOOLS - FFT ANALYSIS
 # ================================================================
 
+
 async def analyze_fft(
     ctx: Context,
     signal_id: str,
     max_frequency: Optional[float] = None,
     segment_duration: Optional[float] = 1.0,
-    random_seed: Optional[int] = None
+    random_seed: Optional[int] = None,
 ) -> FFTResult:
     """
-        Perform FFT (Fast Fourier Transform) analysis on a stored signal.
+    Perform FFT (Fast Fourier Transform) analysis on a stored signal.
 
-        FFT analysis converts the signal from time domain to frequency domain,
-        allowing identification of harmonic components and faults that manifest
-        at specific frequencies. Requires the signal loaded via load_signal()
-        first; the sampling rate comes from the stored signal metadata.
+    FFT analysis converts the signal from time domain to frequency domain,
+    allowing identification of harmonic components and faults that manifest
+    at specific frequencies. Requires the signal loaded via load_signal()
+    first; the sampling rate comes from the stored signal metadata.
 
-        By default analyzes the LEADING 1.0-second segment (deterministic:
-        two identical calls return identical results). Set
-        segment_duration=None to analyze the entire signal, or pass
-        random_seed to sample a seeded random segment position instead.
+    By default analyzes the LEADING 1.0-second segment (deterministic:
+    two identical calls return identical results). Set
+    segment_duration=None to analyze the entire signal, or pass
+    random_seed to sample a seeded random segment position instead.
 
-        Args:
-            ctx: MCP context. Unused — see this module's docstring on logging.
-            signal_id: ID of the stored signal (from load_signal).
-            max_frequency: Maximum frequency to analyze (default: Nyquist frequency)
-            segment_duration: Duration in seconds to analyze (default: leading
-                1.0 s). Set to None to analyze the full signal.
-            random_seed: Seed for random segment position (default: None =
-                deterministic leading segment).
+    Args:
+        ctx: MCP context. Unused — see this module's docstring on logging.
+        signal_id: ID of the stored signal (from load_signal).
+        max_frequency: Maximum frequency to analyze (default: Nyquist frequency)
+        segment_duration: Duration in seconds to analyze (default: leading
+            1.0 s). Set to None to analyze the full signal.
+        random_seed: Seed for random segment position (default: None =
+            deterministic leading segment).
 
-        Returns:
-            FFTResult with top peaks, dominant peak, and spectrum stats.
+    Returns:
+        FFTResult with top peaks, dominant peak, and spectrum stats.
 
-        Raises:
-            ValueError: If the signal_id is not loaded, or the stored signal
-                has no sampling rate.
-        """
+    Raises:
+        ValueError: If the signal_id is not loaded, or the stored signal
+            has no sampling rate.
+    """
     signal_data, info = resolve_signal(signal_id)
     sampling_rate = info.sampling_rate
 
@@ -134,7 +140,7 @@ async def analyze_fft(
 
     # Calculate FFT
     fft_values = fft(signal_windowed)
-    frequencies = fftfreq(N, 1/sampling_rate)
+    frequencies = fftfreq(N, 1 / sampling_rate)
 
     # Take only positive frequencies (excluding DC component at index 0)
     positive_freq_idx = frequencies > 0
@@ -171,11 +177,13 @@ async def analyze_fft(
     for i in top_idx:
         mag_val = float(magnitudes[i])
         mag_db = float(20 * np.log10(max(mag_val, 1e-12) / max(max_mag, 1e-12)))
-        top_peaks.append(SpectralPeak(
-            frequency_hz=round(float(frequencies[i]), 3),
-            magnitude=round(mag_val, 6),
-            magnitude_db=round(mag_db, 2)
-        ))
+        top_peaks.append(
+            SpectralPeak(
+                frequency_hz=round(float(frequencies[i]), 3),
+                magnitude=round(mag_val, 6),
+                magnitude_db=round(mag_db, 2),
+            )
+        )
 
     rms_spectral = float(np.sqrt(np.mean(magnitudes**2)))
 
@@ -185,15 +193,21 @@ async def analyze_fft(
         peak_magnitude=peak_magnitude,
         rms_spectral=round(rms_spectral, 6),
         total_bins=len(frequencies),
-        freq_range_hz=[round(float(frequencies[0]), 3), round(float(frequencies[-1]), 3)] if len(frequencies) > 0 else [0, 0],
+        freq_range_hz=(
+            [round(float(frequencies[0]), 3), round(float(frequencies[-1]), 3)]
+            if len(frequencies) > 0
+            else [0, 0]
+        ),
         sampling_rate=sampling_rate,
         num_samples=N,
-        frequency_resolution=frequency_resolution
+        frequency_resolution=frequency_resolution,
     )
+
 
 # ================================================================
 # TOOLS - ENVELOPE ANALYSIS
 # ================================================================
+
 
 async def analyze_envelope(
     ctx: Context,
@@ -202,52 +216,52 @@ async def analyze_envelope(
     filter_high: float = 5000.0,
     num_peaks: int = 5,
     segment_duration: Optional[float] = 1.0,
-    random_seed: Optional[int] = None
+    random_seed: Optional[int] = None,
 ) -> EnvelopeResult:
     """
-        Envelope-spectrum analysis of a stored signal (bearing fault screening).
+    Envelope-spectrum analysis of a stored signal (bearing fault screening).
 
-        THE unified envelope tool: bandpass filter -> Hilbert
-        envelope -> mean subtraction + Hann window -> FFT -> top peaks.
-        The mean subtraction/window step is an intentional U9 fix: the
-        envelope's DC leakage used to bury the low-frequency FTF zone.
-        Requires the signal loaded via load_signal() first; the sampling
-        rate comes from the stored signal metadata.
+    THE unified envelope tool: bandpass filter -> Hilbert
+    envelope -> mean subtraction + Hann window -> FFT -> top peaks.
+    The mean subtraction/window step is an intentional U9 fix: the
+    envelope's DC leakage used to bury the low-frequency FTF zone.
+    Requires the signal loaded via load_signal() first; the sampling
+    rate comes from the stored signal metadata.
 
-        The requested band must fit the signal: an invalid band (low <= 0,
-        low >= high, high > Nyquist) raises a ValueError — it is NEVER
-        silently clamped. The band used is echoed in the result.
+    The requested band must fit the signal: an invalid band (low <= 0,
+    low >= high, high > Nyquist) raises a ValueError — it is NEVER
+    silently clamped. The band used is echoed in the result.
 
-        By default analyzes the LEADING 1.0-second segment (deterministic:
-        two identical calls return identical results). Set
-        segment_duration=None to analyze the entire signal, or pass
-        random_seed to sample a seeded random segment position instead.
+    By default analyzes the LEADING 1.0-second segment (deterministic:
+    two identical calls return identical results). Set
+    segment_duration=None to analyze the entire signal, or pass
+    random_seed to sample a seeded random segment position instead.
 
-        No reference bearing frequencies are assumed: compare the returned
-        peaks against frequencies computed for the actual bearing and
-        shaft speed (check_bearing_faults or
-        calculate_bearing_characteristic_frequencies).
+    No reference bearing frequencies are assumed: compare the returned
+    peaks against frequencies computed for the actual bearing and
+    shaft speed (check_bearing_faults or
+    calculate_bearing_characteristic_frequencies).
 
-        Args:
-            ctx: MCP context. Unused — see this module's docstring on logging.
-            signal_id: ID of the stored signal (from load_signal).
-            filter_low: Bandpass low edge in Hz (default: 500).
-            filter_high: Bandpass high edge in Hz (default: 5000). Must
-                not exceed the signal's Nyquist frequency.
-            num_peaks: Number of top peaks to return (default: 5).
-            segment_duration: Duration in seconds to analyze (default:
-                leading 1.0 s). None analyzes the full signal.
-            random_seed: Seed for random segment position (default: None =
-                deterministic leading segment).
+    Args:
+        ctx: MCP context. Unused — see this module's docstring on logging.
+        signal_id: ID of the stored signal (from load_signal).
+        filter_low: Bandpass low edge in Hz (default: 500).
+        filter_high: Bandpass high edge in Hz (default: 5000). Must
+            not exceed the signal's Nyquist frequency.
+        num_peaks: Number of top peaks to return (default: 5).
+        segment_duration: Duration in seconds to analyze (default:
+            leading 1.0 s). None analyzes the full signal.
+        random_seed: Seed for random segment position (default: None =
+            deterministic leading segment).
 
-        Returns:
-            EnvelopeResult with the band actually used, top peaks, and
-            comparison guidance.
+    Returns:
+        EnvelopeResult with the band actually used, top peaks, and
+        comparison guidance.
 
-        Raises:
-            ValueError: If the signal_id is not loaded, the stored signal
-                has no sampling rate, or the band is invalid vs Nyquist.
-        """
+    Raises:
+        ValueError: If the signal_id is not loaded, the stored signal
+            has no sampling rate, or the band is invalid vs Nyquist.
+    """
     signal_data, info = resolve_signal(signal_id)
     sampling_rate = info.sampling_rate
 
@@ -289,16 +303,18 @@ async def analyze_envelope(
         diagnosis_lines.append(
             f"  {i}. {p.frequency_hz:7.2f} Hz  (magnitude: {p.magnitude:.2e})"
         )
-    diagnosis_lines.extend([
-        "",
-        "No reference bearing frequencies are assumed for this machine.",
-        "Compare the peaks above against BPFO/BPFI/BSF/FTF computed for the",
-        "actual bearing and shaft speed: use check_bearing_faults(...) with a",
-        "catalog bearing_id, explicit frequencies, or the bearing geometry",
-        "from the machine manual.",
-        "Use generate_envelope_report(...) for visual analysis and harmonic "
-        "identification.",
-    ])
+    diagnosis_lines.extend(
+        [
+            "",
+            "No reference bearing frequencies are assumed for this machine.",
+            "Compare the peaks above against BPFO/BPFI/BSF/FTF computed for the",
+            "actual bearing and shaft speed: use check_bearing_faults(...) with a",
+            "catalog bearing_id, explicit frequencies, or the bearing geometry",
+            "from the machine manual.",
+            "Use generate_envelope_report(...) for visual analysis and harmonic "
+            "identification.",
+        ]
+    )
 
     return EnvelopeResult(
         signal_id=signal_id,
@@ -309,39 +325,41 @@ async def analyze_envelope(
         diagnosis="\n".join(diagnosis_lines),
     )
 
+
 # ================================================================
 # TOOLS - STATISTICAL ANALYSIS
 # ================================================================
 
+
 def analyze_statistics(signal_id: str) -> StatisticalResult:
     """
-        Calculate statistical parameters of a stored signal for diagnostics.
+    Calculate statistical parameters of a stored signal for diagnostics.
 
-        Statistical parameters are key indicators for diagnostics:
-        - RMS: Effective value, correlated to signal energy
-        - Crest Factor: Indicates presence of impulses (high = possible faults)
-        - Kurtosis: Measures impulsiveness (excess kurtosis; >0 = non-Gaussian, >3 = strong impulses)
-        - Peak-to-Peak: Signal range
+    Statistical parameters are key indicators for diagnostics:
+    - RMS: Effective value, correlated to signal energy
+    - Crest Factor: Indicates presence of impulses (high = possible faults)
+    - Kurtosis: Measures impulsiveness (excess kurtosis; >0 = non-Gaussian, >3 = strong impulses)
+    - Peak-to-Peak: Signal range
 
-        Requires the signal loaded via load_signal() first. Statistical
-        parameters are screening indicators, not definitive diagnostics —
-        combine with frequency-domain evidence.
+    Requires the signal loaded via load_signal() first. Statistical
+    parameters are screening indicators, not definitive diagnostics —
+    combine with frequency-domain evidence.
 
-        **Signal units:** all values are in the signal's native unit. The unit
-        is reported only when DECLARED — load_signal(signal_unit=...) or the
-        companion _metadata.json — and never guessed from signal amplitude.
-        ISO 20816-3 severity tools refuse to produce a verdict until the unit
-        is declared.
+    **Signal units:** all values are in the signal's native unit. The unit
+    is reported only when DECLARED — load_signal(signal_unit=...) or the
+    companion _metadata.json — and never guessed from signal amplitude.
+    ISO 20816-3 severity tools refuse to produce a verdict until the unit
+    is declared.
 
-        Args:
-            signal_id: ID of the stored signal (from load_signal).
+    Args:
+        signal_id: ID of the stored signal (from load_signal).
 
-        Returns:
-            StatisticalResult with all statistical parameters
+    Returns:
+        StatisticalResult with all statistical parameters
 
-        Raises:
-            ValueError: If the signal_id is not loaded.
-        """
+    Raises:
+        ValueError: If the signal_id is not loaded.
+    """
     signal_data, info = resolve_signal(signal_id, require_sampling_rate=False)
 
     # Calculate statistical parameters
@@ -355,7 +373,9 @@ def analyze_statistics(signal_id: str) -> StatisticalResult:
     crest_factor = peak / rms if rms > 0 else 0.0
 
     # Kurtosis (using scipy)
-    kurtosis_val = float(kurtosis(signal_data, fisher=True))  # Fisher=True for excess kurtosis
+    kurtosis_val = float(
+        kurtosis(signal_data, fisher=True)
+    )  # Fisher=True for excess kurtosis
     skewness_val = float(skew(signal_data))
 
     # Signal unit: DECLARED only (load_signal parameter or companion
@@ -366,15 +386,15 @@ def analyze_statistics(signal_id: str) -> StatisticalResult:
     if declared_unit is not None:
         unit_note = (
             f"Signal unit declared as '{declared_unit}' for "
-                f"'{signal_id}'. All values above are in this unit."
+            f"'{signal_id}'. All values above are in this unit."
         )
     else:
         unit_note = (
             "Signal unit NOT declared — values are in the signal's native "
-                "(unknown) unit; the unit is never guessed from amplitude. For "
-                "ISO 20816-3 severity assessment, declare it via "
-                "load_signal(filepath=..., signal_unit='g'|'m/s2'|'mm/s'|'m/s') "
-                "or add a 'signal_unit' field to the companion _metadata.json."
+            "(unknown) unit; the unit is never guessed from amplitude. For "
+            "ISO 20816-3 severity assessment, declare it via "
+            "load_signal(filepath=..., signal_unit='g'|'m/s2'|'mm/s'|'m/s') "
+            "or add a 'signal_unit' field to the companion _metadata.json."
         )
 
     return StatisticalResult(
@@ -387,48 +407,50 @@ def analyze_statistics(signal_id: str) -> StatisticalResult:
         mean=mean_val,
         std_dev=std_dev,
         signal_unit=declared_unit,
-        unit_note=unit_note
+        unit_note=unit_note,
     )
+
 
 # ================================================================
 # TOOLS - FEATURE EXTRACTION
 # ================================================================
 
+
 async def extract_features_from_signal(
     signal_id: str,
     segment_duration: float = 0.1,
     overlap_ratio: float = 0.5,
-    ctx: Context = None
+    ctx: Context = None,
 ) -> FeatureExtractionResult:
     """
-        Extract time-domain features from a stored signal using sliding windows.
+    Extract time-domain features from a stored signal using sliding windows.
 
-        Segments the signal into overlapping windows and extracts 17 statistical features
-        from each segment. Features include: mean, std, RMS, kurtosis, crest factor, entropy, etc.
-        Requires the signal loaded via load_signal() first; the sampling rate
-        comes from the stored signal metadata. Returns an in-memory summary
-        only — no CSV is written to data/signals/.
+    Segments the signal into overlapping windows and extracts 17 statistical features
+    from each segment. Features include: mean, std, RMS, kurtosis, crest factor, entropy, etc.
+    Requires the signal loaded via load_signal() first; the sampling rate
+    comes from the stored signal metadata. Returns an in-memory summary
+    only — no CSV is written to data/signals/.
 
-        Args:
-            signal_id: ID of the stored signal (from load_signal).
-            segment_duration: Duration of each segment in seconds (default: 0.1)
-            overlap_ratio: Overlap between segments, 0-1 (default: 0.5 = 50%)
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        signal_id: ID of the stored signal (from load_signal).
+        segment_duration: Duration of each segment in seconds (default: 0.1)
+        overlap_ratio: Overlap between segments, 0-1 (default: 0.5 = 50%)
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            FeatureExtractionResult with features matrix and metadata
+    Returns:
+        FeatureExtractionResult with features matrix and metadata
 
-        Raises:
-            ValueError: If the signal_id is not loaded, or the stored signal
-                has no sampling rate.
+    Raises:
+        ValueError: If the signal_id is not loaded, or the stored signal
+            has no sampling rate.
 
-        Example:
-            extract_features_from_signal(
-                "healthy_motor",
-                segment_duration=0.2,
-                overlap_ratio=0.5
-            )
-        """
+    Example:
+        extract_features_from_signal(
+            "healthy_motor",
+            segment_duration=0.2,
+            overlap_ratio=0.5
+        )
+    """
     logger.info(f"Extracting features from '{signal_id}'...")
 
     signal_data, info = resolve_signal(signal_id)
@@ -469,12 +491,14 @@ async def extract_features_from_signal(
         overlap_ratio=overlap_ratio,
         features_shape=list(features_df.shape),
         feature_names=feature_names,
-        features_preview=[features_list[i] for i in range(min(5, len(features_list)))]
+        features_preview=[features_list[i] for i in range(min(5, len(features_list)))],
     )
+
 
 # ================================================================
 # TOOLS - SPECTRAL ANALYSIS (Phase 1 — signal_id based)
 # ================================================================
+
 
 async def compute_power_spectral_density(
     ctx: Context,
@@ -485,20 +509,24 @@ async def compute_power_spectral_density(
 ) -> PSDResult:
     """Compute Power Spectral Density (Welch method) for a stored signal.
 
-        Requires signal loaded via load_signal() first.
+    Requires signal loaded via load_signal() first.
 
-        Args:
-            signal_id: ID of the stored signal.
-            nperseg: Samples per FFT segment (default 256).
-            noverlap: Overlap between segments (default 128).
-            window: Window function (default 'hann').
-        """
+    Args:
+        signal_id: ID of the stored signal.
+        nperseg: Samples per FFT segment (default 256).
+        noverlap: Overlap between segments (default 128).
+        window: Window function (default 'hann').
+    """
     signal_data, info = resolve_signal(signal_id)
     fs = info.sampling_rate
 
-    logger.info(f"Computing PSD for '{signal_id}' ({info.num_samples} samples, {fs} Hz)")
+    logger.info(
+        f"Computing PSD for '{signal_id}' ({info.num_samples} samples, {fs} Hz)"
+    )
 
-    result = _compute_psd(signal_data, fs, nperseg=nperseg, noverlap=noverlap, window=window)
+    result = _compute_psd(
+        signal_data, fs, nperseg=nperseg, noverlap=noverlap, window=window
+    )
 
     return PSDResult(
         signal_id=signal_id,
@@ -513,6 +541,7 @@ async def compute_power_spectral_density(
         frequency_resolution=result["frequency_resolution"],
     )
 
+
 async def compute_spectrogram_stft(
     ctx: Context,
     signal_id: str,
@@ -522,21 +551,23 @@ async def compute_spectrogram_stft(
 ) -> STFTResult:
     """Compute STFT spectrogram for a stored signal.
 
-        Returns time-frequency summary (no full 2D array). Use for detecting
-        time-varying frequency content (transient faults, speed changes).
+    Returns time-frequency summary (no full 2D array). Use for detecting
+    time-varying frequency content (transient faults, speed changes).
 
-        Args:
-            signal_id: ID of the stored signal.
-            nperseg: Samples per STFT segment (default 256).
-            noverlap: Overlap between segments (default 128).
-            window: Window function (default 'hann').
-        """
+    Args:
+        signal_id: ID of the stored signal.
+        nperseg: Samples per STFT segment (default 256).
+        noverlap: Overlap between segments (default 128).
+        window: Window function (default 'hann').
+    """
     signal_data, info = resolve_signal(signal_id)
     fs = info.sampling_rate
 
     logger.info(f"Computing STFT for '{signal_id}'")
 
-    result = _compute_stft(signal_data, fs, nperseg=nperseg, noverlap=noverlap, window=window)
+    result = _compute_stft(
+        signal_data, fs, nperseg=nperseg, noverlap=noverlap, window=window
+    )
 
     return STFTResult(
         signal_id=signal_id,
@@ -553,6 +584,7 @@ async def compute_spectrogram_stft(
         max_power_time_s=result["max_power_time_s"],
         energy_per_band=result["energy_per_band"],
     )
+
 
 def register(mcp: MCPServer) -> None:
     """Register signal-analysis MCP tools on *mcp*."""

--- a/src/mcp_tools/decision_support_tools.py
+++ b/src/mcp_tools/decision_support_tools.py
@@ -54,27 +54,27 @@ async def generate_maintenance_recommendations(
 ) -> str:
     """Generate maintenance recommendations based on severity and detected faults.
 
-        Combines ISO zone-based urgency with fault-specific maintenance
-        actions. This tool intentionally does NOT accept a confidence
-        value: any number supplied by the caller would be echoed into
-        advisory output without evidential basis.
+    Combines ISO zone-based urgency with fault-specific maintenance
+    actions. This tool intentionally does NOT accept a confidence
+    value: any number supplied by the caller would be echoed into
+    advisory output without evidential basis.
 
-        Args:
-            ctx: MCP context. Unused — see this module's docstring on logging.
-            severity_zone: ISO zone letter — "A", "B", "C", or "D".
-            fault_types: Detected fault types from the closed canonical
-                vocabulary — outer_race/inner_race/ball/cage for bearings
-                (NOT the BPFO/BPFI/BSF/FTF acronyms) plus misalignment/
-                unbalance/looseness. None for zone-only advice.
+    Args:
+        ctx: MCP context. Unused — see this module's docstring on logging.
+        severity_zone: ISO zone letter — "A", "B", "C", or "D".
+        fault_types: Detected fault types from the closed canonical
+            vocabulary — outer_race/inner_race/ball/cage for bearings
+            (NOT the BPFO/BPFI/BSF/FTF acronyms) plus misalignment/
+            unbalance/looseness. None for zone-only advice.
 
-        Returns:
-            Formatted string listing all maintenance recommendations.
+    Returns:
+        Formatted string listing all maintenance recommendations.
 
-        Raises:
-            ValueError: If any fault type is outside the canonical
-                vocabulary (the message lists the allowed values —
-                unknown values are never dropped silently).
-        """
+    Raises:
+        ValueError: If any fault type is outside the canonical
+            vocabulary (the message lists the allowed values —
+            unknown values are never dropped silently).
+    """
     fault_list = list(fault_types) if fault_types else None
 
     logger.info(
@@ -89,7 +89,7 @@ async def generate_maintenance_recommendations(
     for i, rec in enumerate(recs, 1):
         lines.append(
             f"{i}. [{rec['urgency'].upper()}] {rec['action']}\n"
-                f"   {rec['description']}"
+            f"   {rec['description']}"
         )
 
     return "\n\n".join(lines)

--- a/src/mcp_tools/diagnostics_tools.py
+++ b/src/mcp_tools/diagnostics_tools.py
@@ -30,9 +30,14 @@ from mcp.server.mcpserver import MCPServer, Context
 
 from ..config import MODELS_DIR, RESOURCES_DIR
 from ..models import (
-    AnomalyModelResult, AnomalyPredictionResult,
-    BearingCatalogMiss, BearingFaultCheckResult, BearingFaultsSummary,
-    VibrationSeverityResult, ISOSeverityRefusal, DiagnosisResult,
+    AnomalyModelResult,
+    AnomalyPredictionResult,
+    BearingCatalogMiss,
+    BearingFaultCheckResult,
+    BearingFaultsSummary,
+    VibrationSeverityResult,
+    ISOSeverityRefusal,
+    DiagnosisResult,
 )
 from ..document_reader import (
     calculate_bearing_frequencies,
@@ -104,7 +109,9 @@ async def _extract_features_from_ids(
 
         detected_rates[sid] = file_rate
 
-        features = _segment_and_extract_features(signal_data, file_rate, segment_duration, overlap_ratio)
+        features = _segment_and_extract_features(
+            signal_data, file_rate, segment_duration, overlap_ratio
+        )
         all_features.extend(features)
 
     return all_features, detected_rates
@@ -244,9 +251,7 @@ async def assess_severity(
     # the signal route).
     check_power_scope(machine_power_kw)
 
-    custom = (
-        _validate_custom_thresholds(thresholds) if thresholds is not None else None
-    )
+    custom = _validate_custom_thresholds(thresholds) if thresholds is not None else None
 
     if signal_id is not None:
         # --- Stored-signal route (former evaluate_iso_20816 /
@@ -296,9 +301,7 @@ async def assess_severity(
         frequency_range = "not applicable — direct RMS velocity reading"
         unit_conversion = False
         original_unit = "mm/s"
-        logger.info(
-            f"Assessing severity for a direct reading of {rms:.2f} mm/s"
-        )
+        logger.info(f"Assessing severity for a direct reading of {rms:.2f} mm/s")
         zone_info = classify_zone(rms, machine_group, support_type)
         zone_block = {
             "zone": zone_info["zone"],
@@ -342,9 +345,11 @@ async def assess_severity(
         **zone_block,
     )
 
+
 # ------------------------------------------------------------------
 # ML anomaly detection – training
 # ------------------------------------------------------------------
+
 
 async def train_anomaly_model(
     healthy_signal_ids: list[str],
@@ -355,60 +360,62 @@ async def train_anomaly_model(
     fault_signal_ids: Optional[list[str]] = None,
     healthy_validation_ids: Optional[list[str]] = None,
     model_name: str = "anomaly_model",
-    ctx: Context = None
+    ctx: Context = None,
 ) -> AnomalyModelResult:
     """
-        Train ML-based anomaly detection model on healthy data (UNSUPERVISED/SEMI-SUPERVISED).
+    Train ML-based anomaly detection model on healthy data (UNSUPERVISED/SEMI-SUPERVISED).
 
-        All signals are referenced by signal_id: load them first with
-        load_signal — its batch form accepts a list of file paths, e.g.
-        load_signal(filepath=["real_train/baseline_1.csv", ...]). Each
-        signal's sampling rate comes from its stored metadata.
+    All signals are referenced by signal_id: load them first with
+    load_signal — its batch form accepts a list of file paths, e.g.
+    load_signal(filepath=["real_train/baseline_1.csv", ...]). Each
+    signal's sampling rate comes from its stored metadata.
 
-        Complete pipeline:
-        1. Extract features from healthy signals (segmentation + time-domain features)
-        2. Standardize features (StandardScaler - fitted on training data only)
-        3. Dimensionality reduction (PCA with specified variance explained)
-        4. Train novelty detection model (OneClassSVM or LocalOutlierFactor) on HEALTHY DATA ONLY
-        5. Optional hyperparameter tuning using validation data (semi-supervised)
-        6. Save model, scaler, and PCA transformer
+    Complete pipeline:
+    1. Extract features from healthy signals (segmentation + time-domain features)
+    2. Standardize features (StandardScaler - fitted on training data only)
+    3. Dimensionality reduction (PCA with specified variance explained)
+    4. Train novelty detection model (OneClassSVM or LocalOutlierFactor) on HEALTHY DATA ONLY
+    5. Optional hyperparameter tuning using validation data (semi-supervised)
+    6. Save model, scaler, and PCA transformer
 
-        **Training Mode:**
-        - UNSUPERVISED: Train only on healthy data with automatic hyperparameters
-        - SEMI-SUPERVISED: Train on healthy data, tune hyperparameters using validation set (healthy + fault)
+    **Training Mode:**
+    - UNSUPERVISED: Train only on healthy data with automatic hyperparameters
+    - SEMI-SUPERVISED: Train on healthy data, tune hyperparameters using validation set (healthy + fault)
 
-        **Note:** This is NOT supervised learning. OneClassSVM/LOF are trained ONLY on healthy data.
-        Fault data (if provided) is used ONLY for hyperparameter tuning after training.
+    **Note:** This is NOT supervised learning. OneClassSVM/LOF are trained ONLY on healthy data.
+    Fault data (if provided) is used ONLY for hyperparameter tuning after training.
 
-        **Validation Strategy:**
-        - If healthy_validation_ids provided: Use those explicitly (no split)
-        - If healthy_validation_ids NOT provided: Automatic 80/20 split of training data
-        - If fault_signal_ids provided: Enable semi-supervised mode (hyperparameter tuning)
+    **Validation Strategy:**
+    - If healthy_validation_ids provided: Use those explicitly (no split)
+    - If healthy_validation_ids NOT provided: Automatic 80/20 split of training data
+    - If fault_signal_ids provided: Enable semi-supervised mode (hyperparameter tuning)
 
-        Args:
-            healthy_signal_ids: Stored signal IDs with healthy machine data (for training)
-            segment_duration: Segment duration in seconds (default: 0.1)
-            overlap_ratio: Overlap ratio 0-1 (default: 0.5)
-            model_type: 'OneClassSVM' or 'LocalOutlierFactor' (default: 'OneClassSVM')
-            pca_variance: Cumulative variance to explain with PCA (default: 0.95)
-            fault_signal_ids: Optional stored signal IDs for HYPERPARAMETER TUNING (semi-supervised)
-            healthy_validation_ids: Optional stored healthy signal IDs for validation (specificity check).
-                                      If not provided, 20% of training data will be used.
-            model_name: Name for saved model files (default: 'anomaly_model')
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        healthy_signal_ids: Stored signal IDs with healthy machine data (for training)
+        segment_duration: Segment duration in seconds (default: 0.1)
+        overlap_ratio: Overlap ratio 0-1 (default: 0.5)
+        model_type: 'OneClassSVM' or 'LocalOutlierFactor' (default: 'OneClassSVM')
+        pca_variance: Cumulative variance to explain with PCA (default: 0.95)
+        fault_signal_ids: Optional stored signal IDs for HYPERPARAMETER TUNING (semi-supervised)
+        healthy_validation_ids: Optional stored healthy signal IDs for validation (specificity check).
+                                  If not provided, 20% of training data will be used.
+        model_name: Name for saved model files (default: 'anomaly_model')
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            AnomalyModelResult with model paths and performance metrics
+    Returns:
+        AnomalyModelResult with model paths and performance metrics
 
-        Raises:
-            ValueError: If a signal_id is not loaded or has no sampling rate,
-                or model_name/model_type is invalid.
-        """
+    Raises:
+        ValueError: If a signal_id is not loaded or has no sampling rate,
+            or model_name/model_type is invalid.
+    """
     # Fail fast on an unsafe model_name before doing any expensive work or
     # touching the filesystem (the write happens in step 6).
     validate_name_component(model_name, kind="model_name")
 
-    logger.info(f"Training {model_type} model on {len(healthy_signal_ids)} healthy signals...")
+    logger.info(
+        f"Training {model_type} model on {len(healthy_signal_ids)} healthy signals..."
+    )
 
     # Step 1: Extract features from all healthy signals
     all_features, detected_rates = await _extract_features_from_ids(
@@ -440,28 +447,28 @@ async def train_anomaly_model(
             # SEMI-SUPERVISED MODE: Train on healthy, tune hyperparameters with validation (healthy + fault)
             logger.info("Training in SEMI-SUPERVISED mode")
             logger.info("- Training: Healthy data only (unsupervised)")
-            logger.info("- Hyperparameter tuning: Using validation set (healthy + fault)")
+            logger.info(
+                "- Hyperparameter tuning: Using validation set (healthy + fault)"
+            )
             logger.info("Evaluating hyperparameter grid...")
 
             # Prepare validation features for fault signals
             X_fault = await _extract_and_transform_validation_features(
-                fault_signal_ids, segment_duration, overlap_ratio,
-                scaler, pca
+                fault_signal_ids, segment_duration, overlap_ratio, scaler, pca
             )
 
             # Prepare validation features for healthy signals
             X_healthy_val = None
             if healthy_validation_ids:
                 X_healthy_val = await _extract_and_transform_validation_features(
-                    healthy_validation_ids, segment_duration, overlap_ratio,
-                    scaler, pca
+                    healthy_validation_ids, segment_duration, overlap_ratio, scaler, pca
                 )
 
             # Hyperparameter grid
             param_grid = {
-                'nu': [0.01, 0.05, 0.1, 0.2],
-                'gamma': ['scale', 'auto', 0.001, 0.01, 0.1],
-                'kernel': ['rbf']
+                "nu": [0.01, 0.05, 0.1, 0.2],
+                "gamma": ["scale", "auto", 0.001, 0.01, 0.1],
+                "kernel": ["rbf"],
             }
 
             # Manual hyperparameter search with validation scoring
@@ -469,10 +476,10 @@ async def train_anomaly_model(
             best_params = None
             best_model = None
 
-            for nu in param_grid['nu']:
-                for gamma in param_grid['gamma']:
+            for nu in param_grid["nu"]:
+                for gamma in param_grid["gamma"]:
                     # Train on HEALTHY DATA ONLY
-                    model_candidate = OneClassSVM(kernel='rbf', nu=nu, gamma=gamma)
+                    model_candidate = OneClassSVM(kernel="rbf", nu=nu, gamma=gamma)
                     model_candidate.fit(X_pca)  # Only healthy training data
 
                     # Evaluate on validation set (healthy + fault)
@@ -499,12 +506,14 @@ async def train_anomaly_model(
 
                     if validation_score > best_score:
                         best_score = validation_score
-                        best_params = {'kernel': 'rbf', 'nu': nu, 'gamma': gamma}
+                        best_params = {"kernel": "rbf", "nu": nu, "gamma": gamma}
                         best_model = model_candidate
 
             model = best_model
 
-            logger.info(f"Best hyperparameters: nu={best_params['nu']}, gamma={best_params['gamma']}")
+            logger.info(
+                f"Best hyperparameters: nu={best_params['nu']}, gamma={best_params['gamma']}"
+            )
             logger.info(f"Validation balanced accuracy: {best_score:.3f}")
 
         else:
@@ -516,17 +525,17 @@ async def train_anomaly_model(
             nu_auto = min(0.1, max(0.01, 1.0 / np.sqrt(len(X_pca))))
 
             model = OneClassSVM(
-                kernel='rbf',
+                kernel="rbf",
                 nu=nu_auto,  # Adaptive based on sample size
-                gamma='scale'  # Automatic scaling based on features
+                gamma="scale",  # Automatic scaling based on features
             )
             model.fit(X_pca)
 
             best_params = {
-                'kernel': 'rbf',
-                'nu': float(nu_auto),
-                'gamma': 'scale',
-                'mode': 'unsupervised_auto'
+                "kernel": "rbf",
+                "nu": float(nu_auto),
+                "gamma": "scale",
+                "mode": "unsupervised_auto",
             }
 
             logger.info(f"Auto-calculated nu={nu_auto:.4f} based on sample size")
@@ -540,16 +549,14 @@ async def train_anomaly_model(
 
             # Prepare validation features for fault signals
             X_fault = await _extract_and_transform_validation_features(
-                fault_signal_ids, segment_duration, overlap_ratio,
-                scaler, pca
+                fault_signal_ids, segment_duration, overlap_ratio, scaler, pca
             )
 
             # Prepare healthy validation features
             X_healthy_val = None
             if healthy_validation_ids:
                 X_healthy_val = await _extract_and_transform_validation_features(
-                    healthy_validation_ids, segment_duration, overlap_ratio,
-                    scaler, pca
+                    healthy_validation_ids, segment_duration, overlap_ratio, scaler, pca
                 )
 
             # Hyperparameter search for LOF
@@ -562,7 +569,7 @@ async def train_anomaly_model(
                     model_candidate = LocalOutlierFactor(
                         n_neighbors=n_neighbors,
                         contamination=contamination,
-                        novelty=True
+                        novelty=True,
                     )
                     model_candidate.fit(X_pca)  # Only healthy training data
 
@@ -590,12 +597,17 @@ async def train_anomaly_model(
 
                     if validation_score > best_score:
                         best_score = validation_score
-                        best_params = {'n_neighbors': n_neighbors, 'contamination': contamination}
+                        best_params = {
+                            "n_neighbors": n_neighbors,
+                            "contamination": contamination,
+                        }
                         best_model = model_candidate
 
             model = best_model
 
-            logger.info(f"Best parameters: n_neighbors={best_params['n_neighbors']}, contamination={best_params['contamination']}")
+            logger.info(
+                f"Best parameters: n_neighbors={best_params['n_neighbors']}, contamination={best_params['contamination']}"
+            )
 
         else:
             # UNSUPERVISED MODE: Auto parameters
@@ -607,22 +619,22 @@ async def train_anomaly_model(
             contamination_auto = 0.1  # Conservative 10% outlier assumption
 
             model = LocalOutlierFactor(
-                n_neighbors=n_auto,
-                contamination=contamination_auto,
-                novelty=True
+                n_neighbors=n_auto, contamination=contamination_auto, novelty=True
             )
             model.fit(X_pca)
 
             best_params = {
-                'n_neighbors': int(n_auto),
-                'contamination': contamination_auto,
-                'mode': 'unsupervised_auto'
+                "n_neighbors": int(n_auto),
+                "contamination": contamination_auto,
+                "mode": "unsupervised_auto",
             }
 
             logger.info(f"Auto-calculated n_neighbors={n_auto}")
 
     else:
-        raise ValueError(f"Unknown model_type: {model_type}. Use 'OneClassSVM' or 'LocalOutlierFactor'")
+        raise ValueError(
+            f"Unknown model_type: {model_type}. Use 'OneClassSVM' or 'LocalOutlierFactor'"
+        )
 
     # Step 5: Optional validation on healthy + fault data
     validation_accuracy = None
@@ -637,12 +649,13 @@ async def train_anomaly_model(
 
         if healthy_validation_ids:
             # Option 1: User provided explicit healthy validation files
-            logger.info(f"Using {len(healthy_validation_ids)} explicitly provided healthy validation files")
+            logger.info(
+                f"Using {len(healthy_validation_ids)} explicitly provided healthy validation files"
+            )
 
             # Extract and transform features from validation signals
             X_pca_healthy_val = await _extract_and_transform_validation_features(
-                healthy_validation_ids, segment_duration, overlap_ratio,
-                scaler, pca
+                healthy_validation_ids, segment_duration, overlap_ratio, scaler, pca
             )
 
             if X_pca_healthy_val is not None:
@@ -651,7 +664,9 @@ async def train_anomaly_model(
                 healthy_total = len(healthy_predictions)
                 healthy_accuracy = healthy_correct / healthy_total
 
-                logger.info(f"Healthy validation: {healthy_correct}/{healthy_total} correctly classified ({healthy_accuracy*100:.1f}%)")
+                logger.info(
+                    f"Healthy validation: {healthy_correct}/{healthy_total} correctly classified ({healthy_accuracy*100:.1f}%)"
+                )
             else:
                 healthy_correct = 0
                 healthy_total = 0
@@ -659,7 +674,9 @@ async def train_anomaly_model(
 
         else:
             # Option 2: Auto-split training data 80/20
-            logger.info("No healthy validation files provided - using 80/20 split of training data")
+            logger.info(
+                "No healthy validation files provided - using 80/20 split of training data"
+            )
 
             split_idx = int(0.8 * len(X_pca))
             X_pca_train = X_pca[:split_idx]
@@ -668,9 +685,9 @@ async def train_anomaly_model(
             # Retrain model on 80% split for proper validation
             if model_type == "OneClassSVM":
                 model_retrained = OneClassSVM(
-                    kernel=best_params.get('kernel', 'rbf'),
-                    nu=best_params['nu'],
-                    gamma=best_params['gamma']
+                    kernel=best_params.get("kernel", "rbf"),
+                    nu=best_params["nu"],
+                    gamma=best_params["gamma"],
                 )
                 model_retrained.fit(X_pca_train)
                 model = model_retrained  # Use retrained model
@@ -683,14 +700,15 @@ async def train_anomaly_model(
             healthy_total = len(healthy_predictions)
             healthy_accuracy = healthy_correct / healthy_total
 
-            logger.info(f"Healthy validation: {healthy_correct}/{healthy_total} correctly classified ({healthy_accuracy*100:.1f}%)")
+            logger.info(
+                f"Healthy validation: {healthy_correct}/{healthy_total} correctly classified ({healthy_accuracy*100:.1f}%)"
+            )
 
         # Part B: Validate on FAULT data (only if fault files were provided)
         X_fault_pca = None
         if fault_signal_ids:
             X_fault_pca = await _extract_and_transform_validation_features(
-                fault_signal_ids, segment_duration, overlap_ratio,
-                scaler, pca
+                fault_signal_ids, segment_duration, overlap_ratio, scaler, pca
             )
 
         if X_fault_pca is not None:
@@ -706,24 +724,28 @@ async def train_anomaly_model(
             # Overall accuracy = (healthy_correct + fault_correct) / (healthy_total + fault_total)
             total_correct = healthy_correct + anomaly_detected
             total_samples = healthy_total + fault_total
-            validation_accuracy = float(total_correct / total_samples) if total_samples > 0 else 0.0
+            validation_accuracy = (
+                float(total_correct / total_samples) if total_samples > 0 else 0.0
+            )
 
             validation_details = (
                 f"Healthy: {healthy_correct}/{healthy_total} correct ({healthy_accuracy*100:.1f}%), "
-                    f"Fault: {anomaly_detected}/{fault_total} detected ({fault_accuracy*100:.1f}%)"
+                f"Fault: {anomaly_detected}/{fault_total} detected ({fault_accuracy*100:.1f}%)"
             )
 
             validation_metrics = {
-                'healthy_correct': int(healthy_correct),
-                'healthy_total': int(healthy_total),
-                'healthy_accuracy': float(healthy_accuracy),
-                'fault_detected': int(anomaly_detected),
-                'fault_total': int(fault_total),
-                'fault_accuracy': float(fault_accuracy),
-                'overall_accuracy': float(validation_accuracy)
+                "healthy_correct": int(healthy_correct),
+                "healthy_total": int(healthy_total),
+                "healthy_accuracy": float(healthy_accuracy),
+                "fault_detected": int(anomaly_detected),
+                "fault_total": int(fault_total),
+                "fault_accuracy": float(fault_accuracy),
+                "overall_accuracy": float(validation_accuracy),
             }
 
-            logger.info(f"Fault validation: {anomaly_detected}/{fault_total} detected as anomalies ({fault_accuracy*100:.1f}%)")
+            logger.info(
+                f"Fault validation: {anomaly_detected}/{fault_total} detected as anomalies ({fault_accuracy*100:.1f}%)"
+            )
             logger.info(f"Overall validation accuracy: {validation_accuracy*100:.1f}%")
 
     # Step 6: Save model, scaler, and PCA
@@ -737,11 +759,11 @@ async def train_anomaly_model(
     scaler_path = _model_paths.scaler
     pca_path = _model_paths.pca
 
-    with open(model_path, 'wb') as f:
+    with open(model_path, "wb") as f:
         pickle.dump(model, f)
-    with open(scaler_path, 'wb') as f:
+    with open(scaler_path, "wb") as f:
         pickle.dump(scaler, f)
-    with open(pca_path, 'wb') as f:
+    with open(pca_path, "wb") as f:
         pickle.dump(pca, f)
 
     # Save metadata. Each training signal carries its own stored sampling
@@ -749,24 +771,24 @@ async def train_anomaly_model(
     # 'per_file' (prediction then uses the test signal's own stored rate).
     unique_rates = sorted(set(detected_rates.values()))
     metadata = {
-        'model_type': model_type,
-        'training_mode': 'supervised' if fault_signal_ids else 'unsupervised',
-        'feature_names': list(features_df.columns),
-        'num_features_original': X_train.shape[1],
-        'num_features_pca': X_pca.shape[1],
-        'pca_variance': float(pca.explained_variance_ratio_.sum()),
-        'best_params': best_params,
-        'sampling_rate': unique_rates[0] if len(unique_rates) == 1 else 'per_file',
-        'sampling_rates_detected': detected_rates,
-        'segment_duration': segment_duration,
-        'overlap_ratio': overlap_ratio,
-        'multi_rate_training': len(unique_rates) > 1,
-        'validation_with_faults': fault_signal_ids is not None,
-        'num_validation_files': len(fault_signal_ids) if fault_signal_ids else 0
+        "model_type": model_type,
+        "training_mode": "supervised" if fault_signal_ids else "unsupervised",
+        "feature_names": list(features_df.columns),
+        "num_features_original": X_train.shape[1],
+        "num_features_pca": X_pca.shape[1],
+        "pca_variance": float(pca.explained_variance_ratio_.sum()),
+        "best_params": best_params,
+        "sampling_rate": unique_rates[0] if len(unique_rates) == 1 else "per_file",
+        "sampling_rates_detected": detected_rates,
+        "segment_duration": segment_duration,
+        "overlap_ratio": overlap_ratio,
+        "multi_rate_training": len(unique_rates) > 1,
+        "validation_with_faults": fault_signal_ids is not None,
+        "num_validation_files": len(fault_signal_ids) if fault_signal_ids else 0,
     }
 
     metadata_path = _model_paths.metadata
-    with open(metadata_path, 'w') as f:
+    with open(metadata_path, "w") as f:
         json.dump(metadata, f, indent=2)
 
     logger.info(f"Model saved to {model_path}")
@@ -786,45 +808,45 @@ async def train_anomaly_model(
         pca_path=str(pca_path),
         validation_accuracy=validation_accuracy,
         validation_details=validation_details,
-        validation_metrics=validation_metrics
+        validation_metrics=validation_metrics,
     )
+
 
 # ------------------------------------------------------------------
 # ML anomaly detection – prediction
 # ------------------------------------------------------------------
 
+
 async def predict_anomalies(
-    signal_id: str,
-    model_name: str = "anomaly_model",
-    ctx: Context = None
+    signal_id: str, model_name: str = "anomaly_model", ctx: Context = None
 ) -> AnomalyPredictionResult:
     """
-        Predict anomalies in a stored signal using a trained model.
+    Predict anomalies in a stored signal using a trained model.
 
-        Requires the signal loaded via load_signal() first and a model
-        trained via train_anomaly_model (its result echoes the model_name
-        to pass here). Pipeline: segment -> features -> scaler -> PCA ->
-        predict -> aggregate.
+    Requires the signal loaded via load_signal() first and a model
+    trained via train_anomaly_model (its result echoes the model_name
+    to pass here). Pipeline: segment -> features -> scaler -> PCA ->
+    predict -> aggregate.
 
-        Output is BOUNDED: counts, anomaly ratio, score percentiles, and
-        up to 10 worst segments — never per-segment arrays, regardless of
-        signal length.
+    Output is BOUNDED: counts, anomaly ratio, score percentiles, and
+    up to 10 worst segments — never per-segment arrays, regardless of
+    signal length.
 
-        Args:
-            signal_id: ID of the stored signal to analyze (from load_signal)
-            model_name: Name of trained model (default: 'anomaly_model')
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        signal_id: ID of the stored signal to analyze (from load_signal)
+        model_name: Name of trained model (default: 'anomaly_model')
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            AnomalyPredictionResult with aggregate statistics and health
-            assessment.
+    Returns:
+        AnomalyPredictionResult with aggregate statistics and health
+        assessment.
 
-        Raises:
-            FileNotFoundError: If the model does not exist (the message
-                lists the models actually on disk).
-            ValueError: If the signal_id is not loaded, or no sampling rate
-                is available for segmentation.
-        """
+    Raises:
+        FileNotFoundError: If the model does not exist (the message
+            lists the models actually on disk).
+        ValueError: If the signal_id is not loaded, or no sampling rate
+            is available for segmentation.
+    """
     logger.info(f"Predicting anomalies in '{signal_id}'...")
 
     # Validate model_name and contain every derived path (single source of
@@ -836,23 +858,24 @@ async def predict_anomalies(
     metadata_path = _model_paths.metadata
 
     if not model_path.exists():
-        available = sorted(
-            p.name[: -len("_model.pkl")]
-            for p in MODELS_DIR.glob("*_model.pkl")
-        ) if MODELS_DIR.exists() else []
+        available = (
+            sorted(p.name[: -len("_model.pkl")] for p in MODELS_DIR.glob("*_model.pkl"))
+            if MODELS_DIR.exists()
+            else []
+        )
         raise FileNotFoundError(
             f"Model '{model_name}' not found — models on disk: "
             f"{available if available else 'none'}. Train one with "
             f"train_anomaly_model(model_name=...) first."
         )
 
-    with open(model_path, 'rb') as f:
+    with open(model_path, "rb") as f:
         model = pickle.load(f)
-    with open(scaler_path, 'rb') as f:
+    with open(scaler_path, "rb") as f:
         scaler = pickle.load(f)
-    with open(pca_path, 'rb') as f:
+    with open(pca_path, "rb") as f:
         pca = pickle.load(f)
-    with open(metadata_path, 'r') as f:
+    with open(metadata_path, "r") as f:
         metadata = json.load(f)
 
     # Resolve the stored signal (fail fast with the standard message).
@@ -861,21 +884,21 @@ async def predict_anomalies(
     signal_data, info = resolve_signal(signal_id, require_sampling_rate=False)
 
     # Extract features
-    sampling_rate_val = metadata['sampling_rate']
+    sampling_rate_val = metadata["sampling_rate"]
     if isinstance(sampling_rate_val, str):
         # Model was trained with per-file rates: use the stored signal's rate.
         if info.sampling_rate is None:
             raise ValueError(
                 f"Model '{model_name}' was trained with per-file sampling "
-                    f"rates, but signal '{signal_id}' has no stored rate — "
-                    f"re-load it with load_signal(filepath=..., "
-                    f"sampling_rate=..., overwrite=True) or add a "
-                    f"'sampling_rate' field to the companion _metadata.json."
+                f"rates, but signal '{signal_id}' has no stored rate — "
+                f"re-load it with load_signal(filepath=..., "
+                f"sampling_rate=..., overwrite=True) or add a "
+                f"'sampling_rate' field to the companion _metadata.json."
             )
         sampling_rate_val = info.sampling_rate
     sampling_rate_val = float(sampling_rate_val)
-    segment_duration = metadata['segment_duration']
-    overlap_ratio = metadata['overlap_ratio']
+    segment_duration = metadata["segment_duration"]
+    overlap_ratio = metadata["overlap_ratio"]
 
     segment_length_samples = int(segment_duration * sampling_rate_val)
     hop_length = int(segment_length_samples * (1 - overlap_ratio))
@@ -892,7 +915,7 @@ async def predict_anomalies(
 
     features_list = []
     for start in range(0, len(signal_data) - segment_length_samples + 1, hop_length):
-        segment = signal_data[start:start + segment_length_samples]
+        segment = signal_data[start : start + segment_length_samples]
         features = extract_time_domain_features(segment)
         features_list.append(features)
 
@@ -907,7 +930,7 @@ async def predict_anomalies(
 
     # Decision scores when the model exposes them (negative = anomalous).
     scores = None
-    if hasattr(model, 'decision_function'):
+    if hasattr(model, "decision_function"):
         scores = np.asarray(model.decision_function(X_pca), dtype=float)
 
     # Aggregate statistics — the per-segment arrays never leave this
@@ -933,11 +956,7 @@ async def predict_anomalies(
         {
             "segment_index": int(i),
             "start_time_s": round(float(i * hop_s), 4),
-            **(
-                {"score": round(float(scores[i]), 6)}
-                if scores is not None
-                else {}
-            ),
+            **({"score": round(float(scores[i]), 6)} if scores is not None else {}),
         }
         for i in worst_idx
     ]
@@ -966,64 +985,68 @@ async def predict_anomalies(
         overall_health=overall_health,
     )
 
+
 # ------------------------------------------------------------------
 # Machine documentation tools
 # ------------------------------------------------------------------
 
+
 async def list_machine_manuals(ctx: Context | None = None) -> list[dict[str, Any]]:
     """
-        List all machine manuals in resources/machine_manuals/ (PDF/TXT).
+    List all machine manuals in resources/machine_manuals/ (PDF/TXT).
 
-        Use before read_manual_excerpt / extract_manual_specs, and pass the
-        returned filenames exactly as-is.
+    Use before read_manual_excerpt / extract_manual_specs, and pass the
+    returned filenames exactly as-is.
 
-        Returns:
-            List of dicts with filename, size_mb, modified, and path.
-        """
+    Returns:
+        List of dicts with filename, size_mb, modified, and path.
+    """
     manuals_dir = RESOURCES_DIR / "machine_manuals"
     manuals = []
 
     # Support both PDF and TXT files
-    for manual_file in list(manuals_dir.glob("*.pdf")) + list(manuals_dir.glob("*.txt")):
+    for manual_file in list(manuals_dir.glob("*.pdf")) + list(
+        manuals_dir.glob("*.txt")
+    ):
         stat = manual_file.stat()
-        manuals.append({
-            "filename": manual_file.name,
-            "size_mb": stat.st_size / (1024 * 1024),
-            "modified": stat.st_mtime,
-            "path": str(manual_file.relative_to(RESOURCES_DIR))
-        })
+        manuals.append(
+            {
+                "filename": manual_file.name,
+                "size_mb": stat.st_size / (1024 * 1024),
+                "modified": stat.st_mtime,
+                "path": str(manual_file.relative_to(RESOURCES_DIR)),
+            }
+        )
 
     logger.info(f"Found {len(manuals)} machine manuals in resources/machine_manuals/")
 
+    return sorted(manuals, key=lambda x: x["filename"])
 
-    return sorted(manuals, key=lambda x: x['filename'])
 
 async def extract_manual_specs(
-    file_name: str,
-    use_cache: bool = True,
-    ctx: Context | None = None
+    file_name: str, use_cache: bool = True, ctx: Context | None = None
 ) -> dict[str, Any]:
     """
-        Extract machine specifications from an equipment manual (PDF).
+    Extract machine specifications from an equipment manual (PDF).
 
-        Extracts bearing designations (e.g. SKF 6205), operating speeds
-        (RPM), power ratings (kW/HP/MW), and a text excerpt. Results are
-        cached. If a bearing's geometry is not in the manual, follow up
-        with search_bearing_catalog(bearing_id=...); if it is not in the
-        catalog either, ask the user for the geometry — never invent it.
+    Extracts bearing designations (e.g. SKF 6205), operating speeds
+    (RPM), power ratings (kW/HP/MW), and a text excerpt. Results are
+    cached. If a bearing's geometry is not in the manual, follow up
+    with search_bearing_catalog(bearing_id=...); if it is not in the
+    catalog either, ask the user for the geometry — never invent it.
 
-        Args:
-            file_name: Manual filename in resources/machine_manuals/
-            use_cache: Use cached extraction if available (default: True)
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        file_name: Manual filename in resources/machine_manuals/
+        use_cache: Use cached extraction if available (default: True)
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            Dictionary with extracted specifications and text excerpt.
+    Returns:
+        Dictionary with extracted specifications and text excerpt.
 
-        Raises:
-            FileNotFoundError: If the manual does not exist (the message
-                lists the available manuals).
-        """
+    Raises:
+        FileNotFoundError: If the manual does not exist (the message
+            lists the available manuals).
+    """
     logger.info(f"Extracting specifications from: {file_name}")
 
     manual_path = safe_resolve(RESOURCES_DIR / "machine_manuals", file_name)
@@ -1031,7 +1054,7 @@ async def extract_manual_specs(
     if not manual_path.exists():
         raise FileNotFoundError(
             f"Manual not found: {file_name}\n"
-                f"Available manuals: {[f.name for f in (RESOURCES_DIR / 'machine_manuals').glob('*.pdf')]}"
+            f"Available manuals: {[f.name for f in (RESOURCES_DIR / 'machine_manuals').glob('*.pdf')]}"
         )
 
     # Extract specs (with caching)
@@ -1039,10 +1062,11 @@ async def extract_manual_specs(
 
     logger.info(f"Found {len(specs['bearings'])} bearing designations")
     logger.info(f"Found {len(specs['rpm_values'])} RPM values")
-    if specs['bearings']:
+    if specs["bearings"]:
         logger.info(f"Bearings: {', '.join(specs['bearings'][:5])}")
 
     return specs
+
 
 async def calculate_bearing_characteristic_frequencies(
     num_balls: int,
@@ -1050,37 +1074,37 @@ async def calculate_bearing_characteristic_frequencies(
     pitch_diameter_mm: float,
     contact_angle_deg: float = 0.0,
     rpm: float = 1500.0,
-    ctx: Context | None = None
+    ctx: Context | None = None,
 ) -> dict[str, float]:
     """
-        Calculate bearing characteristic frequencies from geometry.
+    Calculate bearing characteristic frequencies from geometry.
 
-        Standard rolling-element kinematic formulas (Randall & Antoni 2011,
-        "Rolling element bearing diagnostics — A tutorial", MSSP 25(2)).
-        Requires the EXACT geometry — from the manual, the catalog
-        (search_bearing_catalog), or the user; never guessed. Deep-groove
-        ball bearings have contact_angle_deg = 0.
+    Standard rolling-element kinematic formulas (Randall & Antoni 2011,
+    "Rolling element bearing diagnostics — A tutorial", MSSP 25(2)).
+    Requires the EXACT geometry — from the manual, the catalog
+    (search_bearing_catalog), or the user; never guessed. Deep-groove
+    ball bearings have contact_angle_deg = 0.
 
-        Args:
-            num_balls: Number of rolling elements (Z)
-            ball_diameter_mm: Ball/roller diameter (Bd) in mm
-            pitch_diameter_mm: Pitch circle diameter (Pd) in mm
-            contact_angle_deg: Contact angle (alpha) in degrees
-            rpm: Shaft rotation speed in RPM
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        num_balls: Number of rolling elements (Z)
+        ball_diameter_mm: Ball/roller diameter (Bd) in mm
+        pitch_diameter_mm: Pitch circle diameter (Pd) in mm
+        contact_angle_deg: Contact angle (alpha) in degrees
+        rpm: Shaft rotation speed in RPM
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            Dictionary with BPFO, BPFI, BSF, FTF in Hz.
+    Returns:
+        Dictionary with BPFO, BPFI, BSF, FTF in Hz.
 
-        Example:
-            >>> # 6205 geometry (CWRU Bearing Data Center) at 1797 RPM
-            >>> freqs = calculate_bearing_characteristic_frequencies(
-            ...     num_balls=9, ball_diameter_mm=7.94,
-            ...     pitch_diameter_mm=39.04, rpm=1797
-            ... )
-            >>> round(freqs['BPFO'], 2)
-            107.36
-        """
+    Example:
+        >>> # 6205 geometry (CWRU Bearing Data Center) at 1797 RPM
+        >>> freqs = calculate_bearing_characteristic_frequencies(
+        ...     num_balls=9, ball_diameter_mm=7.94,
+        ...     pitch_diameter_mm=39.04, rpm=1797
+        ... )
+        >>> round(freqs['BPFO'], 2)
+        107.36
+    """
     logger.info(f"Calculating bearing frequencies for {num_balls} balls at {rpm} RPM")
 
     freqs = calculate_bearing_frequencies(
@@ -1088,7 +1112,7 @@ async def calculate_bearing_characteristic_frequencies(
         ball_diameter_mm=ball_diameter_mm,
         pitch_diameter_mm=pitch_diameter_mm,
         contact_angle_deg=contact_angle_deg,
-        shaft_speed_rpm=rpm
+        shaft_speed_rpm=rpm,
     )
 
     logger.info(f"BPFO (outer race): {freqs['BPFO']:.2f} Hz")
@@ -1098,30 +1122,29 @@ async def calculate_bearing_characteristic_frequencies(
 
     return freqs
 
+
 async def read_manual_excerpt(
-    file_name: str,
-    max_pages: int = 10,
-    ctx: Context | None = None
+    file_name: str, max_pages: int = 10, ctx: Context | None = None
 ) -> str:
     """
-        Read a text excerpt from a machine manual (PDF or TXT).
+    Read a text excerpt from a machine manual (PDF or TXT).
 
-        Use for consecutive-page reading; for targeted questions prefer
-        search_documentation. Start with max_pages=10 and increase only if
-        needed (pages consume tokens).
+    Use for consecutive-page reading; for targeted questions prefer
+    search_documentation. Start with max_pages=10 and increase only if
+    needed (pages consume tokens).
 
-        Args:
-            file_name: Manual filename in resources/machine_manuals/
-                (PDF or TXT)
-            max_pages: Maximum pages to extract (ignored for TXT files)
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        file_name: Manual filename in resources/machine_manuals/
+            (PDF or TXT)
+        max_pages: Maximum pages to extract (ignored for TXT files)
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            Extracted text from the manual.
+    Returns:
+        Extracted text from the manual.
 
-        Raises:
-            FileNotFoundError: If the manual does not exist.
-        """
+    Raises:
+        FileNotFoundError: If the manual does not exist.
+    """
     logger.info(f"Reading from: {file_name}")
 
     manual_path = safe_resolve(RESOURCES_DIR / "machine_manuals", file_name)
@@ -1139,8 +1162,8 @@ async def read_manual_excerpt(
         )
 
     # Read based on file type
-    if manual_path.suffix.lower() == '.txt':
-        with open(manual_path, 'r', encoding='utf-8') as f:
+    if manual_path.suffix.lower() == ".txt":
+        with open(manual_path, "r", encoding="utf-8") as f:
             text = f.read()
         logger.info(f"Extracted {len(text)} characters from text file")
     else:
@@ -1149,47 +1172,53 @@ async def read_manual_excerpt(
 
     return text
 
+
 async def search_bearing_catalog(
-    bearing_id: str,
-    ctx: Context | None = None
+    bearing_id: str, ctx: Context | None = None
 ) -> dict[str, Any] | BearingCatalogMiss:
     """
-        Search for bearing specifications in the local verified catalog.
+    Search for bearing specifications in the local verified catalog.
 
-        Fallback for when the machine manual names a bearing but not its
-        geometry. The catalog is small BY DESIGN: only entries whose
-        geometry is traceable to a public source (mandatory `source`
-        citation). A miss is a legitimate negative outcome — ask the user
-        for the geometry; never guess it.
+    Fallback for when the machine manual names a bearing but not its
+    geometry. The catalog is small BY DESIGN: only entries whose
+    geometry is traceable to a public source (mandatory `source`
+    citation). A miss is a legitimate negative outcome — ask the user
+    for the geometry; never guess it.
 
-        Args:
-            bearing_id: Bearing designation (e.g. "6205", "SKF 6205-2RS")
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        bearing_id: Bearing designation (e.g. "6205", "SKF 6205-2RS")
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            Dictionary with bearing specifications if found, or a
-            BearingCatalogMiss (status='not_found', suggestion,
-            catalog_contains) when the bearing is not in the catalog.
+    Returns:
+        Dictionary with bearing specifications if found, or a
+        BearingCatalogMiss (status='not_found', suggestion,
+        catalog_contains) when the bearing is not in the catalog.
 
-        Raises:
-            Exception: If the catalog itself cannot be read (missing or
-                malformed common_bearings_catalog.json).
-        """
+    Raises:
+        Exception: If the catalog itself cannot be read (missing or
+            malformed common_bearings_catalog.json).
+    """
     logger.info(f"Searching catalog for bearing: {bearing_id}")
 
     bearing_specs = lookup_bearing_in_catalog(bearing_id)
 
     if bearing_specs:
-        logger.info(f"Found {bearing_specs['designation']} in catalog (source: {bearing_specs.get('source', 'unknown')})")
+        logger.info(
+            f"Found {bearing_specs['designation']} in catalog (source: {bearing_specs.get('source', 'unknown')})"
+        )
         logger.info(f"  Type: {bearing_specs.get('type', 'N/A')}")
-        logger.info(f"  Balls: {bearing_specs['num_balls']}, Ball diameter: {bearing_specs['ball_diameter_mm']} mm")
+        logger.info(
+            f"  Balls: {bearing_specs['num_balls']}, Ball diameter: {bearing_specs['ball_diameter_mm']} mm"
+        )
         logger.info(f"  Pitch diameter: {bearing_specs['pitch_diameter_mm']} mm")
         return bearing_specs
 
     # Not in catalog: a legitimate negative outcome — typed result, never an
     # ad-hoc {"error": ...} dict returned as success. No geometry is invented.
     logger.warning(f"Bearing {bearing_id} not found in catalog")
-    logger.warning("  LLM should ask user for bearing geometry or suggest uploading manufacturer catalog")
+    logger.warning(
+        "  LLM should ask user for bearing geometry or suggest uploading manufacturer catalog"
+    )
 
     available = sorted(b["designation"] for b in _list_catalog())
     return BearingCatalogMiss(
@@ -1202,40 +1231,39 @@ async def search_bearing_catalog(
         catalog_contains=available,
     )
 
+
 # ------------------------------------------------------------------
 # Document search (RAG)
 # ------------------------------------------------------------------
 
+
 async def search_documentation(
-    query: str,
-    top_k: int = 5,
-    force_reindex: bool = False,
-    ctx: Context | None = None
+    query: str, top_k: int = 5, force_reindex: bool = False, ctx: Context | None = None
 ) -> dict[str, Any]:
     """
-        Semantic search across all machine manuals and bearing catalogs.
+    Semantic search across all machine manuals and bearing catalogs.
 
-        Uses vector retrieval (RAG) to find the most relevant passages from
-        PDFs, text files, and JSON catalogs in resources/.
+    Uses vector retrieval (RAG) to find the most relevant passages from
+    PDFs, text files, and JSON catalogs in resources/.
 
-        Backends (chosen automatically):
-          - FAISS + sentence-transformers  (pip install predictive-maintenance-mcp[vector-search])
-          - TF-IDF keyword search          (default, zero extra deps)
+    Backends (chosen automatically):
+      - FAISS + sentence-transformers  (pip install predictive-maintenance-mcp[vector-search])
+      - TF-IDF keyword search          (default, zero extra deps)
 
-        The index is built lazily on first call and cached on disk.  It is
-        automatically rebuilt when source files change.
+    The index is built lazily on first call and cached on disk.  It is
+    automatically rebuilt when source files change.
 
-        Args:
-            query: Natural-language question or keywords
-                   (e.g. "bearing 6205 geometry", "maintenance interval pump")
-            top_k: Number of passages to return (default: 5)
-            force_reindex: Rebuild the index even if cache is fresh (default: False)
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        query: Natural-language question or keywords
+               (e.g. "bearing 6205 geometry", "maintenance interval pump")
+        top_k: Number of passages to return (default: 5)
+        force_reindex: Rebuild the index even if cache is fresh (default: False)
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            Dictionary with ranked results, each containing text passage, source
-            file, relevance score, and chunk index.
-        """
+    Returns:
+        Dictionary with ranked results, each containing text passage, source
+        file, relevance score, and chunk index.
+    """
     # Deliberately lazy: the RAG backend may pull in FAISS /
     # sentence-transformers, which are heavy optional dependencies —
     # importing them at module load would slow server startup for
@@ -1250,12 +1278,14 @@ async def search_documentation(
         return {
             "results": [],
             "backend": backend_name(),
-            "note": "No documents indexed. Add PDFs or TXT files to resources/machine_manuals/ or resources/bearing_catalogs/."
+            "note": "No documents indexed. Add PDFs or TXT files to resources/machine_manuals/ or resources/bearing_catalogs/.",
         }
 
     results = idx.query(query, top_k=top_k)
 
-    logger.info(f"Found {len(results)} relevant passages from {len(set(r['source'] for r in results))} documents")
+    logger.info(
+        f"Found {len(results)} relevant passages from {len(set(r['source'] for r in results))} documents"
+    )
 
     return {
         "query": query,
@@ -1265,9 +1295,11 @@ async def search_documentation(
         "results": results,
     }
 
+
 # ------------------------------------------------------------------
 # Unified bearing fault check (U9 merge)
 # ------------------------------------------------------------------
+
 
 async def check_bearing_faults(
     ctx: Context,
@@ -1328,9 +1360,7 @@ async def check_bearing_faults(
     geometry_given = [
         p is not None for p in (num_balls, ball_diameter_mm, pitch_diameter_mm)
     ]
-    routes = sum(
-        [bearing_id is not None, frequencies is not None, any(geometry_given)]
-    )
+    routes = sum([bearing_id is not None, frequencies is not None, any(geometry_given)])
     if routes != 1:
         raise ValueError(
             "Provide exactly ONE expected-frequency route — bearing_id "
@@ -1359,9 +1389,7 @@ async def check_bearing_faults(
     if bearing_id is not None:
         # --- Catalog route (former check_bearing_faults_direct /
         # lookup_bearing_and_compute_tool) -----------------------------
-        logger.info(
-            f"Checking catalog bearing {bearing_id} at {rpm} RPM"
-        )
+        logger.info(f"Checking catalog bearing {bearing_id} at {rpm} RPM")
         result = _check_all_faults(
             signal=signal_data,
             fs=fs,
@@ -1424,9 +1452,11 @@ async def check_bearing_faults(
         source=result["source"],
     )
 
+
 # ------------------------------------------------------------------
 # Integrated diagnosis (signal_id based)
 # ------------------------------------------------------------------
+
 
 async def diagnose_vibration(
     ctx: Context,
@@ -1438,30 +1468,30 @@ async def diagnose_vibration(
 ) -> DiagnosisResult:
     """Full integrated diagnosis: FFT + PSD + STFT + bearing faults + ISO severity.
 
-        Comprehensive vibration diagnostic pipeline. Loads signal from repository,
-        runs all analyses, and synthesizes results into an actionable report.
-        The ISO severity block uses ISO 20816-3 machine group/support type
-        (zone boundaries from ISO 10816-3:2009, provenance noted in output).
+    Comprehensive vibration diagnostic pipeline. Loads signal from repository,
+    runs all analyses, and synthesizes results into an actionable report.
+    The ISO severity block uses ISO 20816-3 machine group/support type
+    (zone boundaries from ISO 10816-3:2009, provenance noted in output).
 
-        The diagnosis DEGRADES instead of failing when the ISO verdict cannot
-        be produced honestly: if the stored signal has no declared unit (or
-        the sampling rate cannot cover the ISO evaluation band), the
-        iso_severity block is a structured refusal (status='refused' with
-        reason and remedy) while the spectral, bearing, and anomaly blocks
-        still run. Units are never guessed from amplitude — declare them via
-        load_signal(signal_unit=...) or the companion _metadata.json.
+    The diagnosis DEGRADES instead of failing when the ISO verdict cannot
+    be produced honestly: if the stored signal has no declared unit (or
+    the sampling rate cannot cover the ISO evaluation band), the
+    iso_severity block is a structured refusal (status='refused' with
+    reason and remedy) while the spectral, bearing, and anomaly blocks
+    still run. Units are never guessed from amplitude — declare them via
+    load_signal(signal_unit=...) or the companion _metadata.json.
 
-        Args:
-            signal_id: ID of the stored signal.
-            rpm: Machine operating speed in RPM.
-            bearing_id: Bearing designation for fault detection (optional).
-            machine_group: 1 (large, >300 kW) or 2 (medium, 15-300 kW).
-                Default 2.
-            support_type: 'rigid' or 'flexible'. Default 'rigid'.
+    Args:
+        signal_id: ID of the stored signal.
+        rpm: Machine operating speed in RPM.
+        bearing_id: Bearing designation for fault detection (optional).
+        machine_group: 1 (large, >300 kW) or 2 (medium, 15-300 kW).
+            Default 2.
+        support_type: 'rigid' or 'flexible'. Default 'rigid'.
 
-        Raises:
-            ValueError: If the stored signal has no sampling rate.
-        """
+    Raises:
+        ValueError: If the stored signal has no sampling rate.
+    """
     signal_data, info = resolve_signal(signal_id)
     fs = info.sampling_rate
 
@@ -1503,19 +1533,15 @@ async def diagnose_vibration(
     # ISO block: assessed result or schema-level refusal (reason + remedy)
     iso_block = result["iso_severity"]
     if iso_block.get("status") == "refused":
-        iso_model: VibrationSeverityResult | ISOSeverityRefusal = (
-            ISOSeverityRefusal(
-                signal_id=iso_block.get("signal_id", signal_id),
-                reason=iso_block["reason"],
-                remedy=iso_block["remedy"],
-            )
+        iso_model: VibrationSeverityResult | ISOSeverityRefusal = ISOSeverityRefusal(
+            signal_id=iso_block.get("signal_id", signal_id),
+            reason=iso_block["reason"],
+            remedy=iso_block["remedy"],
         )
     else:
         iso_model = VibrationSeverityResult(**iso_block)
 
-    logger.info(
-        f"Diagnosis complete: {result['evidence_strength']} fault evidence"
-    )
+    logger.info(f"Diagnosis complete: {result['evidence_strength']} fault evidence")
     if iso_block.get("status") == "refused":
         logger.info(f"ISO severity: refused — {iso_block['reason']}")
     else:

--- a/src/mcp_tools/prognostics_tools.py
+++ b/src/mcp_tools/prognostics_tools.py
@@ -73,6 +73,7 @@ _MULTI_MEASURE_ERROR = (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _extract_feature_series(
     signal_data: np.ndarray,
     feature_name: str,
@@ -118,9 +119,7 @@ def _truncate_series(
     """Evenly subsample a series down to *max_points* for output echoing."""
     if len(values) <= max_points:
         return values, times, False
-    idx = np.unique(
-        np.linspace(0, len(values) - 1, max_points).round().astype(int)
-    )
+    idx = np.unique(np.linspace(0, len(values) - 1, max_points).round().astype(int))
     return (
         [round(values[i], 6) for i in idx],
         [round(times[i], 4) for i in idx],
@@ -168,65 +167,64 @@ async def estimate_rul(
 ) -> RULEstimationResult:
     """Estimate Remaining Useful Life from repeated measurements over time.
 
-        RUL is only physically meaningful when fitted on a degradation trend
-        across MULTIPLE measurements of the same machine taken at different
-        times (days/weeks/months apart). This tool refuses a single
-        recording or single point — for within-recording screening use
-        analyze_signal_trend instead.
+    RUL is only physically meaningful when fitted on a degradation trend
+    across MULTIPLE measurements of the same machine taken at different
+    times (days/weeks/months apart). This tool refuses a single
+    recording or single point — for within-recording screening use
+    analyze_signal_trend instead.
 
-        Two mutually exclusive input routes (both need `timestamps`, one
-        entry per measurement, strictly increasing, in `time_unit`):
-        1. `feature_values`: the degradation indicator already measured
-           externally (e.g. RMS velocity trended by a data collector).
-        2. `signal_ids`: one stored signal per measurement session (loaded
-           via load_signal); each recording is reduced to a single
-           `feature_name` value.
+    Two mutually exclusive input routes (both need `timestamps`, one
+    entry per measurement, strictly increasing, in `time_unit`):
+    1. `feature_values`: the degradation indicator already measured
+       externally (e.g. RMS velocity trended by a data collector).
+    2. `signal_ids`: one stored signal per measurement session (loaded
+       via load_signal); each recording is reduced to a single
+       `feature_name` value.
 
-        The degradation indicator is assumed to RISE toward
-        `failure_threshold`. A statistically significant increasing trend
-        (slope p-value < 0.05) is required before any RUL is computed; a
-        flat/insignificant series returns status 'no_degradation_trend'
-        with no RUL number.
+    The degradation indicator is assumed to RISE toward
+    `failure_threshold`. A statistically significant increasing trend
+    (slope p-value < 0.05) is required before any RUL is computed; a
+    flat/insignificant series returns status 'no_degradation_trend'
+    with no RUL number.
 
-        Args:
-            ctx: MCP context. Unused — see this module's docstring on logging.
-            failure_threshold: Indicator value considered as failure, in the
-                same units as the feature values. No universal default is
-                imposed — but when the indicator is broadband VELOCITY RMS
-                in mm/s, the standard choice is the ISO 10816-3:2009 zone
-                C/D boundary that assess_severity / get_zone_boundaries()
-                reports for the machine's group and support (single source
-                of truth — no boundaries restated here).
-            timestamps: Measurement times in `time_unit`, strictly
-                increasing (e.g. hours since first measurement).
-            feature_values: Indicator values, one per measurement
-                (mutually exclusive with signal_ids).
-            signal_ids: Stored signal IDs, one per measurement session
-                (mutually exclusive with feature_values).
-            feature_name: Time-domain feature used to reduce each signal
-                (default: "rms"). Ignored for feature_values input.
-            method: "linear" (default), "exponential", or "kalman"
-                (kalman needs approximately uniform measurement spacing).
-            time_unit: Label for the time axis; RUL and
-                observation_horizon are expressed in this unit.
+    Args:
+        ctx: MCP context. Unused — see this module's docstring on logging.
+        failure_threshold: Indicator value considered as failure, in the
+            same units as the feature values. No universal default is
+            imposed — but when the indicator is broadband VELOCITY RMS
+            in mm/s, the standard choice is the ISO 10816-3:2009 zone
+            C/D boundary that assess_severity / get_zone_boundaries()
+            reports for the machine's group and support (single source
+            of truth — no boundaries restated here).
+        timestamps: Measurement times in `time_unit`, strictly
+            increasing (e.g. hours since first measurement).
+        feature_values: Indicator values, one per measurement
+            (mutually exclusive with signal_ids).
+        signal_ids: Stored signal IDs, one per measurement session
+            (mutually exclusive with feature_values).
+        feature_name: Time-domain feature used to reduce each signal
+            (default: "rms"). Ignored for feature_values input.
+        method: "linear" (default), "exponential", or "kalman"
+            (kalman needs approximately uniform measurement spacing).
+        time_unit: Label for the time axis; RUL and
+            observation_horizon are expressed in this unit.
 
-        Returns:
-            RULEstimationResult with status, rul (only when estimated),
-            fit_r_squared (goodness of fit — NOT a confidence),
-            observation_horizon, and a plain-language message.
-        """
+    Returns:
+        RULEstimationResult with status, rul (only when estimated),
+        fit_r_squared (goodness of fit — NOT a confidence),
+        observation_horizon, and a plain-language message.
+    """
     # --- Input route validation -----------------------------------
     if method not in ("linear", "exponential", "kalman"):
         raise ValueError(
-            f"Unknown method '{method}' — use 'linear', 'exponential', "
-                "or 'kalman'."
+            f"Unknown method '{method}' — use 'linear', 'exponential', " "or 'kalman'."
         )
 
     if (feature_values is None) == (signal_ids is None):
         raise ValueError(
             "Provide exactly one of feature_values or signal_ids — "
-                "feature_values for externally measured indicator values, "
-                "signal_ids for stored measurement recordings."
+            "feature_values for externally measured indicator values, "
+            "signal_ids for stored measurement recordings."
         )
 
     n = len(feature_values if feature_values is not None else signal_ids)
@@ -242,13 +240,13 @@ async def estimate_rul(
     if len(timestamps) != n:
         raise ValueError(
             f"Got {n} measurements but {len(timestamps)} timestamps — "
-                "provide one timestamp per measurement."
+            "provide one timestamp per measurement."
         )
     t = [float(x) for x in timestamps]
     if any(b <= a for a, b in zip(t, t[1:])):
         raise ValueError(
             "timestamps must be strictly increasing — sort the "
-                "measurements chronologically and remove duplicates."
+            "measurements chronologically and remove duplicates."
         )
 
     horizon = t[-1] - t[0]
@@ -256,7 +254,7 @@ async def estimate_rul(
 
     logger.info(
         f"Estimating RUL ({method}) from {n} measurements spanning "
-            f"{horizon:g} {time_unit} ..."
+        f"{horizon:g} {time_unit} ..."
     )
 
     common = dict(
@@ -276,8 +274,8 @@ async def estimate_rul(
             trend_p_value=None,
             message=(
                 f"The most recent measurement ({current_value:g}) is at or "
-                    f"above the failure threshold ({failure_threshold:g}) — "
-                    "no remaining life to estimate. Inspect the machine now."
+                f"above the failure threshold ({failure_threshold:g}) — "
+                "no remaining life to estimate. Inspect the machine now."
             ),
             **common,
         )
@@ -290,12 +288,12 @@ async def estimate_rul(
         if trend["slope"] <= 0 and p_value is not None and p_value < TREND_ALPHA:
             reason = (
                 "the indicator is decreasing/flat, moving away from the "
-                    "failure threshold"
+                "failure threshold"
             )
         else:
             reason = (
                 "no statistically significant increasing trend "
-                    f"(slope p-value = {p_value if p_value is not None else 'n/a'})"
+                f"(slope p-value = {p_value if p_value is not None else 'n/a'})"
             )
         return RULEstimationResult(
             status="no_degradation_trend",
@@ -303,9 +301,9 @@ async def estimate_rul(
             fit_r_squared=round(trend["r_squared"], 4),
             message=(
                 f"No degradation trend detected: {reason}. The machine "
-                    f"appears stable over the {horizon:g} {time_unit} "
-                    "observed — keep collecting measurements and re-run "
-                    "estimate_rul as the series grows."
+                f"appears stable over the {horizon:g} {time_unit} "
+                "observed — keep collecting measurements and re-run "
+                "estimate_rul as the series grows."
             ),
             **common,
         )
@@ -323,20 +321,16 @@ async def estimate_rul(
         if spread > KALMAN_MAX_SPACING_SPREAD:
             raise ValueError(
                 "The kalman method assumes uniformly spaced measurements, "
-                    f"but the intervals vary by {spread * 100:.0f}% — use "
-                    "method='linear' or 'exponential', or resample the series "
-                    "to a regular interval."
+                f"but the intervals vary by {spread * 100:.0f}% — use "
+                "method='linear' or 'exponential', or resample the series "
+                "to a regular interval."
             )
         result = estimate_rul_kalman(
             values, failure_threshold, sampling_interval=mean_dt
         )
         if result is not None:
-            extra["rul_interval_95"] = [
-                round(x, 4) for x in result["rul_interval_95"]
-            ]
-            extra["precision_heuristic"] = round(
-                result["precision_heuristic"], 4
-            )
+            extra["rul_interval_95"] = [round(x, 4) for x in result["rul_interval_95"]]
+            extra["precision_heuristic"] = round(result["precision_heuristic"], 4)
             extra["estimated_rate"] = round(result["estimated_rate"], 6)
 
     if result is None:
@@ -346,8 +340,8 @@ async def estimate_rul(
             fit_r_squared=round(trend["r_squared"], 4),
             message=(
                 f"The fitted {method} degradation curve does not reach the "
-                    f"failure threshold ({failure_threshold:g}) after the last "
-                    "measurement — no finite RUL. Keep collecting measurements."
+                f"failure threshold ({failure_threshold:g}) after the last "
+                "measurement — no finite RUL. Keep collecting measurements."
             ),
             **common,
         )
@@ -359,13 +353,13 @@ async def estimate_rul(
 
     message = (
         f"RUL estimated at {rul:g} {time_unit} from {n} measurements "
-            f"spanning {horizon:g} {time_unit}. This is an extrapolation of "
-            "the observed trend — treat it as planning input, not a guarantee."
+        f"spanning {horizon:g} {time_unit}. This is an extrapolation of "
+        "the observed trend — treat it as planning input, not a guarantee."
     )
     if rul > horizon:
         message += (
             f" Caution: the estimate extends {rul / horizon:.1f}x beyond "
-                "the observation horizon, so its reliability is low."
+            "the observation horizon, so its reliability is low."
         )
 
     return RULEstimationResult(
@@ -378,6 +372,7 @@ async def estimate_rul(
         **extra,
     )
 
+
 async def analyze_signal_trend(
     ctx: Context,
     signal_id: str,
@@ -388,67 +383,64 @@ async def analyze_signal_trend(
 ) -> TrendAnalysisResult:
     """Within-recording screening: feature trend + degradation onset.
 
-        THE unified screening tool: feature trend AND degradation
-        onset in one call. Segments a single recording
-        (seconds of data), extracts the requested feature per segment,
-        tests whether the per-segment values show a statistically
-        significant trend (slope p < 0.05), and detects the first segment
-        AFTER the baseline window (first half of the series) whose value
-        exceeds baseline mean + onset_threshold_sigma standard deviations.
-        Onset inside the baseline window cannot be detected (the baseline
-        defines "normal"). Requires the signal loaded via load_signal()
-        first; the sampling rate comes from the stored signal metadata.
+    THE unified screening tool: feature trend AND degradation
+    onset in one call. Segments a single recording
+    (seconds of data), extracts the requested feature per segment,
+    tests whether the per-segment values show a statistically
+    significant trend (slope p < 0.05), and detects the first segment
+    AFTER the baseline window (first half of the series) whose value
+    exceeds baseline mean + onset_threshold_sigma standard deviations.
+    Onset inside the baseline window cannot be detected (the baseline
+    defines "normal"). Requires the signal loaded via load_signal()
+    first; the sampling rate comes from the stored signal metadata.
 
-        This is a SCREENING tool, not a prognosis: a trend inside seconds
-        of signal says whether the recording is stationary, not how long
-        the machine will live. For Remaining Useful Life, collect repeated
-        measurements over days/weeks (one recording per session) and pass
-        them to estimate_rul — this tool returns the per-segment feature
-        series so each recording can be reduced to one measurement point.
+    This is a SCREENING tool, not a prognosis: a trend inside seconds
+    of signal says whether the recording is stationary, not how long
+    the machine will live. For Remaining Useful Life, collect repeated
+    measurements over days/weeks (one recording per session) and pass
+    them to estimate_rul — this tool returns the per-segment feature
+    series so each recording can be reduced to one measurement point.
 
-        Args:
-            ctx: MCP context. Unused — see this module's docstring on logging.
-            signal_id: ID of the stored signal (from load_signal).
-            feature_name: Time-domain feature to analyze (default: "rms").
-            segment_duration: Duration of each segment in seconds.
-            overlap_ratio: Overlap between segments (0-1).
-            onset_threshold_sigma: Baseline standard deviations above the
-                baseline mean that trigger onset detection (default: 3.0).
+    Args:
+        ctx: MCP context. Unused — see this module's docstring on logging.
+        signal_id: ID of the stored signal (from load_signal).
+        feature_name: Time-domain feature to analyze (default: "rms").
+        segment_duration: Duration of each segment in seconds.
+        overlap_ratio: Overlap between segments (0-1).
+        onset_threshold_sigma: Baseline standard deviations above the
+            baseline mean that trigger onset detection (default: 3.0).
 
-        Returns:
-            TrendAnalysisResult with slope, direction (p-value based),
-            fit quality, the (truncated) per-segment feature series, and
-            the onset-detection outcome (onset_detected,
-            onset_segment_index, onset_time_s, baseline_segments).
+    Returns:
+        TrendAnalysisResult with slope, direction (p-value based),
+        fit quality, the (truncated) per-segment feature series, and
+        the onset-detection outcome (onset_detected,
+        onset_segment_index, onset_time_s, baseline_segments).
 
-        Raises:
-            ValueError: If the signal_id is not loaded, or the stored
-                signal has no sampling rate.
-        """
+    Raises:
+        ValueError: If the signal_id is not loaded, or the stored
+            signal has no sampling rate.
+    """
     signal_data, info = resolve_signal(signal_id)
     sr = info.sampling_rate
     logger.info(
-        f"Screening within-recording trend of '{feature_name}' in "
-            f"'{signal_id}' ..."
+        f"Screening within-recording trend of '{feature_name}' in " f"'{signal_id}' ..."
     )
 
     feature_series, segment_times = _extract_feature_series(
-        signal_data, feature_name, sr, segment_duration, overlap_ratio,
+        signal_data,
+        feature_name,
+        sr,
+        segment_duration,
+        overlap_ratio,
     )
-    logger.info(
-        f"Extracted {len(feature_series)} segments, fitting trend ..."
-    )
+    logger.info(f"Extracted {len(feature_series)} segments, fitting trend ...")
 
     trend = analyze_trend(feature_series, timestamps=segment_times)
-    series_out, times_out, truncated = _truncate_series(
-        feature_series, segment_times
-    )
+    series_out, times_out, truncated = _truncate_series(feature_series, segment_times)
 
     # Onset detection (merged detect_signal_degradation_onset): scan only
     # AFTER the baseline window — the baseline defines "normal".
-    onset_index = detect_degradation_onset(
-        feature_series, onset_threshold_sigma
-    )
+    onset_index = detect_degradation_onset(feature_series, onset_threshold_sigma)
     onset_time_s = (
         round(segment_times[onset_index], 4) if onset_index is not None else None
     )

--- a/src/mcp_tools/prompts.py
+++ b/src/mcp_tools/prompts.py
@@ -11,7 +11,6 @@ from typing import Optional
 from mcp.server.mcpserver import MCPServer
 
 
-
 def diagnose_bearing(
     signal_id: str,
     sampling_rate: Optional[float] = None,
@@ -21,54 +20,61 @@ def diagnose_bearing(
     bpfo: Optional[float] = None,
     bpfi: Optional[float] = None,
     bsf: Optional[float] = None,
-    ftf: Optional[float] = None
+    ftf: Optional[float] = None,
 ) -> str:
     """
-        Guided workflow for bearing diagnostics with ISO 20816-3 compliance.
+    Guided workflow for bearing diagnostics with ISO 20816-3 compliance.
 
-        Evidence-based policy:
-        - Envelope peaks at characteristic frequencies are PRIMARY indicators (strong evidence)
-        - Statistical indicators (CF>6, Kurtosis>6) are SECONDARY/confirmatory
-        - If envelope shows clear peaks at BPFO/BPFI/BSF/FTF (±5% tolerance) → bearing fault is STRONGLY indicated
-        - Additional high CF or Kurtosis reinforces the diagnosis but is not strictly required if envelope evidence is clear
+    Evidence-based policy:
+    - Envelope peaks at characteristic frequencies are PRIMARY indicators (strong evidence)
+    - Statistical indicators (CF>6, Kurtosis>6) are SECONDARY/confirmatory
+    - If envelope shows clear peaks at BPFO/BPFI/BSF/FTF (±5% tolerance) → bearing fault is STRONGLY indicated
+    - Additional high CF or Kurtosis reinforces the diagnosis but is not strictly required if envelope evidence is clear
 
-        **ISO 20816-3 Defaults** (use if user doesn't specify):
-        - machine_group = 2 (medium-sized machines, 15-300 kW, most common)
-        - support_type = "rigid" (horizontal machines on foundations)
+    **ISO 20816-3 Defaults** (use if user doesn't specify):
+    - machine_group = 2 (medium-sized machines, 15-300 kW, most common)
+    - support_type = "rigid" (horizontal machines on foundations)
 
-        Args:
-            signal_id: ID of the stored signal (or the file to load in STEP 0)
-            sampling_rate: Sampling frequency in Hz (if None, will check metadata or ask user)
-            machine_group: ISO machine group (1=large >300kW, 2=medium 15-300kW) (default: 2)
-            support_type: 'rigid' or 'flexible' (default: 'rigid' for horizontal machines)
-            rpm: Operating speed in RPM (required for interpreting results)
-            bpfo: Ball Pass Frequency Outer race (Hz) - if known
-            bpfi: Ball Pass Frequency Inner race (Hz) - if known
-            bsf: Ball Spin Frequency (Hz) - if known
-            ftf: Fundamental Train Frequency (Hz) - if known
-        """
+    Args:
+        signal_id: ID of the stored signal (or the file to load in STEP 0)
+        sampling_rate: Sampling frequency in Hz (if None, will check metadata or ask user)
+        machine_group: ISO machine group (1=large >300kW, 2=medium 15-300kW) (default: 2)
+        support_type: 'rigid' or 'flexible' (default: 'rigid' for horizontal machines)
+        rpm: Operating speed in RPM (required for interpreting results)
+        bpfo: Ball Pass Frequency Outer race (Hz) - if known
+        bpfi: Ball Pass Frequency Inner race (Hz) - if known
+        bsf: Ball Spin Frequency (Hz) - if known
+        ftf: Fundamental Train Frequency (Hz) - if known
+    """
     # Build frequency reference string
     freq_refs = []
-    if bpfo: freq_refs.append(f"BPFO={bpfo:.2f} Hz")
-    if bpfi: freq_refs.append(f"BPFI={bpfi:.2f} Hz")
-    if bsf: freq_refs.append(f"BSF={bsf:.2f} Hz")
-    if ftf: freq_refs.append(f"FTF={ftf:.2f} Hz")
-    freq_info = ", ".join(freq_refs) if freq_refs else "NOT PROVIDED - must request from user"
+    if bpfo:
+        freq_refs.append(f"BPFO={bpfo:.2f} Hz")
+    if bpfi:
+        freq_refs.append(f"BPFI={bpfi:.2f} Hz")
+    if bsf:
+        freq_refs.append(f"BSF={bsf:.2f} Hz")
+    if ftf:
+        freq_refs.append(f"FTF={ftf:.2f} Hz")
+    freq_info = (
+        ", ".join(freq_refs) if freq_refs else "NOT PROVIDED - must request from user"
+    )
 
     bearing_freqs_dict = (
         "{"
         + ", ".join(
             f'"{name}": {val}'
             for name, val in (
-                ("BPFO", bpfo), ("BPFI", bpfi), ("BSF", bsf), ("FTF", ftf)
+                ("BPFO", bpfo),
+                ("BPFI", bpfi),
+                ("BSF", bsf),
+                ("FTF", ftf),
             )
             if val
         )
         + "}"
     )
-    freqs_placeholder = (
-        '{"BPFO": <hz>, "BPFI": <hz>, "BSF": <hz>, "FTF": <hz>}'
-    )
+    freqs_placeholder = '{"BPFO": <hz>, "BPFI": <hz>, "BSF": <hz>, "FTF": <hz>}'
 
     rpm_kwarg = f", rpm={rpm}" if rpm else ""
     fs_info = f"{sampling_rate}" if sampling_rate else "UNKNOWN"
@@ -292,24 +298,22 @@ def diagnose_gear(
     signal_id: str,
     sampling_rate: Optional[float] = None,
     num_teeth: Optional[int] = None,
-    rpm: Optional[float] = None
+    rpm: Optional[float] = None,
 ) -> str:
     """
-        Evidence-based guided workflow for gear diagnostics with strict anti-speculation rules.
+    Evidence-based guided workflow for gear diagnostics with strict anti-speculation rules.
 
-        Args:
-            signal_id: ID of the stored signal (or the file to load in STEP 0)
-            sampling_rate: Sampling frequency in Hz (if None, will check metadata or ask user)
-            num_teeth: Number of gear teeth (REQUIRED for GMF calculation)
-            rpm: Shaft rotation speed in RPM (REQUIRED for GMF and sideband identification)
-        """
+    Args:
+        signal_id: ID of the stored signal (or the file to load in STEP 0)
+        sampling_rate: Sampling frequency in Hz (if None, will check metadata or ask user)
+        num_teeth: Number of gear teeth (REQUIRED for GMF calculation)
+        rpm: Shaft rotation speed in RPM (REQUIRED for GMF and sideband identification)
+    """
     fs_info = f"{sampling_rate}" if sampling_rate else "UNKNOWN"
     fs_kwarg = f", sampling_rate={sampling_rate}" if sampling_rate else ""
     teeth_info = f"{num_teeth}" if num_teeth else "NOT PROVIDED"
     rpm_info = f"{rpm}" if rpm else "NOT PROVIDED"
-    gmf_value = (
-        f"{rpm/60 * num_teeth:.2f}" if (rpm and num_teeth) else "<gmf_hz>"
-    )
+    gmf_value = f"{rpm/60 * num_teeth:.2f}" if (rpm and num_teeth) else "<gmf_hz>"
 
     return f"""Perform an evidence-based gear diagnostic on signal_id "{signal_id}":
 
@@ -429,11 +433,11 @@ def diagnose_gear(
 
 def quick_diagnostic_report(signal_id: str) -> str:
     """
-        Quick, evidence-aware screening report (non-definitive).
+    Quick, evidence-aware screening report (non-definitive).
 
-        Args:
-            signal_id: ID of the stored signal (or the file to load in STEP 0)
-        """
+    Args:
+        signal_id: ID of the stored signal (or the file to load in STEP 0)
+    """
     return f"""Generate a concise screening report for signal_id "{signal_id}" using only observable evidence:
 
     STEP 0 — SIGNAL RESOLUTION

--- a/src/mcp_tools/report_tools.py
+++ b/src/mcp_tools/report_tools.py
@@ -78,7 +78,6 @@ def _companion_metadata(info: StoredSignalInfo) -> dict:
     return {}
 
 
-
 async def generate_diagnostic_report_docx(
     signal_id: str,
     sections: dict[str, Any],
@@ -86,32 +85,32 @@ async def generate_diagnostic_report_docx(
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     """
-        Generate a structured Word (.docx) diagnostic report for a stored signal.
+    Generate a structured Word (.docx) diagnostic report for a stored signal.
 
-        Requires: ``pip install predictive-maintenance-mcp[docx]``
+    Requires: ``pip install predictive-maintenance-mcp[docx]``
 
-        ``sections`` is a dict whose keys define what to include (all optional):
-          - statistics:           dict  (RMS, Kurtosis, Crest Factor …)
-          - fft_peaks:            list  [{frequency, magnitude_db, note}, …]
-          - envelope_peaks:       list  [{frequency, magnitude_db, match}, …]
-          - bearing_frequencies:  dict  {BPFO, BPFI, BSF, FTF}
-          - iso:                  dict  (mapped from assess_severity output)
-          - diagnosis:            str   (free-text diagnostic summary)
+    ``sections`` is a dict whose keys define what to include (all optional):
+      - statistics:           dict  (RMS, Kurtosis, Crest Factor …)
+      - fft_peaks:            list  [{frequency, magnitude_db, note}, …]
+      - envelope_peaks:       list  [{frequency, magnitude_db, match}, …]
+      - bearing_frequencies:  dict  {BPFO, BPFI, BSF, FTF}
+      - iso:                  dict  (mapped from assess_severity output)
+      - diagnosis:            str   (free-text diagnostic summary)
 
-        Args:
-            signal_id: ID of the stored signal (from load_signal); used for
-                the report title / filename.
-            sections: Content sections to include (see above)
-            title: Optional custom report title
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        signal_id: ID of the stored signal (from load_signal); used for
+            the report title / filename.
+        sections: Content sections to include (see above)
+        title: Optional custom report title
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            Dictionary with file_path, file_name, and per-section summary.
+    Returns:
+        Dictionary with file_path, file_name, and per-section summary.
 
-        Raises:
-            ValueError: If the signal_id is not loaded, or python-docx is
-                not installed.
-        """
+    Raises:
+        ValueError: If the signal_id is not loaded, or python-docx is
+            not installed.
+    """
     # Validate the handle: reports are only produced for loaded signals.
     resolve_signal(signal_id, require_sampling_rate=False)
 
@@ -125,42 +124,43 @@ async def generate_diagnostic_report_docx(
 
     return result
 
+
 async def plot_signal(
     signal_id: str,
     time_range: Optional[list[float]] = None,
     show_statistics: bool = True,
     title: Optional[str] = None,
-    ctx: Context | None = None
+    ctx: Context | None = None,
 ) -> str:
     """
-        Generate interactive time-domain plot for a stored signal.
+    Generate interactive time-domain plot for a stored signal.
 
-        Creates an interactive HTML plot showing the signal in the time domain.
-        Useful for inspecting signal quality, identifying anomalies, and
-        visualizing transients. Requires the signal loaded via load_signal()
-        first; the sampling rate comes from the stored signal metadata.
+    Creates an interactive HTML plot showing the signal in the time domain.
+    Useful for inspecting signal quality, identifying anomalies, and
+    visualizing transients. Requires the signal loaded via load_signal()
+    first; the sampling rate comes from the stored signal metadata.
 
-        Args:
-            signal_id: ID of the stored signal (from load_signal).
-            time_range: [start_time, end_time] in seconds to zoom on a portion (optional)
-            show_statistics: Show RMS, peak levels as horizontal lines (default: True)
-            title: Custom plot title (optional)
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        signal_id: ID of the stored signal (from load_signal).
+        time_range: [start_time, end_time] in seconds to zoom on a portion (optional)
+        show_statistics: Show RMS, peak levels as horizontal lines (default: True)
+        title: Custom plot title (optional)
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            Path to generated HTML file
+    Returns:
+        Path to generated HTML file
 
-        Raises:
-            ValueError: If the signal_id is not loaded, or the stored signal
-                has no sampling rate.
+    Raises:
+        ValueError: If the signal_id is not loaded, or the stored signal
+            has no sampling rate.
 
-        Example:
-            plot_signal(
-                "bearing_signal",
-                time_range=[0.1, 0.3],  # Zoom on 100-300 ms
-                show_statistics=True
-            )
-        """
+    Example:
+        plot_signal(
+            "bearing_signal",
+            time_range=[0.1, 0.3],  # Zoom on 100-300 ms
+            show_statistics=True
+        )
+    """
     logger.info(f"Generating time-domain plot for '{signal_id}'...")
 
     signal_data, info = resolve_signal(signal_id)
@@ -189,66 +189,78 @@ async def plot_signal(
     fig = go.Figure()
 
     # Main signal
-    fig.add_trace(go.Scatter(
-        x=time_plot,
-        y=signal_plot,
-        mode='lines',
-        name='Signal',
-        line=dict(color='blue', width=1),
-        hovertemplate='Time: %{x:.4f} s<br>Amplitude: %{y:.4f}<extra></extra>'
-    ))
+    fig.add_trace(
+        go.Scatter(
+            x=time_plot,
+            y=signal_plot,
+            mode="lines",
+            name="Signal",
+            line=dict(color="blue", width=1),
+            hovertemplate="Time: %{x:.4f} s<br>Amplitude: %{y:.4f}<extra></extra>",
+        )
+    )
 
     # Add statistical reference lines if requested
     if show_statistics:
         # RMS lines
-        fig.add_trace(go.Scatter(
-            x=[time_plot[0], time_plot[-1]],
-            y=[rms, rms],
-            mode='lines',
-            name=f'RMS (+{rms:.4f})',
-            line=dict(color='green', width=2, dash='dash'),
-            hovertemplate=f'RMS: {rms:.4f}<extra></extra>'
-        ))
+        fig.add_trace(
+            go.Scatter(
+                x=[time_plot[0], time_plot[-1]],
+                y=[rms, rms],
+                mode="lines",
+                name=f"RMS (+{rms:.4f})",
+                line=dict(color="green", width=2, dash="dash"),
+                hovertemplate=f"RMS: {rms:.4f}<extra></extra>",
+            )
+        )
 
-        fig.add_trace(go.Scatter(
-            x=[time_plot[0], time_plot[-1]],
-            y=[-rms, -rms],
-            mode='lines',
-            name=f'RMS (−{rms:.4f})',
-            line=dict(color='green', width=2, dash='dash'),
-            showlegend=False,
-            hovertemplate=f'RMS: -{rms:.4f}<extra></extra>'
-        ))
+        fig.add_trace(
+            go.Scatter(
+                x=[time_plot[0], time_plot[-1]],
+                y=[-rms, -rms],
+                mode="lines",
+                name=f"RMS (−{rms:.4f})",
+                line=dict(color="green", width=2, dash="dash"),
+                showlegend=False,
+                hovertemplate=f"RMS: -{rms:.4f}<extra></extra>",
+            )
+        )
 
         # Peak lines
-        fig.add_trace(go.Scatter(
-            x=[time_plot[0], time_plot[-1]],
-            y=[peak_pos, peak_pos],
-            mode='lines',
-            name=f'Peak (+{peak_pos:.4f})',
-            line=dict(color='red', width=1, dash='dot'),
-            hovertemplate=f'Peak: {peak_pos:.4f}<extra></extra>'
-        ))
+        fig.add_trace(
+            go.Scatter(
+                x=[time_plot[0], time_plot[-1]],
+                y=[peak_pos, peak_pos],
+                mode="lines",
+                name=f"Peak (+{peak_pos:.4f})",
+                line=dict(color="red", width=1, dash="dot"),
+                hovertemplate=f"Peak: {peak_pos:.4f}<extra></extra>",
+            )
+        )
 
-        fig.add_trace(go.Scatter(
-            x=[time_plot[0], time_plot[-1]],
-            y=[peak_neg, peak_neg],
-            mode='lines',
-            name=f'Peak (−{abs(peak_neg):.4f})',
-            line=dict(color='red', width=1, dash='dot'),
-            hovertemplate=f'Peak: {peak_neg:.4f}<extra></extra>'
-        ))
+        fig.add_trace(
+            go.Scatter(
+                x=[time_plot[0], time_plot[-1]],
+                y=[peak_neg, peak_neg],
+                mode="lines",
+                name=f"Peak (−{abs(peak_neg):.4f})",
+                line=dict(color="red", width=1, dash="dot"),
+                hovertemplate=f"Peak: {peak_neg:.4f}<extra></extra>",
+            )
+        )
 
         # Mean line
         if abs(mean_val) > 1e-6:  # Only show if mean is significant
-            fig.add_trace(go.Scatter(
-                x=[time_plot[0], time_plot[-1]],
-                y=[mean_val, mean_val],
-                mode='lines',
-                name=f'Mean ({mean_val:.4f})',
-                line=dict(color='orange', width=1, dash='dashdot'),
-                hovertemplate=f'Mean: {mean_val:.4f}<extra></extra>'
-            ))
+            fig.add_trace(
+                go.Scatter(
+                    x=[time_plot[0], time_plot[-1]],
+                    y=[mean_val, mean_val],
+                    mode="lines",
+                    name=f"Mean ({mean_val:.4f})",
+                    line=dict(color="orange", width=1, dash="dashdot"),
+                    hovertemplate=f"Mean: {mean_val:.4f}<extra></extra>",
+                )
+            )
 
     # Layout
     plot_title = title or f"Time-Domain Signal - {signal_id}"
@@ -258,20 +270,22 @@ async def plot_signal(
         title=plot_title,
         xaxis_title="Time (s)",
         yaxis_title="Amplitude",
-        hovermode='x unified',
-        template='plotly_white',
+        hovermode="x unified",
+        template="plotly_white",
         width=1200,
         height=600,
         showlegend=True,
         annotations=[
             dict(
                 text=f"Duration: {duration:.3f} s | Samples: {len(signal_plot)} | Fs: {sampling_rate} Hz",
-                xref="paper", yref="paper",
-                x=0.5, y=-0.15,
+                xref="paper",
+                yref="paper",
+                x=0.5,
+                y=-0.15,
                 showarrow=False,
-                font=dict(size=10, color="gray")
+                font=dict(size=10, color="gray"),
             )
-        ]
+        ],
     )
 
     # Save HTML to reports directory (timestamped: runs never overwrite)
@@ -279,43 +293,42 @@ async def plot_signal(
     fig.write_html(str(output_file))
 
     logger.info(f"Plot saved to {output_file.name}")
-    logger.info(
-        "To view report metadata: list_html_reports(file_name=...)"
-    )
+    logger.info("To view report metadata: list_html_reports(file_name=...)")
 
     return f"Interactive plot saved to: {output_file}\nUse list_html_reports() to see all reports, or open file in browser"
+
 
 async def generate_fft_report(
     signal_id: str,
     max_freq: float = 5000.0,
     num_peaks: int = 15,
     rpm: Optional[float] = None,
-    ctx: Context | None = None
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """
-        Generate an interactive FFT spectrum report (HTML) for a stored signal.
+    Generate an interactive FFT spectrum report (HTML) for a stored signal.
 
-        Saves a self-contained Plotly HTML report (spectrum in dB, automatic
-        peak detection, harmonic labels) to the reports/ directory with a
-        timestamped filename — consecutive runs produce distinct files.
-        Requires the signal loaded via load_signal() first; the sampling
-        rate comes from the stored signal metadata.
+    Saves a self-contained Plotly HTML report (spectrum in dB, automatic
+    peak detection, harmonic labels) to the reports/ directory with a
+    timestamped filename — consecutive runs produce distinct files.
+    Requires the signal loaded via load_signal() first; the sampling
+    rate comes from the stored signal metadata.
 
-        Args:
-            signal_id: ID of the stored signal (from load_signal).
-            max_freq: Maximum frequency to display (Hz). Default 5000 Hz
-            num_peaks: Number of peaks to detect and label. Default 15
-            rpm: Optional shaft speed in RPM — peaks at integer multiples
-                of rpm/60 Hz are labeled as 1x/2x/... harmonics.
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        signal_id: ID of the stored signal (from load_signal).
+        max_freq: Maximum frequency to display (Hz). Default 5000 Hz
+        num_peaks: Number of peaks to detect and label. Default 15
+        rpm: Optional shaft speed in RPM — peaks at integer multiples
+            of rpm/60 Hz are labeled as 1x/2x/... harmonics.
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            Dictionary with file path, metadata, and summary (NO HTML content)
+    Returns:
+        Dictionary with file path, metadata, and summary (NO HTML content)
 
-        Raises:
-            ValueError: If the signal_id is not loaded, or the stored signal
-                has no sampling rate.
-        """
+    Raises:
+        ValueError: If the signal_id is not loaded, or the stored signal
+            has no sampling rate.
+    """
     logger.info(f"Generating FFT report for '{signal_id}'...")
 
     signal_data, info = resolve_signal(signal_id)
@@ -327,7 +340,7 @@ async def generate_fft_report(
     signal_windowed = signal_data * window
 
     fft_values = fft(signal_windowed)
-    frequencies = fftfreq(N, 1/sampling_rate)
+    frequencies = fftfreq(N, 1 / sampling_rate)
 
     # Positive frequencies only
     positive_idx = frequencies > 0
@@ -344,13 +357,14 @@ async def generate_fft_report(
         signal_data=signal_data,
         max_freq=max_freq,
         num_peaks=num_peaks,
-        rotation_freq=(rpm / 60.0) if rpm is not None else None
+        rotation_freq=(rpm / 60.0) if rpm is not None else None,
     )
 
-    logger.info(result['message'])
+    logger.info(result["message"])
     logger.info(f"Report location: {result['file_path']}")
 
     return result
+
 
 async def generate_envelope_report(
     signal_id: str,
@@ -359,44 +373,44 @@ async def generate_envelope_report(
     max_freq: float = 500.0,
     num_peaks: int = 15,
     bearing_freqs: Optional[dict[str, float]] = None,
-    ctx: Context | None = None
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """
-        Generate professional envelope analysis report (HTML) for a stored signal.
+    Generate professional envelope analysis report (HTML) for a stored signal.
 
-        Generates a professional HTML report file instead of inline content.
-        Saves to reports/ directory. Requires the signal loaded via
-        load_signal() first; the sampling rate comes from the stored signal
-        metadata. Reference bearing frequencies (BPFO/BPFI/BSF/FTF) can be
-        passed explicitly or, if omitted, are read from the source file's
-        companion _metadata.json when present.
+    Generates a professional HTML report file instead of inline content.
+    Saves to reports/ directory. Requires the signal loaded via
+    load_signal() first; the sampling rate comes from the stored signal
+    metadata. Reference bearing frequencies (BPFO/BPFI/BSF/FTF) can be
+    passed explicitly or, if omitted, are read from the source file's
+    companion _metadata.json when present.
 
-        Args:
-            signal_id: ID of the stored signal (from load_signal).
-            filter_low: Bandpass filter low cutoff (Hz). Default 500 Hz
-            filter_high: Bandpass filter high cutoff (Hz). Default (None)
-                adapts to the signal: min(5000, Nyquist-1). An explicit value
-                above Nyquist is rejected, never clamped.
-            max_freq: Max envelope spectrum frequency to display. Default 500 Hz
-            num_peaks: Number of peaks to detect. Default 15
-            bearing_freqs: Optional dict with BPFO, BPFI, BSF, FTF
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        signal_id: ID of the stored signal (from load_signal).
+        filter_low: Bandpass filter low cutoff (Hz). Default 500 Hz
+        filter_high: Bandpass filter high cutoff (Hz). Default (None)
+            adapts to the signal: min(5000, Nyquist-1). An explicit value
+            above Nyquist is rejected, never clamped.
+        max_freq: Max envelope spectrum frequency to display. Default 500 Hz
+        num_peaks: Number of peaks to detect. Default 15
+        bearing_freqs: Optional dict with BPFO, BPFI, BSF, FTF
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            Dictionary with file path, metadata, and summary (NO HTML content)
+    Returns:
+        Dictionary with file path, metadata, and summary (NO HTML content)
 
-        Raises:
-            ValueError: If the signal_id is not loaded, or the stored signal
-                has no sampling rate.
+    Raises:
+        ValueError: If the signal_id is not loaded, or the stored signal
+            has no sampling rate.
 
-        Example:
-            >>> # Bearing frequencies computed for YOUR bearing/rpm (here: 6205
-            >>> # per CWRU geometry at 1797 RPM)
-            >>> result = generate_envelope_report(
-            ...     "real_train_OuterRaceFault_1",
-            ...     bearing_freqs={"BPFO": 107.36, "BPFI": 162.19, "BSF": 70.58, "FTF": 11.93}
-            ... )
-        """
+    Example:
+        >>> # Bearing frequencies computed for YOUR bearing/rpm (here: 6205
+        >>> # per CWRU geometry at 1797 RPM)
+        >>> result = generate_envelope_report(
+        ...     "real_train_OuterRaceFault_1",
+        ...     bearing_freqs={"BPFO": 107.36, "BPFI": 162.19, "BSF": 70.58, "FTF": 11.93}
+        ... )
+    """
     logger.info(f"Generating envelope analysis report for '{signal_id}'...")
 
     signal_data, info = resolve_signal(signal_id)
@@ -424,14 +438,14 @@ async def generate_envelope_report(
                 "BPFO": metadata.get("BPFO"),
                 "BPFI": metadata.get("BPFI"),
                 "BSF": metadata.get("BSF"),
-                "FTF": metadata.get("FTF")
+                "FTF": metadata.get("FTF"),
             }
 
     # Bandpass filter (a corner exactly AT Nyquist is realized 1 Hz below
     # it — a digital filter corner cannot sit at Nyquist)
     nyquist = sampling_rate / 2
     high_norm = min(filter_high, nyquist - 1.0) / nyquist
-    sos = butter(4, [filter_low / nyquist, high_norm], btype='band', output='sos')
+    sos = butter(4, [filter_low / nyquist, high_norm], btype="band", output="sos")
     filtered_signal = sosfiltfilt(sos, signal_data)
 
     # Envelope via Hilbert
@@ -441,7 +455,7 @@ async def generate_envelope_report(
     # Envelope spectrum
     N = len(envelope)
     env_fft = fft(envelope)
-    env_frequencies = fftfreq(N, 1/sampling_rate)
+    env_frequencies = fftfreq(N, 1 / sampling_rate)
 
     positive_idx = env_frequencies > 0
     env_frequencies = env_frequencies[positive_idx]
@@ -458,48 +472,51 @@ async def generate_envelope_report(
         env_magnitudes=env_magnitudes,
         bearing_freqs=bearing_freqs,
         max_freq=max_freq,
-        num_peaks=num_peaks
+        num_peaks=num_peaks,
     )
 
-    logger.info(result['message'])
+    logger.info(result["message"])
     logger.info(f"Report location: {result['file_path']}")
-    if result.get('bearing_matches'):
-        logger.info(f"Bearing frequency matches: {', '.join(result['bearing_matches'])}")
+    if result.get("bearing_matches"):
+        logger.info(
+            f"Bearing frequency matches: {', '.join(result['bearing_matches'])}"
+        )
 
     return result
+
 
 async def generate_iso_report(
     signal_id: str,
     machine_group: Literal[1, 2] = 2,
     support_type: Literal["rigid", "flexible"] = "rigid",
     rpm: Optional[float] = None,
-    ctx: Context | None = None
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """
-        Generate an ISO 20816-3 evaluation report (HTML) for a stored signal.
+    Generate an ISO 20816-3 evaluation report (HTML) for a stored signal.
 
-        Saves a self-contained Plotly HTML report (color-coded A-D zone
-        chart with the measured RMS marker, boundaries, severity text) to
-        the reports/ directory with a timestamped filename. The evaluation
-        itself is delegated to assess_severity — requires the signal loaded
-        via load_signal() first with sampling rate AND a declared unit
-        (units are never guessed).
+    Saves a self-contained Plotly HTML report (color-coded A-D zone
+    chart with the measured RMS marker, boundaries, severity text) to
+    the reports/ directory with a timestamped filename. The evaluation
+    itself is delegated to assess_severity — requires the signal loaded
+    via load_signal() first with sampling rate AND a declared unit
+    (units are never guessed).
 
-        Args:
-            signal_id: ID of the stored signal (from load_signal).
-            machine_group: 1 (large, >300 kW) or 2 (medium, 15-300 kW)
-            support_type: 'rigid' or 'flexible'
-            rpm: Operating speed in RPM (optional; selects the ISO band's
-                lower edge below 600 RPM)
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        signal_id: ID of the stored signal (from load_signal).
+        machine_group: 1 (large, >300 kW) or 2 (medium, 15-300 kW)
+        support_type: 'rigid' or 'flexible'
+        rpm: Operating speed in RPM (optional; selects the ISO band's
+            lower edge below 600 RPM)
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            Dictionary with file path, metadata, and summary (NO HTML content)
+    Returns:
+        Dictionary with file path, metadata, and summary (NO HTML content)
 
-        Raises:
-            ValueError: If the signal_id is not loaded, or the stored signal
-                has no sampling rate or no declared unit.
-        """
+    Raises:
+        ValueError: If the signal_id is not loaded, or the stored signal
+            has no sampling rate or no declared unit.
+    """
     logger.info(f"Generating ISO 20816-3 report for '{signal_id}'...")
 
     # Perform ISO evaluation via the unified severity tool (U9 merge).
@@ -508,7 +525,7 @@ async def generate_iso_report(
         signal_id=signal_id,
         machine_group=machine_group,
         support_type=support_type,
-        rpm=rpm
+        rpm=rpm,
     )
 
     # Map the unified model onto the report template's expected keys.
@@ -529,39 +546,37 @@ async def generate_iso_report(
     }
 
     # Generate and save report (signal_id is the report's signal label)
-    result = save_iso_report(
-        signal_file=signal_id,
-        iso_result=iso_dict
-    )
+    result = save_iso_report(signal_file=signal_id, iso_result=iso_dict)
 
-    logger.info(result['message'])
+    logger.info(result["message"])
     logger.info(f"Report location: {result['file_path']}")
 
     return result
+
 
 def list_html_reports(
     file_name: Optional[str] = None,
 ) -> list[dict[str, Any]] | dict[str, Any]:
     """
-        List HTML reports, or get one report's embedded metadata.
+    List HTML reports, or get one report's embedded metadata.
 
-        Without file_name: lists every report in reports/ with file name,
-        type, signal, and size. With file_name: returns that report's
-        embedded metadata block (absorbed get_report_info). Never returns
-        HTML content — metadata only, to avoid token consumption.
+    Without file_name: lists every report in reports/ with file name,
+    type, signal, and size. With file_name: returns that report's
+    embedded metadata block (absorbed get_report_info). Never returns
+    HTML content — metadata only, to avoid token consumption.
 
-        Args:
-            file_name: Optional report filename inside reports/ — returns
-                its metadata instead of the listing.
+    Args:
+        file_name: Optional report filename inside reports/ — returns
+            its metadata instead of the listing.
 
-        Returns:
-            List of report summaries (no file_name), or a dict with the
-            single report's metadata (file_name given).
+    Returns:
+        List of report summaries (no file_name), or a dict with the
+        single report's metadata (file_name given).
 
-        Raises:
-            ValueError: If file_name escapes the reports directory, does
-                not exist, or carries no metadata block.
-        """
+    Raises:
+        ValueError: If file_name escapes the reports directory, does
+            not exist, or carries no metadata block.
+    """
     if file_name is not None:
         # Single-report route (former get_report_info). The read path stays
         # on read_report_metadata, which contains the user-supplied name via
@@ -569,54 +584,55 @@ def list_html_reports(
         return read_report_metadata(file_name)
     return list_reports()
 
+
 async def generate_pca_visualization_report(
     model_name: str,
     test_signal_ids: Optional[list[str]] = None,
     true_labels: Optional[dict[str, str]] = None,
     segment_duration: float = 0.1,
     overlap_ratio: float = 0.5,
-    ctx: Context | None = None
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """
-        Generate PCA visualization HTML report showing test data in 2D PCA space.
+    Generate PCA visualization HTML report showing test data in 2D PCA space.
 
-        Creates interactive scatter plot with:
-        - Test/prediction data (green = predicted healthy, red = predicted anomaly)
-        - PC1 vs PC2 axes with variance explained
-        - Hover information showing segment details and prediction status
+    Creates interactive scatter plot with:
+    - Test/prediction data (green = predicted healthy, red = predicted anomaly)
+    - PC1 vs PC2 axes with variance explained
+    - Hover information showing segment details and prediction status
 
-        **IMPORTANT**: Labels show MODEL PREDICTIONS, not ground truth. Use `true_labels`
-        parameter to provide actual labels for validation visualization.
+    **IMPORTANT**: Labels show MODEL PREDICTIONS, not ground truth. Use `true_labels`
+    parameter to provide actual labels for validation visualization.
 
-        Requires the test signals loaded via load_signal() first; each
-        signal's sampling rate comes from its stored metadata.
+    Requires the test signals loaded via load_signal() first; each
+    signal's sampling rate comes from its stored metadata.
 
-        Args:
-            model_name: Name of trained model (e.g., 'bearing_health_model')
-            test_signal_ids: Optional list of stored signal IDs to predict and visualize
-            true_labels: Optional dict mapping signal_ids to true labels.
-                        Format: {"real_test_baseline_3": "healthy",
-                                 "real_test_InnerRaceFault_vload_6": "faulty"}
-                        When provided, legend shows both true and predicted labels for validation.
-            segment_duration: Segment duration in seconds (default: 0.1s for ML)
-            overlap_ratio: Overlap ratio 0-1 (default: 0.5)
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        model_name: Name of trained model (e.g., 'bearing_health_model')
+        test_signal_ids: Optional list of stored signal IDs to predict and visualize
+        true_labels: Optional dict mapping signal_ids to true labels.
+                    Format: {"real_test_baseline_3": "healthy",
+                             "real_test_InnerRaceFault_vload_6": "faulty"}
+                    When provided, legend shows both true and predicted labels for validation.
+        segment_duration: Segment duration in seconds (default: 0.1s for ML)
+        overlap_ratio: Overlap ratio 0-1 (default: 0.5)
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            Dictionary with file path, metadata, and summary (includes validation metrics if true_labels provided)
+    Returns:
+        Dictionary with file path, metadata, and summary (includes validation metrics if true_labels provided)
 
-        Raises:
-            FileNotFoundError: If the model does not exist.
-            ValueError: If a signal_id is not loaded or has no sampling rate.
+    Raises:
+        FileNotFoundError: If the model does not exist.
+        ValueError: If a signal_id is not loaded or has no sampling rate.
 
-        Example (with validation):
-            >>> generate_pca_visualization_report(
-            ...     model_name="bearing_health_model",
-            ...     test_signal_ids=["real_test_baseline_3", "real_test_InnerRaceFault_vload_6"],
-            ...     true_labels={"real_test_baseline_3": "healthy",
-            ...                  "real_test_InnerRaceFault_vload_6": "faulty"}
-            ... )
-        """
+    Example (with validation):
+        >>> generate_pca_visualization_report(
+        ...     model_name="bearing_health_model",
+        ...     test_signal_ids=["real_test_baseline_3", "real_test_InnerRaceFault_vload_6"],
+        ...     true_labels={"real_test_baseline_3": "healthy",
+        ...                  "real_test_InnerRaceFault_vload_6": "faulty"}
+        ... )
+    """
     logger.info(f"Generating PCA visualization for model '{model_name}'...")
 
     # Load model, scaler, PCA — validate the name and contain every derived
@@ -630,13 +646,13 @@ async def generate_pca_visualization_report(
     if not model_path.exists():
         raise FileNotFoundError(f"Model not found: {model_path}")
 
-    with open(model_path, 'rb') as f:
+    with open(model_path, "rb") as f:
         model = pickle.load(f)
-    with open(scaler_path, 'rb') as f:
+    with open(scaler_path, "rb") as f:
         scaler = pickle.load(f)
-    with open(pca_path, 'rb') as f:
+    with open(pca_path, "rb") as f:
         pca = pickle.load(f)
-    with open(metadata_path, 'r') as f:
+    with open(metadata_path, "r") as f:
         model_metadata = json.load(f)
 
     # Collect training data (reconstruct from model metadata if available)
@@ -670,8 +686,10 @@ async def generate_pca_visualization_report(
                 )
 
             features_list = []
-            for start in range(0, len(signal_data) - segment_length_samples + 1, hop_length):
-                segment = signal_data[start:start + segment_length_samples]
+            for start in range(
+                0, len(signal_data) - segment_length_samples + 1, hop_length
+            ):
+                segment = signal_data[start : start + segment_length_samples]
                 features = extract_time_domain_features(segment)
                 features_list.append(features)
 
@@ -684,20 +702,18 @@ async def generate_pca_visualization_report(
             # Predict
             predictions = model.predict(X_pca)
 
-            test_data_list.append({
-                'signal_id': sid,
-                'pca_data': X_pca,
-                'predictions': predictions
-            })
+            test_data_list.append(
+                {"signal_id": sid, "pca_data": X_pca, "predictions": predictions}
+            )
 
     # Create Plotly figure
     fig = go.Figure()
 
     # Plot test data
     for test_data in test_data_list:
-        X_pca = test_data['pca_data']
-        predictions = test_data['predictions']
-        sid = test_data['signal_id']
+        X_pca = test_data["pca_data"]
+        predictions = test_data["predictions"]
+        sid = test_data["signal_id"]
 
         # Determine true label if provided (keyed by signal_id)
         true_label = None
@@ -711,40 +727,44 @@ async def generate_pca_visualization_report(
         # Create legend labels
         if true_label:
             # Show both true and predicted labels for validation
-            healthy_legend = f'{sid} (True: {true_label}, Predicted: Healthy)'
-            anomaly_legend = f'{sid} (True: {true_label}, Predicted: Anomaly)'
+            healthy_legend = f"{sid} (True: {true_label}, Predicted: Healthy)"
+            anomaly_legend = f"{sid} (True: {true_label}, Predicted: Anomaly)"
 
             # Update hover template to show both
-            healthy_hover = f'<b>{sid}</b><br>PC1: %{{x:.3f}}<br>PC2: %{{y:.3f}}<br>True Label: {true_label}<br>Predicted: Healthy<extra></extra>'
-            anomaly_hover = f'<b>{sid}</b><br>PC1: %{{x:.3f}}<br>PC2: %{{y:.3f}}<br>True Label: {true_label}<br>Predicted: ANOMALY<extra></extra>'
+            healthy_hover = f"<b>{sid}</b><br>PC1: %{{x:.3f}}<br>PC2: %{{y:.3f}}<br>True Label: {true_label}<br>Predicted: Healthy<extra></extra>"
+            anomaly_hover = f"<b>{sid}</b><br>PC1: %{{x:.3f}}<br>PC2: %{{y:.3f}}<br>True Label: {true_label}<br>Predicted: ANOMALY<extra></extra>"
         else:
             # Show only predictions (no ground truth assumed)
-            healthy_legend = f'{sid} (Predicted: Healthy)'
-            anomaly_legend = f'{sid} (Predicted: Anomaly)'
+            healthy_legend = f"{sid} (Predicted: Healthy)"
+            anomaly_legend = f"{sid} (Predicted: Anomaly)"
 
             # Hover template clarifies these are predictions
-            healthy_hover = f'<b>{sid}</b><br>PC1: %{{x:.3f}}<br>PC2: %{{y:.3f}}<br>Predicted: Healthy<extra></extra>'
-            anomaly_hover = f'<b>{sid}</b><br>PC1: %{{x:.3f}}<br>PC2: %{{y:.3f}}<br>Predicted: ANOMALY<extra></extra>'
+            healthy_hover = f"<b>{sid}</b><br>PC1: %{{x:.3f}}<br>PC2: %{{y:.3f}}<br>Predicted: Healthy<extra></extra>"
+            anomaly_hover = f"<b>{sid}</b><br>PC1: %{{x:.3f}}<br>PC2: %{{y:.3f}}<br>Predicted: ANOMALY<extra></extra>"
 
         if np.any(healthy_idx):
-            fig.add_trace(go.Scatter(
-                x=X_pca[healthy_idx, 0],
-                y=X_pca[healthy_idx, 1],
-                mode='markers',
-                name=healthy_legend,
-                marker=dict(color='green', size=8, opacity=0.6),
-                hovertemplate=healthy_hover
-            ))
+            fig.add_trace(
+                go.Scatter(
+                    x=X_pca[healthy_idx, 0],
+                    y=X_pca[healthy_idx, 1],
+                    mode="markers",
+                    name=healthy_legend,
+                    marker=dict(color="green", size=8, opacity=0.6),
+                    hovertemplate=healthy_hover,
+                )
+            )
 
         if np.any(anomaly_idx):
-            fig.add_trace(go.Scatter(
-                x=X_pca[anomaly_idx, 0],
-                y=X_pca[anomaly_idx, 1],
-                mode='markers',
-                name=anomaly_legend,
-                marker=dict(color='red', size=8, opacity=0.6, symbol='x'),
-                hovertemplate=anomaly_hover
-            ))
+            fig.add_trace(
+                go.Scatter(
+                    x=X_pca[anomaly_idx, 0],
+                    y=X_pca[anomaly_idx, 1],
+                    mode="markers",
+                    name=anomaly_legend,
+                    marker=dict(color="red", size=8, opacity=0.6, symbol="x"),
+                    hovertemplate=anomaly_hover,
+                )
+            )
 
     # Layout
     variance_explained = pca.explained_variance_ratio_
@@ -752,43 +772,43 @@ async def generate_pca_visualization_report(
         title=f"PCA Visualization - {model_name}",
         xaxis_title=f"PC1 ({variance_explained[0]*100:.1f}% variance)",
         yaxis_title=f"PC2 ({variance_explained[1]*100:.1f}% variance)",
-        hovermode='closest',
-        template='plotly_white',
+        hovermode="closest",
+        template="plotly_white",
         width=1000,
         height=700,
-        showlegend=True
+        showlegend=True,
     )
 
     # Save HTML report (timestamped: consecutive runs never overwrite)
-    output_file = REPORTS_DIR / timestamped_report_name(
-        "pca_visualization", model_name
-    )
+    output_file = REPORTS_DIR / timestamped_report_name("pca_visualization", model_name)
     fig.write_html(str(output_file))
 
     # Prepare metadata - convert all numpy types to Python natives
     metadata = {
-        'report_type': 'pca_visualization',
-        'model_name': model_name,
-        'test_signals': test_signal_ids or [],
-        'pca_components': int(pca.n_components_),
-        'variance_explained_pc1': float(variance_explained[0]),
-        'variance_explained_pc2': float(variance_explained[1]),
-        'total_variance_2d': float(variance_explained[0] + variance_explained[1]),
-        'segment_duration': float(segment_duration),
-        'sampling_rate': (
+        "report_type": "pca_visualization",
+        "model_name": model_name,
+        "test_signals": test_signal_ids or [],
+        "pca_components": int(pca.n_components_),
+        "variance_explained_pc1": float(variance_explained[0]),
+        "variance_explained_pc2": float(variance_explained[1]),
+        "total_variance_2d": float(variance_explained[0] + variance_explained[1]),
+        "segment_duration": float(segment_duration),
+        "sampling_rate": (
             float(last_sampling_rate) if last_sampling_rate is not None else None
         ),
-        'validation_mode': true_labels is not None
+        "validation_mode": true_labels is not None,
     }
 
     # Calculate summary statistics - convert numpy int to Python int
-    total_segments = int(sum(len(td['predictions']) for td in test_data_list))
-    total_anomalies = int(sum(np.sum(td['predictions'] == -1) for td in test_data_list))
+    total_segments = int(sum(len(td["predictions"]) for td in test_data_list))
+    total_anomalies = int(sum(np.sum(td["predictions"] == -1) for td in test_data_list))
 
     summary = {
-        'total_segments': int(total_segments),
-        'total_anomalies': int(total_anomalies),
-        'anomaly_ratio': float(total_anomalies / total_segments) if total_segments > 0 else 0.0
+        "total_segments": int(total_segments),
+        "total_anomalies": int(total_anomalies),
+        "anomaly_ratio": (
+            float(total_anomalies / total_segments) if total_segments > 0 else 0.0
+        ),
     }
 
     # Calculate validation metrics if true labels provided
@@ -798,14 +818,16 @@ async def generate_pca_visualization_report(
         per_file_accuracy = {}
 
         for test_data in test_data_list:
-            sid = test_data['signal_id']
+            sid = test_data["signal_id"]
 
             if sid in true_labels:
-                predictions = test_data['predictions']
+                predictions = test_data["predictions"]
                 true_label = true_labels[sid].lower()
 
                 # Determine expected predictions (1 = healthy, -1 = anomaly)
-                expected_prediction = 1 if true_label in ['healthy', 'normal', 'baseline'] else -1
+                expected_prediction = (
+                    1 if true_label in ["healthy", "normal", "baseline"] else -1
+                )
 
                 # Count correct predictions
                 file_correct = int(np.sum(predictions == expected_prediction))
@@ -814,88 +836,115 @@ async def generate_pca_visualization_report(
                 total_with_labels += file_total
 
                 per_file_accuracy[sid] = {
-                    'correct': file_correct,
-                    'total': file_total,
-                    'accuracy': float(file_correct / file_total) if file_total > 0 else 0.0,
-                    'true_label': true_label
+                    "correct": file_correct,
+                    "total": file_total,
+                    "accuracy": (
+                        float(file_correct / file_total) if file_total > 0 else 0.0
+                    ),
+                    "true_label": true_label,
                 }
 
-        overall_accuracy = float(correct_predictions / total_with_labels) if total_with_labels > 0 else 0.0
+        overall_accuracy = (
+            float(correct_predictions / total_with_labels)
+            if total_with_labels > 0
+            else 0.0
+        )
 
-        summary['validation_metrics'] = {
-            'overall_accuracy': overall_accuracy,
-            'total_labeled_segments': total_with_labels,
-            'correct_predictions': correct_predictions,
-            'per_file_accuracy': per_file_accuracy
+        summary["validation_metrics"] = {
+            "overall_accuracy": overall_accuracy,
+            "total_labeled_segments": total_with_labels,
+            "correct_predictions": correct_predictions,
+            "per_file_accuracy": per_file_accuracy,
         }
 
         logger.info(f"Validation Mode: Overall accuracy = {overall_accuracy*100:.2f}%")
         for fname, acc_info in per_file_accuracy.items():
-            logger.info(f"  - {fname}: {acc_info['accuracy']*100:.1f}% ({acc_info['correct']}/{acc_info['total']})")
+            logger.info(
+                f"  - {fname}: {acc_info['accuracy']*100:.1f}% ({acc_info['correct']}/{acc_info['total']})"
+            )
 
     message = f"PCA visualization report saved: {output_file.name}"
     logger.info(message)
     logger.info(f"PC1+PC2 explain {metadata['total_variance_2d']*100:.1f}% of variance")
-    logger.info(f"Analyzed {total_segments} segments, {total_anomalies} anomalies detected")
+    logger.info(
+        f"Analyzed {total_segments} segments, {total_anomalies} anomalies detected"
+    )
 
     return {
-        'file_path': str(output_file),
-        'file_name': output_file.name,
-        'message': message,
-        'metadata': metadata,
-        'summary': summary
+        "file_path": str(output_file),
+        "file_name": output_file.name,
+        "message": message,
+        "metadata": metadata,
+        "summary": summary,
     }
+
 
 async def generate_feature_comparison_report(
     signal_groups: dict[str, list[str]],
     segment_duration: float = 0.1,
     overlap_ratio: float = 0.5,
     features_to_plot: Optional[list[str]] = None,
-    ctx: Context | None = None
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """
-        Generate feature comparison report with violin plots comparing time-domain features.
+    Generate feature comparison report with violin plots comparing time-domain features.
 
-        Creates interactive HTML report with violin plots showing distribution of 17
-        time-domain features across different signal groups (e.g., Healthy vs Faulty).
-        Requires every signal loaded via load_signal() first; each signal's
-        sampling rate comes from its stored metadata.
+    Creates interactive HTML report with violin plots showing distribution of 17
+    time-domain features across different signal groups (e.g., Healthy vs Faulty).
+    Requires every signal loaded via load_signal() first; each signal's
+    sampling rate comes from its stored metadata.
 
-        **Strategy**: Same HTML report approach as other reports. Useful for understanding
-        which features are most discriminative for fault detection.
+    **Strategy**: Same HTML report approach as other reports. Useful for understanding
+    which features are most discriminative for fault detection.
 
-        Args:
-            signal_groups: Dictionary mapping group names to lists of stored
-                          signal IDs.
-                          Example: {"Healthy": ["real_train_baseline_1"],
-                                   "Faulty": ["real_train_OuterRaceFault_1"]}
-            segment_duration: Segment duration in seconds (default: 0.1s for ML)
-            overlap_ratio: Overlap ratio 0-1 (default: 0.5)
-            features_to_plot: List of feature names to plot (default: all 17 features)
-            ctx: MCP context. Unused — see this module's docstring on logging.
+    Args:
+        signal_groups: Dictionary mapping group names to lists of stored
+                      signal IDs.
+                      Example: {"Healthy": ["real_train_baseline_1"],
+                               "Faulty": ["real_train_OuterRaceFault_1"]}
+        segment_duration: Segment duration in seconds (default: 0.1s for ML)
+        overlap_ratio: Overlap ratio 0-1 (default: 0.5)
+        features_to_plot: List of feature names to plot (default: all 17 features)
+        ctx: MCP context. Unused — see this module's docstring on logging.
 
-        Returns:
-            Dictionary with file path, metadata, and summary
+    Returns:
+        Dictionary with file path, metadata, and summary
 
-        Raises:
-            ValueError: If a signal_id is not loaded or has no sampling rate.
+    Raises:
+        ValueError: If a signal_id is not loaded or has no sampling rate.
 
-        Example:
-            >>> generate_feature_comparison_report(
-            ...     signal_groups={
-            ...         "Healthy": ["real_train_baseline_1", "real_train_baseline_2"],
-            ...         "Inner Fault": ["real_train_InnerRaceFault_vload_1"],
-            ...         "Outer Fault": ["real_train_OuterRaceFault_1"]
-            ...     }
-            ... )
-        """
-    logger.info(f"Generating feature comparison report for {len(signal_groups)} groups...")
+    Example:
+        >>> generate_feature_comparison_report(
+        ...     signal_groups={
+        ...         "Healthy": ["real_train_baseline_1", "real_train_baseline_2"],
+        ...         "Inner Fault": ["real_train_InnerRaceFault_vload_1"],
+        ...         "Outer Fault": ["real_train_OuterRaceFault_1"]
+        ...     }
+        ... )
+    """
+    logger.info(
+        f"Generating feature comparison report for {len(signal_groups)} groups..."
+    )
 
     # All possible features
     all_feature_names = [
-        'mean', 'std', 'var', 'mean_abs', 'rms', 'max', 'min', 'range',
-        'crest_factor', 'kurtosis', 'skewness', 'shape_factor', 'impulse_factor',
-        'clearance_factor', 'power', 'entropy', 'zero_crossing_rate'
+        "mean",
+        "std",
+        "var",
+        "mean_abs",
+        "rms",
+        "max",
+        "min",
+        "range",
+        "crest_factor",
+        "kurtosis",
+        "skewness",
+        "shape_factor",
+        "impulse_factor",
+        "clearance_factor",
+        "power",
+        "entropy",
+        "zero_crossing_rate",
     ]
 
     if features_to_plot is None:
@@ -917,8 +966,10 @@ async def generate_feature_comparison_report(
             segment_length_samples = int(segment_duration * fs)
             hop_length = int(segment_length_samples * (1 - overlap_ratio))
 
-            for start in range(0, len(signal_data) - segment_length_samples + 1, hop_length):
-                segment = signal_data[start:start + segment_length_samples]
+            for start in range(
+                0, len(signal_data) - segment_length_samples + 1, hop_length
+            ):
+                segment = signal_data[start : start + segment_length_samples]
                 features = extract_time_domain_features(segment)
                 all_features_for_group.append(features)
 
@@ -934,10 +985,10 @@ async def generate_feature_comparison_report(
         cols=cols,
         subplot_titles=features_to_plot,
         vertical_spacing=0.12,
-        horizontal_spacing=0.10
+        horizontal_spacing=0.10,
     )
 
-    colors = ['blue', 'red', 'green', 'orange', 'purple', 'brown', 'pink']
+    colors = ["blue", "red", "green", "orange", "purple", "brown", "pink"]
 
     for idx, feature in enumerate(features_to_plot):
         row = idx // 3 + 1
@@ -956,10 +1007,10 @@ async def generate_feature_comparison_report(
                     fillcolor=colors[group_idx % len(colors)],
                     opacity=0.6,
                     showlegend=(idx == 0),  # Show legend only once
-                    hovertemplate=f'<b>{group_name}</b><br>{feature}: %{{y:.4f}}<extra></extra>'
+                    hovertemplate=f"<b>{group_name}</b><br>{feature}: %{{y:.4f}}<extra></extra>",
                 ),
                 row=row,
-                col=col
+                col=col,
             )
 
     # Update layout
@@ -967,15 +1018,9 @@ async def generate_feature_comparison_report(
         title="Time-Domain Feature Comparison (Violin Plots)",
         height=400 * rows,
         width=1400,
-        template='plotly_white',
+        template="plotly_white",
         showlegend=True,
-        legend=dict(
-            orientation="h",
-            yanchor="bottom",
-            y=1.02,
-            xanchor="center",
-            x=0.5
-        )
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="center", x=0.5),
     )
 
     # Save HTML report (timestamped: consecutive runs never overwrite)
@@ -989,23 +1034,25 @@ async def generate_feature_comparison_report(
 
     # Prepare metadata
     metadata = {
-        'report_type': 'feature_comparison',
-        'groups': {name: len(ids) for name, ids in signal_groups.items()},
-        'features_plotted': features_to_plot,
-        'segment_duration': segment_duration,
-        'sampling_rate': last_sampling_rate,
-        'segments_per_group': {name: len(df) for name, df in group_features.items()}
+        "report_type": "feature_comparison",
+        "groups": {name: len(ids) for name, ids in signal_groups.items()},
+        "features_plotted": features_to_plot,
+        "segment_duration": segment_duration,
+        "sampling_rate": last_sampling_rate,
+        "segments_per_group": {name: len(df) for name, df in group_features.items()},
     }
 
     message = f"Feature comparison report saved: {output_file.name}"
     logger.info(message)
-    logger.info(f"Compared {len(signal_groups)} groups across {len(features_to_plot)} features")
+    logger.info(
+        f"Compared {len(signal_groups)} groups across {len(features_to_plot)} features"
+    )
 
     return {
-        'file_path': str(output_file),
-        'file_name': output_file.name,
-        'message': message,
-        'metadata': metadata
+        "file_path": str(output_file),
+        "file_name": output_file.name,
+        "message": message,
+        "metadata": metadata,
     }
 
 

--- a/src/models.py
+++ b/src/models.py
@@ -11,23 +11,31 @@ from pydantic import BaseModel, Field, model_validator
 
 class SpectralPeak(BaseModel):
     """A single peak in the frequency spectrum."""
+
     frequency_hz: float = Field(description="Peak frequency in Hz")
     magnitude: float = Field(description="Peak magnitude (linear)")
     magnitude_db: float = Field(description="Peak magnitude in dB (relative to max)")
-    note: str = Field(default="", description="Optional annotation (e.g. harmonic label)")
+    note: str = Field(
+        default="", description="Optional annotation (e.g. harmonic label)"
+    )
 
 
 class FFTResult(BaseModel):
     """FFT analysis result — compact summary (top peaks + stats, no full arrays).
-    
+
     Full-length arrays are never returned to the LLM to avoid context overflow.
     Use generate_fft_report() for visual inspection."""
-    top_peaks: list[SpectralPeak] = Field(description="Top spectral peaks sorted by magnitude")
+
+    top_peaks: list[SpectralPeak] = Field(
+        description="Top spectral peaks sorted by magnitude"
+    )
     peak_frequency: float = Field(description="Dominant peak frequency (Hz)")
     peak_magnitude: float = Field(description="Dominant peak magnitude")
     rms_spectral: float = Field(description="RMS of the magnitude spectrum")
     total_bins: int = Field(description="Total number of FFT bins computed")
-    freq_range_hz: list[float] = Field(description="[min_freq, max_freq] of the spectrum")
+    freq_range_hz: list[float] = Field(
+        description="[min_freq, max_freq] of the spectrum"
+    )
     sampling_rate: float = Field(description="Sampling frequency (Hz)")
     num_samples: int = Field(description="Number of analyzed samples")
     frequency_resolution: float = Field(description="Frequency resolution (Hz)")
@@ -41,6 +49,7 @@ class EnvelopeResult(BaseModel):
     (audit 2.8 fix), so low-frequency (FTF-zone) peaks are not buried by
     DC leakage.
     """
+
     signal_id: str = Field(description="Signal identifier used")
     num_samples: int = Field(description="Number of samples analyzed (envelope length)")
     sampling_rate: float = Field(description="Sampling rate (Hz)")
@@ -66,6 +75,7 @@ class StatisticalResult(BaseModel):
     DECLARED (companion ``_metadata.json`` or ``load_signal(signal_unit=...)``)
     — it is never guessed from signal amplitude.
     """
+
     rms: float = Field(description="Root Mean Square (effective value)")
     peak_to_peak: float = Field(description="Peak-to-peak value")
     peak: float = Field(description="Peak value")
@@ -81,40 +91,63 @@ class StatisticalResult(BaseModel):
             "metadata — never guessed from amplitude. None when not declared."
         ),
     )
-    unit_note: str = Field(description="Unit declaration status and how to declare the unit for ISO severity assessment")
+    unit_note: str = Field(
+        description="Unit declaration status and how to declare the unit for ISO severity assessment"
+    )
 
 
 class FeatureExtractionResult(BaseModel):
     """Result of time-domain feature extraction from signal segments."""
+
     num_segments: int = Field(description="Number of segments extracted")
     segment_length_samples: int = Field(description="Samples per segment")
     segment_duration_s: float = Field(description="Duration of each segment in seconds")
     overlap_ratio: float = Field(description="Overlap ratio between segments")
-    features_shape: list[int] = Field(description="Shape of feature matrix [num_segments, num_features]")
+    features_shape: list[int] = Field(
+        description="Shape of feature matrix [num_segments, num_features]"
+    )
     feature_names: list[str] = Field(description="Names of extracted features")
-    features_preview: list[dict[str, float]] = Field(description="First 5 segments features (preview)")
+    features_preview: list[dict[str, float]] = Field(
+        description="First 5 segments features (preview)"
+    )
 
 
 class AnomalyModelResult(BaseModel):
     """Result of anomaly detection model training."""
+
     model_name: str = Field(
         description=(
             "Name under which the model was saved — pass this to "
             "predict_anomalies(model_name=...)"
         )
     )
-    model_type: str = Field(description="Type of model: 'OneClassSVM' or 'LocalOutlierFactor'")
-    num_training_samples: int = Field(description="Number of healthy samples used for training")
+    model_type: str = Field(
+        description="Type of model: 'OneClassSVM' or 'LocalOutlierFactor'"
+    )
+    num_training_samples: int = Field(
+        description="Number of healthy samples used for training"
+    )
     num_features_original: int = Field(description="Number of original features")
-    num_features_pca: int = Field(description="Number of PCA components (features after dimensionality reduction)")
-    variance_explained: float = Field(description="Cumulative variance explained by PCA components")
+    num_features_pca: int = Field(
+        description="Number of PCA components (features after dimensionality reduction)"
+    )
+    variance_explained: float = Field(
+        description="Cumulative variance explained by PCA components"
+    )
     model_params: dict[str, Any] = Field(description="Best model hyperparameters")
     model_path: str = Field(description="Path to saved model file (.pkl)")
     scaler_path: str = Field(description="Path to saved scaler file (.pkl)")
     pca_path: str = Field(description="Path to saved PCA file (.pkl)")
-    validation_accuracy: Optional[float] = Field(None, description="Overall balanced accuracy on healthy + fault validation data")
-    validation_details: Optional[str] = Field(None, description="Validation details with healthy and fault metrics")
-    validation_metrics: Optional[dict[str, Any]] = Field(None, description="Detailed validation metrics (healthy/fault accuracy breakdown)")
+    validation_accuracy: Optional[float] = Field(
+        None, description="Overall balanced accuracy on healthy + fault validation data"
+    )
+    validation_details: Optional[str] = Field(
+        None, description="Validation details with healthy and fault metrics"
+    )
+    validation_metrics: Optional[dict[str, Any]] = Field(
+        None,
+        description="Detailed validation metrics (healthy/fault accuracy breakdown)",
+    )
 
 
 class AnomalyPredictionResult(BaseModel):
@@ -124,6 +157,7 @@ class AnomalyPredictionResult(BaseModel):
     segments only — never per-segment arrays (a 6M-sample signal would
     dump tens of thousands of entries into the chat context).
     """
+
     model_name: str = Field(description="Name of the trained model used")
     num_segments: int = Field(description="Number of segments analyzed")
     anomaly_count: int = Field(description="Number of anomalies detected")
@@ -147,7 +181,9 @@ class AnomalyPredictionResult(BaseModel):
             "worst regions without dumping per-segment arrays."
         ),
     )
-    overall_health: str = Field(description="Overall health status: 'Healthy', 'Suspicious', 'Faulty' (thresholded on anomaly_ratio: <0.1, <0.3, >=0.3)")
+    overall_health: str = Field(
+        description="Overall health status: 'Healthy', 'Suspicious', 'Faulty' (thresholded on anomaly_ratio: <0.1, <0.3, >=0.3)"
+    )
 
 
 # ============================================================================
@@ -157,6 +193,7 @@ class AnomalyPredictionResult(BaseModel):
 
 class StoredSignalInfo(BaseModel):
     """Metadata for a signal stored in the SignalRepository."""
+
     signal_id: str = Field(description="Unique identifier for the stored signal")
     filepath: str = Field(description="Original file path")
     load_timestamp: str = Field(description="ISO 8601 timestamp when signal was loaded")
@@ -188,6 +225,7 @@ class StoredSignalInfo(BaseModel):
 
 class PSDResult(BaseModel):
     """Power Spectral Density (Welch method) result."""
+
     signal_id: str = Field(description="Signal identifier used")
     num_samples: int = Field(description="Number of samples analyzed")
     sampling_rate: float = Field(description="Sampling rate (Hz)")
@@ -202,6 +240,7 @@ class PSDResult(BaseModel):
 
 class STFTResult(BaseModel):
     """STFT Spectrogram result — summary only, no full 2D arrays."""
+
     signal_id: str = Field(description="Signal identifier used")
     num_samples: int = Field(description="Number of samples analyzed")
     sampling_rate: float = Field(description="Sampling rate (Hz)")
@@ -214,11 +253,14 @@ class STFTResult(BaseModel):
     time_range_s: list[float] = Field(description="[start_time, end_time]")
     max_power_freq_hz: float = Field(description="Frequency with maximum power")
     max_power_time_s: float = Field(description="Time of maximum power")
-    energy_per_band: list[dict[str, float]] = Field(description="Energy in predefined frequency bands")
+    energy_per_band: list[dict[str, float]] = Field(
+        description="Energy in predefined frequency bands"
+    )
 
 
 class BearingFaultCheckResult(BaseModel):
     """Result of checking for a specific expected fault frequency."""
+
     signal_id: str = Field(description="Signal identifier used")
     bearing_id: Optional[str] = Field(
         None, description="Bearing designation (None for arbitrary-frequency checks)"
@@ -229,9 +271,9 @@ class BearingFaultCheckResult(BaseModel):
             "user-provided label (e.g. 'GMF')"
         )
     )
-    fault_type_canonical: Optional[Literal[
-        "outer_race", "inner_race", "ball", "cage"
-    ]] = Field(
+    fault_type_canonical: Optional[
+        Literal["outer_race", "inner_race", "ball", "cage"]
+    ] = Field(
         None,
         description=(
             "Canonical fault vocabulary for the standard acronyms "
@@ -241,10 +283,18 @@ class BearingFaultCheckResult(BaseModel):
     )
     expected_frequency_hz: float = Field(description="Expected fault frequency")
     detected: bool = Field(description="Whether a peak was detected within tolerance")
-    detected_frequency_hz: Optional[float] = Field(None, description="Actual peak frequency")
-    magnitude: Optional[float] = Field(None, description="Magnitude at detected frequency")
-    deviation_pct: Optional[float] = Field(None, description="Deviation from expected (%)")
-    harmonics_detected: list[dict[str, float]] = Field(default=[], description="Harmonics found")
+    detected_frequency_hz: Optional[float] = Field(
+        None, description="Actual peak frequency"
+    )
+    magnitude: Optional[float] = Field(
+        None, description="Magnitude at detected frequency"
+    )
+    deviation_pct: Optional[float] = Field(
+        None, description="Deviation from expected (%)"
+    )
+    harmonics_detected: list[dict[str, float]] = Field(
+        default=[], description="Harmonics found"
+    )
     evidence_strength: str = Field(
         description=(
             "Strength of the spectral evidence for this fault: 'high' "
@@ -257,6 +307,7 @@ class BearingFaultCheckResult(BaseModel):
 
 class BearingFaultsSummary(BaseModel):
     """Summary of all expected-frequency checks for one bearing/machine."""
+
     signal_id: str = Field(description="Signal identifier used")
     bearing_id: Optional[str] = Field(
         None,
@@ -270,12 +321,16 @@ class BearingFaultsSummary(BaseModel):
     bearing_frequencies: dict[str, float] = Field(
         description="Expected frequencies checked (Hz), plus shaft_freq_hz"
     )
-    fault_checks: list[BearingFaultCheckResult] = Field(description="Results for each checked frequency")
+    fault_checks: list[BearingFaultCheckResult] = Field(
+        description="Results for each checked frequency"
+    )
     overall_assessment: str = Field(description="Summary assessment text")
-    most_likely_fault: Optional[str] = Field(None, description="Most likely fault label if any")
-    most_likely_fault_canonical: Optional[Literal[
-        "outer_race", "inner_race", "ball", "cage"
-    ]] = Field(
+    most_likely_fault: Optional[str] = Field(
+        None, description="Most likely fault label if any"
+    )
+    most_likely_fault_canonical: Optional[
+        Literal["outer_race", "inner_race", "ball", "cage"]
+    ] = Field(
         None,
         description="Canonical form of most_likely_fault (None for arbitrary labels)",
     )
@@ -297,13 +352,12 @@ class BearingCatalogMiss(BaseModel):
     so the miss is expressed in the SCHEMA (status + suggestion) instead of
     an ad-hoc dict with an 'error' key. No geometry is ever invented.
     """
+
     status: Literal["not_found"] = Field(
         "not_found",
         description="Always 'not_found' — discriminates from a catalog hit",
     )
-    bearing_id: str = Field(
-        description="The bearing designation that was searched for"
-    )
+    bearing_id: str = Field(description="The bearing designation that was searched for")
     suggestion: str = Field(
         description="Concrete next step to obtain the bearing geometry"
     )
@@ -320,8 +374,10 @@ class ISOSeverityRefusal(BaseModel):
     ISO evaluation band, machine out of scope). The refusal is part of the
     SCHEMA — not prose in a log message — so LLM clients cannot lose it.
     """
+
     status: Literal["refused"] = Field(
-        "refused", description="Always 'refused' — discriminates from an assessed result"
+        "refused",
+        description="Always 'refused' — discriminates from an assessed result",
     )
     signal_id: str = Field(default="", description="Signal identifier used")
     reason: str = Field(description="Why the ISO severity verdict was refused")
@@ -342,29 +398,42 @@ class VibrationSeverityResult(BaseModel):
     RMS velocity reading (``signal_id`` None). Alert fields
     (``alert_level``, ``exceeded_threshold``) are derived from the zone.
     """
+
     status: Literal["assessed"] = Field(
-        "assessed", description="Always 'assessed' — discriminates from a refused result"
+        "assessed",
+        description="Always 'assessed' — discriminates from a refused result",
     )
     signal_id: Optional[str] = Field(
         None,
         description="Signal identifier used (None for a direct rms_velocity_mm_s reading)",
     )
     rms_velocity_mm_s: float = Field(description="RMS velocity in mm/s")
-    machine_group: int = Field(description="ISO 20816-3 machine group: 1 (large, >300 kW) or 2 (medium, 15-300 kW)")
+    machine_group: int = Field(
+        description="ISO 20816-3 machine group: 1 (large, >300 kW) or 2 (medium, 15-300 kW)"
+    )
     support_type: str = Field(description="Support type: 'rigid' or 'flexible'")
     axis: str = Field("vertical", description="Measurement axis (informational)")
     zone: str = Field(description="ISO zone: A, B, C, or D")
     zone_description: str = Field(description="Zone description")
-    severity_level: str = Field(description="Good, Acceptable, Unsatisfactory, or Unacceptable")
+    severity_level: str = Field(
+        description="Good, Acceptable, Unsatisfactory, or Unacceptable"
+    )
     color_code: str = Field(description="green, yellow, orange, or red")
     boundaries: dict[str, float] = Field(
         description="Zone boundaries {AB, BC, CD} in mm/s (ISO or custom)"
     )
-    frequency_range: str = Field(description="Actual evaluation band used (may be narrower than the ISO nominal 10-1000 Hz when fs limits it); 'not applicable' for direct RMS readings")
-    unit_conversion_performed: bool = Field(description="Whether acceleration-to-velocity conversion was done")
-    original_unit: Optional[str] = Field(None, description="Original signal unit before conversion")
+    frequency_range: str = Field(
+        description="Actual evaluation band used (may be narrower than the ISO nominal 10-1000 Hz when fs limits it); 'not applicable' for direct RMS readings"
+    )
+    unit_conversion_performed: bool = Field(
+        description="Whether acceleration-to-velocity conversion was done"
+    )
+    original_unit: Optional[str] = Field(
+        None, description="Original signal unit before conversion"
+    )
     operating_speed_rpm: Optional[float] = Field(
-        None, description="Operating speed in RPM, when provided (selects the band's lower edge)"
+        None,
+        description="Operating speed in RPM, when provided (selects the band's lower edge)",
     )
     machine_power_kw: Optional[float] = Field(
         None,
@@ -387,7 +456,9 @@ class VibrationSeverityResult(BaseModel):
             "filled automatically from zone + boundaries)"
         ),
     )
-    threshold_provenance: str = Field(description="Provenance of the zone boundary values (ISO edition note, or custom-threshold note)")
+    threshold_provenance: str = Field(
+        description="Provenance of the zone boundary values (ISO edition note, or custom-threshold note)"
+    )
 
     @model_validator(mode="after")
     def _derive_alert_fields(self):
@@ -410,15 +481,22 @@ class VibrationSeverityResult(BaseModel):
 
 class DiagnosisResult(BaseModel):
     """Full integrated diagnosis pipeline result."""
+
     signal_id: str = Field(description="Signal identifier used")
     rpm: float = Field(description="Machine speed (RPM)")
     bearing_id: Optional[str] = Field(None, description="Bearing used (if any)")
-    machine_group: int = Field(description="ISO 20816-3 machine group used for severity: 1 (large) or 2 (medium)")
-    support_type: str = Field(description="Support type used for severity: 'rigid' or 'flexible'")
+    machine_group: int = Field(
+        description="ISO 20816-3 machine group used for severity: 1 (large) or 2 (medium)"
+    )
+    support_type: str = Field(
+        description="Support type used for severity: 'rigid' or 'flexible'"
+    )
     fft_summary: dict[str, Any] = Field(description="FFT key findings")
     psd_summary: dict[str, Any] = Field(description="PSD key findings")
     stft_summary: dict[str, Any] = Field(description="STFT key findings")
-    bearing_faults: Optional[BearingFaultsSummary] = Field(None, description="Bearing fault results")
+    bearing_faults: Optional[BearingFaultsSummary] = Field(
+        None, description="Bearing fault results"
+    )
     iso_severity: VibrationSeverityResult | ISOSeverityRefusal = Field(
         description=(
             "ISO severity assessment, or a structured refusal "
@@ -428,7 +506,9 @@ class DiagnosisResult(BaseModel):
             "(spectral, bearing, anomaly) still run."
         )
     )
-    anomaly_detection: Optional[dict[str, Any]] = Field(None, description="Anomaly detection results (health, ratio, score)")
+    anomaly_detection: Optional[dict[str, Any]] = Field(
+        None, description="Anomaly detection results (health, ratio, score)"
+    )
     overall_diagnosis: str = Field(description="Combined diagnostic text")
     evidence_strength: str = Field(
         description=(
@@ -457,7 +537,10 @@ class RULEstimationResult(BaseModel):
     observed series; it is NOT a probability that the estimate is correct.
     Extrapolation beyond the observation horizon is inherently uncertain.
     """
-    status: Literal["estimated", "no_degradation_trend", "threshold_already_exceeded"] = Field(
+
+    status: Literal[
+        "estimated", "no_degradation_trend", "threshold_already_exceeded"
+    ] = Field(
         description=(
             "'estimated' (RUL computed), 'no_degradation_trend' (no "
             "statistically significant trend toward the threshold — healthy "
@@ -465,7 +548,9 @@ class RULEstimationResult(BaseModel):
             "measurement is at/above the failure threshold)."
         )
     )
-    method: str = Field(description="Estimation method used: linear, exponential, or kalman")
+    method: str = Field(
+        description="Estimation method used: linear, exponential, or kalman"
+    )
     feature_name: str = Field(description="Degradation indicator tracked (e.g. 'rms')")
     num_measurements: int = Field(description="Number of measurements in the series")
     observation_horizon: float = Field(
@@ -475,8 +560,12 @@ class RULEstimationResult(BaseModel):
             "are extrapolations with low reliability."
         )
     )
-    time_unit: str = Field(description="Unit of timestamps, observation_horizon, and rul")
-    failure_threshold: float = Field(description="Indicator value considered as failure")
+    time_unit: str = Field(
+        description="Unit of timestamps, observation_horizon, and rul"
+    )
+    failure_threshold: float = Field(
+        description="Indicator value considered as failure"
+    )
     current_value: float = Field(description="Most recent measured indicator value")
     trend_p_value: Optional[float] = Field(
         None,
@@ -517,7 +606,9 @@ class RULEstimationResult(BaseModel):
             "present it as a probability of correctness."
         ),
     )
-    message: str = Field(description="Human-readable explanation of the outcome and its caveats")
+    message: str = Field(
+        description="Human-readable explanation of the outcome and its caveats"
+    )
 
 
 class TrendAnalysisResult(BaseModel):
@@ -528,10 +619,15 @@ class TrendAnalysisResult(BaseModel):
     stationary. It cannot estimate Remaining Useful Life: for RUL, collect
     repeated measurements over days/weeks and pass them to estimate_rul.
     """
+
     feature_name: str = Field(description="Feature analyzed")
-    slope: float = Field(description="Trend slope in feature units per second (within the recording)")
+    slope: float = Field(
+        description="Trend slope in feature units per second (within the recording)"
+    )
     intercept: float = Field(description="Trend intercept")
-    r_squared: float = Field(description="R-squared goodness of fit of the linear trend")
+    r_squared: float = Field(
+        description="R-squared goodness of fit of the linear trend"
+    )
     trend_direction: str = Field(
         description=(
             "increasing, decreasing, or stable — based on the slope "

--- a/src/prognostics/kalman_rul.py
+++ b/src/prognostics/kalman_rul.py
@@ -66,10 +66,12 @@ def estimate_rul_kalman(
     H = np.array([[1.0, 0.0]])
 
     # Process noise covariance.
-    Q = process_noise * np.array([
-        [dt ** 3 / 3.0, dt ** 2 / 2.0],
-        [dt ** 2 / 2.0, dt],
-    ])
+    Q = process_noise * np.array(
+        [
+            [dt**3 / 3.0, dt**2 / 2.0],
+            [dt**2 / 2.0, dt],
+        ]
+    )
 
     # Measurement noise covariance (scalar).
     R = np.array([[measurement_noise]])

--- a/src/rag.py
+++ b/src/rag.py
@@ -51,9 +51,11 @@ def backend_name() -> str:
     """Return the active retrieval backend name."""
     return "faiss" if _HAS_FAISS else "tfidf"
 
+
 # ---------------------------------------------------------------------------
 # Chunking
 # ---------------------------------------------------------------------------
+
 
 def chunk_text(
     text: str,
@@ -78,13 +80,15 @@ def chunk_text(
         end = start + chunk_size
         chunk_text_str = text[start:end]
         if chunk_text_str.strip():
-            chunks.append({
-                "text": chunk_text_str,
-                "source": source,
-                "index": idx,
-                "start": start,
-                "end": min(end, len(text)),
-            })
+            chunks.append(
+                {
+                    "text": chunk_text_str,
+                    "source": source,
+                    "index": idx,
+                    "start": start,
+                    "end": min(end, len(text)),
+                }
+            )
             idx += 1
         start += chunk_size - chunk_overlap
     return chunks
@@ -109,32 +113,37 @@ def chunk_text_by_paragraphs(
         if not para:
             continue
         if len(buf) + len(para) + 2 > max_chunk_chars and buf:
-            chunks.append({
-                "text": buf,
-                "source": source,
-                "index": idx,
-                "start": offset,
-                "end": offset + len(buf),
-            })
+            chunks.append(
+                {
+                    "text": buf,
+                    "source": source,
+                    "index": idx,
+                    "start": offset,
+                    "end": offset + len(buf),
+                }
+            )
             idx += 1
             offset += len(buf)
             buf = para
         else:
             buf = f"{buf}\n\n{para}" if buf else para
     if buf.strip():
-        chunks.append({
-            "text": buf,
-            "source": source,
-            "index": idx,
-            "start": offset,
-            "end": offset + len(buf),
-        })
+        chunks.append(
+            {
+                "text": buf,
+                "source": source,
+                "index": idx,
+                "start": offset,
+                "end": offset + len(buf),
+            }
+        )
     return chunks
 
 
 # ---------------------------------------------------------------------------
 # Index — abstract interface + two concrete backends
 # ---------------------------------------------------------------------------
+
 
 class DocumentIndex:
     """Unified document index with FAISS or TF-IDF backend."""
@@ -151,8 +160,8 @@ class DocumentIndex:
         )
         self._tfidf_matrix = None  # sparse TF-IDF matrix
         # FAISS backend (only when deps available)
-        self._faiss_index = None   # faiss.IndexFlatIP
-        self._embedder = None      # SentenceTransformer instance
+        self._faiss_index = None  # faiss.IndexFlatIP
+        self._embedder = None  # SentenceTransformer instance
         self._backend: str = "tfidf"
 
     # -- persistence --
@@ -177,7 +186,9 @@ class DocumentIndex:
             data["matrix"] = self._tfidf_matrix
         with open(self._cache_path(), "wb") as f:
             pickle.dump(data, f)
-        logger.info("RAG index saved (%s backend, %d chunks)", self._backend, len(self._chunks))
+        logger.info(
+            "RAG index saved (%s backend, %d chunks)", self._backend, len(self._chunks)
+        )
 
     @classmethod
     def load(cls) -> Optional["DocumentIndex"]:
@@ -200,7 +211,11 @@ class DocumentIndex:
                 idx._backend = "tfidf"
             else:
                 return None
-            logger.info("RAG index loaded (%s backend, %d chunks)", idx._backend, len(idx._chunks))
+            logger.info(
+                "RAG index loaded (%s backend, %d chunks)",
+                idx._backend,
+                len(idx._chunks),
+            )
             return idx
         except Exception as exc:
             logger.warning("Failed to load RAG index cache: %s", exc)
@@ -237,9 +252,13 @@ class DocumentIndex:
             self._backend = "faiss"
             logger.info("Building FAISS index with sentence-transformers …")
             self._embedder = SentenceTransformer("all-MiniLM-L6-v2")
-            embeddings = self._embedder.encode(texts, show_progress_bar=False, normalize_embeddings=True)
+            embeddings = self._embedder.encode(
+                texts, show_progress_bar=False, normalize_embeddings=True
+            )
             dim = embeddings.shape[1]
-            self._faiss_index = faiss.IndexFlatIP(dim)  # inner-product on L2-normalised = cosine
+            self._faiss_index = faiss.IndexFlatIP(
+                dim
+            )  # inner-product on L2-normalised = cosine
             self._faiss_index.add(embeddings.astype(np.float32))
             # Also build TF-IDF as hybrid fallback
             self._tfidf_matrix = self._tfidf_vectorizer.fit_transform(texts)
@@ -247,35 +266,53 @@ class DocumentIndex:
         else:
             self._backend = "tfidf"
             self._tfidf_matrix = self._tfidf_vectorizer.fit_transform(texts)
-            logger.info("TF-IDF index built: %d chunks, %d features", len(self._chunks), self._tfidf_matrix.shape[1])
+            logger.info(
+                "TF-IDF index built: %d chunks, %d features",
+                len(self._chunks),
+                self._tfidf_matrix.shape[1],
+            )
 
     # -- query --
 
-    def query(self, question: str, top_k: int = 5, min_score: float = 0.05) -> list[dict[str, Any]]:
+    def query(
+        self, question: str, top_k: int = 5, min_score: float = 0.05
+    ) -> list[dict[str, Any]]:
         """Return the *top_k* most relevant chunks for *question*."""
         if not self._chunks:
             return []
 
-        if self._backend == "faiss" and self._faiss_index is not None and self._embedder is not None:
+        if (
+            self._backend == "faiss"
+            and self._faiss_index is not None
+            and self._embedder is not None
+        ):
             return self._query_faiss(question, top_k, min_score)
         return self._query_tfidf(question, top_k, min_score)
 
-    def _query_faiss(self, question: str, top_k: int, min_score: float) -> list[dict[str, Any]]:
-        q_emb = self._embedder.encode([question], normalize_embeddings=True).astype(np.float32)
+    def _query_faiss(
+        self, question: str, top_k: int, min_score: float
+    ) -> list[dict[str, Any]]:
+        q_emb = self._embedder.encode([question], normalize_embeddings=True).astype(
+            np.float32
+        )
         scores, indices = self._faiss_index.search(q_emb, top_k)
         results = []
         for score, idx in zip(scores[0], indices[0]):
             if idx < 0 or score < min_score:
                 continue
-            results.append({
-                "text": self._chunks[idx]["text"],
-                "source": self._chunks[idx]["source"],
-                "chunk_index": self._chunks[idx]["index"],
-                "score": round(float(score), 4),
-            })
+            results.append(
+                {
+                    "text": self._chunks[idx]["text"],
+                    "source": self._chunks[idx]["source"],
+                    "chunk_index": self._chunks[idx]["index"],
+                    "score": round(float(score), 4),
+                }
+            )
         return results
 
-    def _query_tfidf(self, question: str, top_k: int, min_score: float) -> list[dict[str, Any]]:
+    def _query_tfidf(
+        self, question: str, top_k: int, min_score: float
+    ) -> list[dict[str, Any]]:
         if self._tfidf_matrix is None:
             return []
         q_vec = self._tfidf_vectorizer.transform([question])
@@ -285,12 +322,14 @@ class DocumentIndex:
         for i in top_idx:
             if scores[i] < min_score:
                 continue
-            results.append({
-                "text": self._chunks[i]["text"],
-                "source": self._chunks[i]["source"],
-                "chunk_index": self._chunks[i]["index"],
-                "score": round(float(scores[i]), 4),
-            })
+            results.append(
+                {
+                    "text": self._chunks[i]["text"],
+                    "source": self._chunks[i]["source"],
+                    "chunk_index": self._chunks[i]["index"],
+                    "score": round(float(scores[i]), 4),
+                }
+            )
         return results
 
     @property
@@ -320,6 +359,7 @@ def _collect_documents() -> tuple[list[dict[str, Any]], list[Path]]:
             if fpath.suffix.lower() == ".pdf":
                 try:
                     from .document_reader import extract_text_from_pdf
+
                     text = extract_text_from_pdf(fpath, max_pages=50)
                     docs.append({"text": text, "source": fpath.name})
                     paths.append(fpath)

--- a/src/report_generator.py
+++ b/src/report_generator.py
@@ -19,11 +19,7 @@ import numpy as np
 from scipy.signal import find_peaks
 
 # Import HTML templates
-from .html_templates import (
-    create_fft_report,
-    create_envelope_report,
-    create_iso_report
-)
+from .html_templates import create_fft_report, create_envelope_report, create_iso_report
 
 from .config import REPORTS_DIR
 from .path_safety import safe_resolve
@@ -35,6 +31,7 @@ try:
     from docx import Document as DocxDocument
     from docx.shared import Pt
     from docx.enum.table import WD_TABLE_ALIGNMENT
+
     HAS_DOCX = True
 except ImportError:
     HAS_DOCX = False
@@ -43,6 +40,7 @@ except ImportError:
 # HTML rendering writes, so the two cannot diverge in what they claim.
 try:
     from weasyprint import HTML as WeasyHTML
+
     HAS_PDF = True
 except ImportError:  # pragma: no cover - exercised by the missing-dep path
     HAS_PDF = False
@@ -83,11 +81,11 @@ def save_fft_report(
     signal_data: np.ndarray,
     max_freq: Optional[float] = None,
     num_peaks: int = 15,
-    rotation_freq: Optional[float] = None
+    rotation_freq: Optional[float] = None,
 ) -> Dict[str, Any]:
     """
     Generate and save professional FFT spectrum report.
-    
+
     Args:
         signal_file: Signal filename
         sampling_rate: Sampling rate in Hz
@@ -97,68 +95,62 @@ def save_fft_report(
         max_freq: Maximum frequency to display (default: Nyquist)
         num_peaks: Number of peaks to detect and label
         rotation_freq: Optional shaft rotation frequency for harmonic labeling
-    
+
     Returns:
         Dictionary with file path, metadata, and summary
     """
     # Apply frequency limit
     if max_freq is None:
         max_freq = sampling_rate / 2.0
-    
+
     mask = frequencies <= max_freq
     freq_display = frequencies[mask]
     mag_display = magnitudes[mask]
-    
+
     # Convert to dB scale (normalized to max)
     max_mag = np.max(mag_display)
     mag_display_db = 20 * np.log10((mag_display + 1e-12) / max_mag)
-    
+
     # Peak detection
     freq_resolution = frequencies[1] - frequencies[0]
     min_peak_distance = max(1, int(10 / freq_resolution))
-    
+
     peak_indices, properties = find_peaks(
-        mag_display_db,
-        height=-40,  # Within 40 dB of max
-        distance=min_peak_distance
+        mag_display_db, height=-40, distance=min_peak_distance  # Within 40 dB of max
     )
-    
+
     # Sort by magnitude and take top N
-    peak_mags_db = properties['peak_heights']
+    peak_mags_db = properties["peak_heights"]
     top_peak_idx = np.argsort(peak_mags_db)[::-1][:num_peaks]
     peak_indices = peak_indices[top_peak_idx]
-    
+
     # Build peaks list with harmonic detection
     peaks = []
     for idx in peak_indices:
         freq = float(freq_display[idx])
         mag_db = float(mag_display_db[idx])
-        
+
         # Check if harmonic of rotation frequency
         note = ""
         if rotation_freq and rotation_freq > 0:
             harmonic_order = round(freq / rotation_freq)
             if abs(freq - harmonic_order * rotation_freq) < rotation_freq * 0.1:
                 note = f"Harmonic {harmonic_order}× shaft"
-        
-        peaks.append({
-            'frequency': freq,
-            'magnitude_db': mag_db,
-            'note': note
-        })
-    
+
+        peaks.append({"frequency": freq, "magnitude_db": mag_db, "note": note})
+
     # Metadata
     metadata = {
-        'signal_file': signal_file,
-        'sampling_rate': sampling_rate,
-        'num_samples': len(signal_data),
-        'duration': len(signal_data) / sampling_rate,
-        'max_frequency': max_freq,
-        'num_peaks': len(peaks),
-        'rotation_freq': rotation_freq,
-        'report_type': 'fft_spectrum'
+        "signal_file": signal_file,
+        "sampling_rate": sampling_rate,
+        "num_samples": len(signal_data),
+        "duration": len(signal_data) / sampling_rate,
+        "max_frequency": max_freq,
+        "num_peaks": len(peaks),
+        "rotation_freq": rotation_freq,
+        "report_type": "fft_spectrum",
     }
-    
+
     # Generate HTML
     html = create_fft_report(
         signal_file=signal_file,
@@ -166,24 +158,24 @@ def save_fft_report(
         frequencies=freq_display.tolist(),
         magnitudes_db=mag_display_db.tolist(),
         peaks=peaks,
-        metadata=metadata
+        metadata=metadata,
     )
-    
+
     # Save HTML file (timestamped: consecutive runs never overwrite)
     output_file = REPORTS_DIR / timestamped_report_name("fft_spectrum", signal_file)
-    output_file.write_text(html, encoding='utf-8')
-    
+    output_file.write_text(html, encoding="utf-8")
+
     logger.info(f"FFT report saved: {output_file.name}")
-    
+
     return {
-        'file_path': str(output_file.absolute()),
-        'file_name': output_file.name,
-        'file_size_kb': output_file.stat().st_size / 1024,
-        'report_type': 'fft_spectrum',
-        'num_peaks_detected': len(peaks),
-        'peak_frequencies': [p['frequency'] for p in peaks[:5]],  # Top 5 for summary
-        'metadata': metadata,
-        'message': f"✓ FFT spectrum report saved: {output_file.name} ({output_file.stat().st_size / 1024:.1f} KB)"
+        "file_path": str(output_file.absolute()),
+        "file_name": output_file.name,
+        "file_size_kb": output_file.stat().st_size / 1024,
+        "report_type": "fft_spectrum",
+        "num_peaks_detected": len(peaks),
+        "peak_frequencies": [p["frequency"] for p in peaks[:5]],  # Top 5 for summary
+        "metadata": metadata,
+        "message": f"✓ FFT spectrum report saved: {output_file.name} ({output_file.stat().st_size / 1024:.1f} KB)",
     }
 
 
@@ -197,11 +189,11 @@ def save_envelope_report(
     env_magnitudes: np.ndarray,
     bearing_freqs: Optional[Dict[str, float]] = None,
     max_freq: float = 500.0,
-    num_peaks: int = 15
+    num_peaks: int = 15,
 ) -> Dict[str, Any]:
     """
     Generate and save professional envelope analysis report.
-    
+
     Args:
         signal_file: Signal filename
         sampling_rate: Sampling rate in Hz
@@ -213,7 +205,7 @@ def save_envelope_report(
         bearing_freqs: Optional dict with BPFO, BPFI, BSF, FTF
         max_freq: Max frequency to display in envelope spectrum
         num_peaks: Number of peaks to detect
-    
+
     Returns:
         Dictionary with file path, metadata, and summary
     """
@@ -221,32 +213,30 @@ def save_envelope_report(
     mask = env_frequencies <= max_freq
     env_freq_display = env_frequencies[mask]
     env_mag_display = env_magnitudes[mask]
-    
+
     # Convert to dB scale (normalized to max)
     max_mag = np.max(env_mag_display)
     env_mag_display_db = 20 * np.log10((env_mag_display + 1e-12) / max_mag)
-    
+
     # Peak detection
     freq_resolution = env_frequencies[1] - env_frequencies[0]
     min_peak_distance = max(1, int(5 / freq_resolution))
-    
+
     peak_indices, properties = find_peaks(
-        env_mag_display_db,
-        height=-40,
-        distance=min_peak_distance
+        env_mag_display_db, height=-40, distance=min_peak_distance
     )
-    
+
     # Sort and take top N
-    peak_mags_db = properties['peak_heights']
+    peak_mags_db = properties["peak_heights"]
     top_idx = np.argsort(peak_mags_db)[::-1][:num_peaks]
     peak_indices = peak_indices[top_idx]
-    
+
     # Build peaks list with bearing frequency matching
     peaks = []
     for idx in peak_indices:
         freq = float(env_freq_display[idx])
         mag_db = float(env_mag_display_db[idx])
-        
+
         # Check match with bearing frequencies
         match = ""
         if bearing_freqs:
@@ -254,33 +244,31 @@ def save_envelope_report(
                 if bf and abs(freq - bf) < bf * 0.05:  # Within 5%
                     match = f"≈ {name}"
                     break
-        
-        peaks.append({
-            'frequency': freq,
-            'magnitude_db': mag_db,
-            'match': match
-        })
-    
+
+        peaks.append({"frequency": freq, "magnitude_db": mag_db, "match": match})
+
     # Time arrays for plotting (downsample for file size)
     downsample_factor = max(1, len(filtered_signal) // 1000)
-    time_data = np.linspace(0, len(filtered_signal) / sampling_rate, len(filtered_signal))
+    time_data = np.linspace(
+        0, len(filtered_signal) / sampling_rate, len(filtered_signal)
+    )
     time_display = time_data[::downsample_factor].tolist()
     filtered_display = filtered_signal[::downsample_factor].tolist()
     envelope_display = envelope[::downsample_factor].tolist()
-    
+
     # Metadata
     metadata = {
-        'signal_file': signal_file,
-        'sampling_rate': sampling_rate,
-        'filter_band': filter_band,
-        'num_samples': len(filtered_signal),
-        'duration': len(filtered_signal) / sampling_rate,
-        'max_frequency': max_freq,
-        'num_peaks': len(peaks),
-        'bearing_frequencies': bearing_freqs,
-        'report_type': 'envelope_analysis'
+        "signal_file": signal_file,
+        "sampling_rate": sampling_rate,
+        "filter_band": filter_band,
+        "num_samples": len(filtered_signal),
+        "duration": len(filtered_signal) / sampling_rate,
+        "max_frequency": max_freq,
+        "num_peaks": len(peaks),
+        "bearing_frequencies": bearing_freqs,
+        "report_type": "envelope_analysis",
     }
-    
+
     # Generate HTML
     html = create_envelope_report(
         signal_file=signal_file,
@@ -293,88 +281,83 @@ def save_envelope_report(
         env_mag_db=env_mag_display_db.tolist(),
         peaks=peaks,
         bearing_freqs=bearing_freqs,
-        metadata=metadata
+        metadata=metadata,
     )
-    
+
     # Save HTML file (timestamped: consecutive runs never overwrite)
     output_file = REPORTS_DIR / timestamped_report_name(
         "envelope_analysis", signal_file
     )
-    output_file.write_text(html, encoding='utf-8')
-    
+    output_file.write_text(html, encoding="utf-8")
+
     logger.info(f"Envelope report saved: {output_file.name}")
-    
+
     # Summary of matches
-    matches_found = [p['match'] for p in peaks if p['match']]
-    
+    matches_found = [p["match"] for p in peaks if p["match"]]
+
     return {
-        'file_path': str(output_file.absolute()),
-        'file_name': output_file.name,
-        'file_size_kb': output_file.stat().st_size / 1024,
-        'report_type': 'envelope_analysis',
-        'num_peaks_detected': len(peaks),
-        'peak_frequencies': [p['frequency'] for p in peaks[:5]],
-        'bearing_matches': matches_found,
-        'metadata': metadata,
-        'message': f"✓ Envelope analysis report saved: {output_file.name} ({output_file.stat().st_size / 1024:.1f} KB)"
+        "file_path": str(output_file.absolute()),
+        "file_name": output_file.name,
+        "file_size_kb": output_file.stat().st_size / 1024,
+        "report_type": "envelope_analysis",
+        "num_peaks_detected": len(peaks),
+        "peak_frequencies": [p["frequency"] for p in peaks[:5]],
+        "bearing_matches": matches_found,
+        "metadata": metadata,
+        "message": f"✓ Envelope analysis report saved: {output_file.name} ({output_file.stat().st_size / 1024:.1f} KB)",
     }
 
 
-def save_iso_report(
-    signal_file: str,
-    iso_result: Dict[str, Any]
-) -> Dict[str, Any]:
+def save_iso_report(signal_file: str, iso_result: Dict[str, Any]) -> Dict[str, Any]:
     """
     Generate and save professional ISO 20816-3 evaluation report.
-    
+
     Args:
         signal_file: Signal filename
         iso_result: ISO evaluation dict (mapped from assess_severity output)
-    
+
     Returns:
         Dictionary with file path, metadata, and summary
     """
     # Metadata
     metadata = {
-        'signal_file': signal_file,
-        'rms_velocity': iso_result['rms_velocity'],
-        'zone': iso_result['zone'],
-        'severity_level': iso_result['severity_level'],
-        'machine_group': iso_result['machine_group'],
-        'support_type': iso_result['support_type'],
-        'report_type': 'iso_20816'
+        "signal_file": signal_file,
+        "rms_velocity": iso_result["rms_velocity"],
+        "zone": iso_result["zone"],
+        "severity_level": iso_result["severity_level"],
+        "machine_group": iso_result["machine_group"],
+        "support_type": iso_result["support_type"],
+        "report_type": "iso_20816",
     }
-    
+
     # Generate HTML
     html = create_iso_report(
-        signal_file=signal_file,
-        iso_result=iso_result,
-        metadata=metadata
+        signal_file=signal_file, iso_result=iso_result, metadata=metadata
     )
-    
+
     # Save HTML file (timestamped: consecutive runs never overwrite)
     output_file = REPORTS_DIR / timestamped_report_name("iso_20816", signal_file)
-    output_file.write_text(html, encoding='utf-8')
-    
+    output_file.write_text(html, encoding="utf-8")
+
     logger.info(f"ISO report saved: {output_file.name}")
-    
+
     return {
-        'file_path': str(output_file.absolute()),
-        'file_name': output_file.name,
-        'file_size_kb': output_file.stat().st_size / 1024,
-        'report_type': 'iso_20816',
-        'zone': iso_result['zone'],
-        'severity': iso_result['severity_level'],
-        'rms_velocity': iso_result['rms_velocity'],
-        'metadata': metadata,
-        'message': f"✓ ISO 20816-3 report saved: {output_file.name} - Zone {iso_result['zone']} ({iso_result['severity_level']})"
+        "file_path": str(output_file.absolute()),
+        "file_name": output_file.name,
+        "file_size_kb": output_file.stat().st_size / 1024,
+        "report_type": "iso_20816",
+        "zone": iso_result["zone"],
+        "severity": iso_result["severity_level"],
+        "rms_velocity": iso_result["rms_velocity"],
+        "metadata": metadata,
+        "message": f"✓ ISO 20816-3 report saved: {output_file.name} - Zone {iso_result['zone']} ({iso_result['severity_level']})",
     }
 
 
 def save_integrated_diagnostic_report(
     advisory: Dict[str, Any],
     figure: Optional[Dict[str, Any]] = None,
-    formats: Sequence[str] = ("html",)
+    formats: Sequence[str] = ("html",),
 ) -> Dict[str, Any]:
     """
     Save the integrated diagnostic report in one or more renderings.
@@ -438,12 +421,14 @@ def save_integrated_diagnostic_report(
             output_file.write_text(html, encoding="utf-8")
         else:
             WeasyHTML(string=html).write_pdf(target=str(output_file))
-        files.append({
-            "format": fmt,
-            "file_path": str(output_file.absolute()),
-            "file_name": output_file.name,
-            "file_size_kb": output_file.stat().st_size / 1024,
-        })
+        files.append(
+            {
+                "format": fmt,
+                "file_path": str(output_file.absolute()),
+                "file_name": output_file.name,
+                "file_size_kb": output_file.stat().st_size / 1024,
+            }
+        )
         logger.info(f"Integrated diagnostic report saved: {output_file.name}")
 
     verdict = advisory["verdict"]
@@ -502,12 +487,12 @@ def read_report_metadata(file_name: str) -> Dict[str, Any]:
         )
 
     # Read file and extract JSON metadata
-    with open(file_path, 'r', encoding='utf-8') as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         content = f.read()
 
     # Find metadata JSON block
     start_marker = '<script type="application/json" id="report-metadata">'
-    end_marker = '</script>'
+    end_marker = "</script>"
 
     start_idx = content.find(start_marker)
     if start_idx == -1:
@@ -529,18 +514,18 @@ def read_report_metadata(file_name: str) -> Dict[str, Any]:
         raise ValueError(f"Malformed metadata in report {file_name}: {e}") from e
 
     return {
-        'file_name': file_name,
-        'file_path': str(file_path.absolute()),
-        'file_size_kb': file_path.stat().st_size / 1024,
-        'metadata': metadata,
-        'message': f"Metadata loaded from {file_name}"
+        "file_name": file_name,
+        "file_path": str(file_path.absolute()),
+        "file_size_kb": file_path.stat().st_size / 1024,
+        "metadata": metadata,
+        "message": f"Metadata loaded from {file_name}",
     }
 
 
 def list_reports() -> List[Dict[str, Any]]:
     """
     List all available HTML reports in reports/ directory.
-    
+
     Returns:
         List of dicts with report information
     """
@@ -554,24 +539,27 @@ def list_reports() -> List[Dict[str, Any]]:
         except ValueError:
             continue
 
-        meta = metadata_info.get('metadata', {})
-        reports.append({
-            'file_name': html_file.name,
-            'file_size_kb': html_file.stat().st_size / 1024,
-            'report_type': meta.get('report_type', 'unknown'),
-            'signal_file': meta.get('signal_file', 'unknown'),
-            'created': html_file.stat().st_mtime
-        })
-    
+        meta = metadata_info.get("metadata", {})
+        reports.append(
+            {
+                "file_name": html_file.name,
+                "file_size_kb": html_file.stat().st_size / 1024,
+                "report_type": meta.get("report_type", "unknown"),
+                "signal_file": meta.get("signal_file", "unknown"),
+                "created": html_file.stat().st_mtime,
+            }
+        )
+
     # Sort by creation time (newest first)
-    reports.sort(key=lambda x: x['created'], reverse=True)
-    
+    reports.sort(key=lambda x: x["created"], reverse=True)
+
     return reports
 
 
 # ============================================================================
 # DOCX REPORT GENERATION (optional: requires python-docx)
 # ============================================================================
+
 
 def save_diagnostic_report_docx(
     signal_file: str,
@@ -638,7 +626,11 @@ def save_diagnostic_report_docx(
         table = doc.add_table(rows=1, cols=3, style="Light Shading Accent 1")
         table.alignment = WD_TABLE_ALIGNMENT.CENTER
         hdr = table.rows[0].cells
-        hdr[0].text, hdr[1].text, hdr[2].text = "Frequency (Hz)", "Magnitude (dB)", "Note"
+        hdr[0].text, hdr[1].text, hdr[2].text = (
+            "Frequency (Hz)",
+            "Magnitude (dB)",
+            "Note",
+        )
         for p in fft_peaks:
             row = table.add_row().cells
             row[0].text = f"{p['frequency']:.2f}"
@@ -652,7 +644,11 @@ def save_diagnostic_report_docx(
         table = doc.add_table(rows=1, cols=3, style="Light Shading Accent 1")
         table.alignment = WD_TABLE_ALIGNMENT.CENTER
         hdr = table.rows[0].cells
-        hdr[0].text, hdr[1].text, hdr[2].text = "Frequency (Hz)", "Magnitude (dB)", "Bearing Match"
+        hdr[0].text, hdr[1].text, hdr[2].text = (
+            "Frequency (Hz)",
+            "Magnitude (dB)",
+            "Bearing Match",
+        )
         for p in env_peaks:
             row = table.add_row().cells
             row[0].text = f"{p['frequency']:.2f}"

--- a/src/server.py
+++ b/src/server.py
@@ -74,8 +74,7 @@ class _OneBoundedLine(logging.Filter):
         text = record.getMessage()
         if len(text) > _MAX_RECORD_CHARS:
             text = (
-                f"{text[:_MAX_RECORD_CHARS]}… "
-                f"[truncated, {len(text)} chars total]"
+                f"{text[:_MAX_RECORD_CHARS]}… " f"[truncated, {len(text)} chars total]"
             )
         # Interpolate once, here, so args cannot reintroduce a newline.
         record.msg = text.replace("\r", "\\r").replace("\n", "\\n")
@@ -285,7 +284,7 @@ mcp = MCPServer(
     - diagnose_bearing() - Complete bearing diagnostic workflow with evidence-based decision tree
     - diagnose_gear() - Gear fault detection workflow
     - quick_diagnostic_report() - Fast screening analysis (non-definitive)
-    """
+    """,
 )
 
 # ---------------------------------------------------------------------------
@@ -354,7 +353,8 @@ def build_parser() -> argparse.ArgumentParser:
         description="Predictive Maintenance MCP Server",
     )
     parser.add_argument(
-        "--transport", "-t",
+        "--transport",
+        "-t",
         choices=list(TRANSPORTS),
         default=transport,
         help="Transport protocol (default: stdio, env: MCP_TRANSPORT)",
@@ -365,7 +365,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="Bind address for SSE/HTTP (default: 127.0.0.1, env: MCP_HOST)",
     )
     parser.add_argument(
-        "--port", "-p",
+        "--port",
+        "-p",
         type=int,
         default=port,
         help="Port for SSE/HTTP transport (default: 8000, env: MCP_PORT)",

--- a/src/signal_acquisition/loaders.py
+++ b/src/signal_acquisition/loaders.py
@@ -60,11 +60,16 @@ def load_signal_data(filename: str) -> Optional[np.ndarray]:
 
         elif file_path.suffix == ".mat":
             from scipy.io import loadmat
+
             mat_data = loadmat(str(file_path))
             for key, value in mat_data.items():
-                if key.startswith('__'):
+                if key.startswith("__"):
                     continue
-                if isinstance(value, np.ndarray) and value.dtype.kind in ('f', 'i', 'u'):
+                if isinstance(value, np.ndarray) and value.dtype.kind in (
+                    "f",
+                    "i",
+                    "u",
+                ):
                     data = value.flatten()
                     if len(data) > 0:
                         return data.astype(np.float64)
@@ -73,10 +78,11 @@ def load_signal_data(filename: str) -> Optional[np.ndarray]:
 
         elif file_path.suffix == ".wav":
             from scipy.io import wavfile
+
             sample_rate, data = wavfile.read(str(file_path))
             if data.ndim > 1:
                 data = data[:, 0]
-            if data.dtype.kind == 'i':
+            if data.dtype.kind == "i":
                 data = data.astype(np.float64) / np.iinfo(data.dtype).max
             return data.astype(np.float64)
 
@@ -122,7 +128,7 @@ def extract_segment(
     rng = np.random.default_rng(seed)
     start_idx = int(rng.integers(0, max_start + 1))
 
-    return signal[start_idx:start_idx + segment_samples]
+    return signal[start_idx : start_idx + segment_samples]
 
 
 def get_metadata_path(signal_filename: str) -> Path:

--- a/src/signal_acquisition/repository.py
+++ b/src/signal_acquisition/repository.py
@@ -402,9 +402,7 @@ class SignalRepository:
         with self._lock:
             if not overwrite:
                 collisions = [
-                    e["signal_id"]
-                    for e in entries
-                    if e["signal_id"] in self._store
+                    e["signal_id"] for e in entries if e["signal_id"] in self._store
                 ]
                 if collisions:
                     ids = ", ".join(f"'{c}'" for c in collisions)
@@ -482,10 +480,7 @@ class SignalRepository:
 
     def _evict_if_needed(self, new_size: int) -> None:
         """Evict LRU entries until new_size fits. Caller must hold lock."""
-        while (
-            self._store
-            and self._current_memory + new_size > self._max_memory
-        ):
+        while self._store and self._current_memory + new_size > self._max_memory:
             oldest_id, oldest_entry = next(iter(self._store.items()))
             logger.info(
                 f"Evicting signal '{oldest_id}' "
@@ -531,10 +526,12 @@ class SignalRepository:
                 return np.load(filepath)
             elif filepath.suffix in (".csv", ".txt"):
                 import pandas as pd
+
                 df = pd.read_csv(filepath, header=None)
                 return df.iloc[:, 0].values
             elif filepath.suffix == ".mat":
                 from scipy.io import loadmat
+
                 mat = loadmat(str(filepath))
                 for k, v in mat.items():
                     if not k.startswith("__") and isinstance(v, np.ndarray):
@@ -562,7 +559,5 @@ def get_repository() -> SignalRepository:
             # Double-checked locking
             if _repository is None:
                 max_gb = float(os.environ.get("PMM_SIGNAL_CACHE_GB", "10"))
-                _repository = SignalRepository(
-                    max_memory_bytes=int(max_gb * 1024**3)
-                )
+                _repository = SignalRepository(max_memory_bytes=int(max_gb * 1024**3))
     return _repository

--- a/src/signal_processing/features.py
+++ b/src/signal_processing/features.py
@@ -62,9 +62,13 @@ def extract_time_domain_features(segment: np.ndarray) -> dict[str, float]:
     # Dimensionless indicators
     shape_factor_val = rms_val / mean_abs_val if mean_abs_val > 0 else 0.0
     crest_factor_val = float(np.max(np.abs(segment))) / rms_val if rms_val > 0 else 0.0
-    impulse_factor_val = float(np.max(np.abs(segment))) / mean_abs_val if mean_abs_val > 0 else 0.0
+    impulse_factor_val = (
+        float(np.max(np.abs(segment))) / mean_abs_val if mean_abs_val > 0 else 0.0
+    )
     sqrt_mean = float(np.mean(np.sqrt(np.abs(segment))))
-    clearance_factor_val = float(np.max(np.abs(segment))) / (sqrt_mean**2) if sqrt_mean > 0 else 0.0
+    clearance_factor_val = (
+        float(np.max(np.abs(segment))) / (sqrt_mean**2) if sqrt_mean > 0 else 0.0
+    )
 
     # Energy and entropy
     power_val = float(np.mean(segment**2))
@@ -161,6 +165,7 @@ def resolve_sampling_rate(
 
     if metadata_resolver is None:
         from ..signal_acquisition.loaders import get_metadata_path
+
         metadata_resolver = get_metadata_path
 
     metadata_path = metadata_resolver(signal_file)

--- a/src/signal_processing/spectral.py
+++ b/src/signal_processing/spectral.py
@@ -67,12 +67,14 @@ def compute_psd(
     for i in top_idx:
         mag = float(pxx[i])
         mag_db = float(10 * np.log10(max(mag, 1e-12) / max_pxx))
-        top_peaks.append({
-            "frequency_hz": round(float(freqs[i]), 3),
-            "magnitude": round(mag, 8),
-            "magnitude_db": round(mag_db, 2),
-            "note": "",
-        })
+        top_peaks.append(
+            {
+                "frequency_hz": round(float(freqs[i]), 3),
+                "magnitude": round(mag, 8),
+                "magnitude_db": round(mag_db, 2),
+                "note": "",
+            }
+        )
 
     return {
         "top_peaks": top_peaks,
@@ -144,9 +146,7 @@ def compute_stft_spectrogram(
     }
 
 
-def validate_bandpass_band(
-    filter_low: float, filter_high: float, fs: float
-) -> None:
+def validate_bandpass_band(filter_low: float, filter_high: float, fs: float) -> None:
     """Validate a bandpass band against the signal's Nyquist limit, or raise.
 
     Single band-validation path for every envelope/bandpass consumer.
@@ -339,12 +339,14 @@ def compute_envelope_spectrum(
     for i in top_idx:
         mag = float(env_mags[i])
         mag_db = float(20 * np.log10(max(mag, 1e-12) / max_mag))
-        top_peaks.append({
-            "frequency_hz": round(float(env_freqs[i]), 3),
-            "magnitude": round(mag, 6),
-            "magnitude_db": round(mag_db, 2),
-            "note": "",
-        })
+        top_peaks.append(
+            {
+                "frequency_hz": round(float(env_freqs[i]), 3),
+                "magnitude": round(mag, 6),
+                "magnitude_db": round(mag_db, 2),
+                "note": "",
+            }
+        )
 
     # Diagnosis text
     lines = [

--- a/tests/_golden_signals.py
+++ b/tests/_golden_signals.py
@@ -41,10 +41,9 @@ def golden_signals() -> dict[str, np.ndarray]:
         + 0.8 * np.sin(2 * np.pi * BPFO_6205_1800 * t1)
         + 0.3 * np.sin(2 * np.pi * 2 * BPFO_6205_1800 * t1)
     )
-    signals["golden_bearing"] = (
-        np.sin(2 * np.pi * 3000.0 * t1) * modulation
-        + 0.05 * rng.standard_normal(t1.size)
-    )
+    signals["golden_bearing"] = np.sin(
+        2 * np.pi * 3000.0 * t1
+    ) * modulation + 0.05 * rng.standard_normal(t1.size)
 
     # Pure seeded noise (no fault), 1 s.
     rng2 = np.random.default_rng(456)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,13 +141,14 @@ TEST_DATA_DIR = REPO_ROOT / "data" / "signals" / "real_train"
 
 # Fixtures
 
+
 @pytest.fixture
 def sample_healthy_signal():
     """Load baseline healthy signal."""
     signal_path = TEST_DATA_DIR / "baseline_1.csv"
     if not signal_path.exists():
         pytest.skip(f"Sample data not found: {signal_path}")
-    
+
     df = pd.read_csv(signal_path, header=None)
     return df.iloc[:, 0].values
 
@@ -158,7 +159,7 @@ def sample_faulty_signal():
     signal_path = TEST_DATA_DIR / "OuterRaceFault_1.csv"
     if not signal_path.exists():
         pytest.skip(f"Sample data not found: {signal_path}")
-    
+
     df = pd.read_csv(signal_path, header=None)
     return df.iloc[:, 0].values
 
@@ -169,8 +170,8 @@ def sample_metadata():
     metadata_path = TEST_DATA_DIR / "baseline_1_metadata.json"
     if not metadata_path.exists():
         pytest.skip(f"Metadata not found: {metadata_path}")
-    
-    with open(metadata_path, 'r') as f:
+
+    with open(metadata_path, "r") as f:
         return json.load(f)
 
 
@@ -180,10 +181,10 @@ def synthetic_sine_signal():
     fs = 10000  # 10 kHz
     duration = 2.0  # 2 seconds
     freq = 50.0  # 50 Hz
-    
+
     t = np.linspace(0, duration, int(fs * duration), endpoint=False)
     signal = np.sin(2 * np.pi * freq * t)
-    
+
     return signal, fs, freq
 
 
@@ -191,10 +192,10 @@ def synthetic_sine_signal():
 def temp_csv_file(tmp_path, synthetic_sine_signal):
     """Create temporary CSV file with synthetic signal."""
     signal, fs, freq = synthetic_sine_signal
-    
+
     csv_path = tmp_path / "test_signal.csv"
     pd.DataFrame(signal).to_csv(csv_path, index=False, header=False)
-    
+
     return csv_path, fs, freq
 
 

--- a/tests/test_acquisition_tools.py
+++ b/tests/test_acquisition_tools.py
@@ -11,10 +11,10 @@ from mcp.server.mcpserver import MCPServer
 
 from predictive_maintenance_mcp.mcp_tools.acquisition_tools import register
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mcp():
@@ -46,10 +46,16 @@ def data_dir(tmp_path, monkeypatch):
     sub.mkdir()
     pd.DataFrame(sig[:5000]).to_csv(sub / "baseline_1.csv", index=False, header=False)
 
-    monkeypatch.setattr("predictive_maintenance_mcp.mcp_tools.acquisition_tools.DATA_DIR", signals_dir)
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.mcp_tools.acquisition_tools.DATA_DIR", signals_dir
+    )
     monkeypatch.setattr("predictive_maintenance_mcp.config.DATA_DIR", signals_dir)
-    monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", signals_dir)
-    monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.repository.DATA_DIR", signals_dir)
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", signals_dir
+    )
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.signal_acquisition.repository.DATA_DIR", signals_dir
+    )
     return signals_dir
 
 
@@ -65,6 +71,7 @@ def mock_ctx():
 # ---------------------------------------------------------------------------
 # Registered tools – tested via MCP server internals
 # ---------------------------------------------------------------------------
+
 
 class TestListSignals:
     """Tests for the merged list_signals tool (scope='disk'|'memory')."""
@@ -102,7 +109,9 @@ class TestListSignals:
     async def test_empty_directory(self, mcp, tmp_path, monkeypatch):
         empty_dir = tmp_path / "empty"
         empty_dir.mkdir()
-        monkeypatch.setattr("predictive_maintenance_mcp.mcp_tools.acquisition_tools.DATA_DIR", empty_dir)
+        monkeypatch.setattr(
+            "predictive_maintenance_mcp.mcp_tools.acquisition_tools.DATA_DIR", empty_dir
+        )
         tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
         result = await tools["list_signals"](scope="disk")
         assert result["count"] == 0
@@ -213,7 +222,9 @@ class TestSignalRepository:
     @pytest.mark.asyncio
     async def test_clear_all(self, mcp, data_dir, mock_ctx):
         tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
-        await tools["load_signal"](ctx=mock_ctx, filepath="test_sine.csv", signal_id="s1")
+        await tools["load_signal"](
+            ctx=mock_ctx, filepath="test_sine.csv", signal_id="s1"
+        )
         result = await tools["clear_signals"](ctx=mock_ctx)
         assert result["cleared_count"] >= 1
 
@@ -246,9 +257,7 @@ class TestSignalRepository:
             await tools["load_signal"](
                 ctx=mock_ctx, filepath="test_sine.csv", signal_id="meta_rich"
             )
-            info = await tools["get_signal_info"](
-                ctx=mock_ctx, signal_id="meta_rich"
-            )
+            info = await tools["get_signal_info"](ctx=mock_ctx, signal_id="meta_rich")
             assert info.source_metadata["shaft_speed"] == 1797
             assert info.source_metadata["rpm"] == 1797
             assert info.source_metadata["BPFO"] == 107.36
@@ -361,7 +370,9 @@ class TestLoadSignalUnit:
         tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
         try:
             result = await tools["load_signal"](
-                ctx=mock_ctx, filepath="test_sine.csv", signal_id="param_unit",
+                ctx=mock_ctx,
+                filepath="test_sine.csv",
+                signal_id="param_unit",
                 signal_unit="mm/s",
             )
             assert result.signal_unit == "mm/s"  # declared > metadata ('g')
@@ -374,7 +385,8 @@ class TestLoadSignalUnit:
         tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
         try:
             result = await tools["load_signal"](
-                ctx=mock_ctx, filepath="real_train/baseline_1.csv",
+                ctx=mock_ctx,
+                filepath="real_train/baseline_1.csv",
                 signal_id="no_unit",
             )
             assert result.signal_unit is None
@@ -386,6 +398,8 @@ class TestLoadSignalUnit:
         tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
         with pytest.raises(ValueError, match="signal_unit"):
             await tools["load_signal"](
-                ctx=mock_ctx, filepath="test_sine.csv", signal_id="bad_unit",
+                ctx=mock_ctx,
+                filepath="test_sine.csv",
+                signal_id="bad_unit",
                 signal_unit="furlongs",
             )

--- a/tests/test_advisory.py
+++ b/tests/test_advisory.py
@@ -21,7 +21,6 @@ from predictive_maintenance_mcp.decision_support.advisory import (
 )
 from predictive_maintenance_mcp.diagnostics.iso20816 import THRESHOLD_PROVENANCE
 
-
 # ---------------------------------------------------------------------------
 # Fixtures — diagnose_vibration-shaped results, built explicitly so each test
 # states the condition it exercises rather than hiding it in a factory.
@@ -212,12 +211,12 @@ class TestNoConfidenceLabel:
         def walk(node, path=""):
             if isinstance(node, dict):
                 for key, value in node.items():
-                    assert "confidence" not in key.lower(), (
-                        f"confidence-shaped key at {path}.{key}"
-                    )
-                    assert "probability" not in key.lower(), (
-                        f"probability-shaped key at {path}.{key}"
-                    )
+                    assert (
+                        "confidence" not in key.lower()
+                    ), f"confidence-shaped key at {path}.{key}"
+                    assert (
+                        "probability" not in key.lower()
+                    ), f"probability-shaped key at {path}.{key}"
                     walk(value, f"{path}.{key}")
             elif isinstance(node, list):
                 for i, value in enumerate(node):

--- a/tests/test_analysis_tools.py
+++ b/tests/test_analysis_tools.py
@@ -15,10 +15,10 @@ from mcp.server.mcpserver import MCPServer
 from predictive_maintenance_mcp.mcp_tools.analysis_tools import register
 from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mcp():
@@ -55,8 +55,12 @@ def data_dir(tmp_path, monkeypatch):
 
     # Patch all relevant modules
     monkeypatch.setattr("predictive_maintenance_mcp.config.DATA_DIR", signals_dir)
-    monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", signals_dir)
-    monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.repository.DATA_DIR", signals_dir)
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", signals_dir
+    )
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.signal_acquisition.repository.DATA_DIR", signals_dir
+    )
     return signals_dir
 
 
@@ -82,6 +86,7 @@ def mock_ctx():
 # ---------------------------------------------------------------------------
 # analyze_fft
 # ---------------------------------------------------------------------------
+
 
 class TestAnalyzeFFT:
     """Tests for analyze_fft tool (signal_id handle)."""
@@ -122,7 +127,9 @@ class TestAnalyzeFFT:
         fs = 10000
         t = np.linspace(0, 0.5, fs // 2, endpoint=False)
         sig = np.sin(2 * np.pi * 50 * t)
-        pd.DataFrame(sig).to_csv(data_dir / "no_meta_fft.csv", index=False, header=False)
+        pd.DataFrame(sig).to_csv(
+            data_dir / "no_meta_fft.csv", index=False, header=False
+        )
         repo.load_signal("no_meta_fft.csv")  # no metadata → no rate
 
         with pytest.raises(ValueError, match="No sampling rate"):
@@ -161,6 +168,7 @@ class TestAnalyzeFFT:
 # ---------------------------------------------------------------------------
 # analyze_envelope
 # ---------------------------------------------------------------------------
+
 
 class TestAnalyzeEnvelope:
     """Tests for the unified analyze_envelope tool (signal_id handle)."""
@@ -204,6 +212,7 @@ class TestAnalyzeEnvelope:
 # extract_features_from_signal
 # ---------------------------------------------------------------------------
 
+
 class TestExtractFeatures:
     """Tests for extract_features_from_signal tool (signal_id handle)."""
 
@@ -240,6 +249,7 @@ class TestExtractFeatures:
 # PSD, STFT, Envelope Spectrum (delegation tools)
 # ---------------------------------------------------------------------------
 
+
 class TestSpectralDelegation:
     """Tests for PSD/STFT/envelope tools that delegate to spectral.py."""
 
@@ -262,10 +272,10 @@ class TestSpectralDelegation:
             pytest.skip("STFT model validation issue with energy_per_band")
 
 
-
 # ---------------------------------------------------------------------------
 # analyze_statistics
 # ---------------------------------------------------------------------------
+
 
 class TestAnalyzeStatistics:
     """Tests for analyze_statistics tool (signal_id handle)."""
@@ -288,7 +298,9 @@ class TestAnalyzeStatistics:
         fs = 10000
         t = np.linspace(0, 0.5, fs // 2, endpoint=False)
         sig = 4.0 * np.sqrt(2) * np.sin(2 * np.pi * 50 * t)  # RMS ~4 > 0.5
-        pd.DataFrame(sig).to_csv(data_dir / "loud_no_meta.csv", index=False, header=False)
+        pd.DataFrame(sig).to_csv(
+            data_dir / "loud_no_meta.csv", index=False, header=False
+        )
         repo.load_signal("loud_no_meta.csv", sampling_rate=fs)
 
         result = tools["analyze_statistics"](signal_id="loud_no_meta")

--- a/tests/test_bearing_catalog_validation.py
+++ b/tests/test_bearing_catalog_validation.py
@@ -59,9 +59,7 @@ class TestCatalogGeometryValidity:
     def test_bore_pitch_od_ordering(self, designation, entry):
         """bore < pitch diameter < outer diameter (strict)."""
         assert (
-            entry["bore_mm"]
-            < entry["pitch_diameter_mm"]
-            < entry["outer_diameter_mm"]
+            entry["bore_mm"] < entry["pitch_diameter_mm"] < entry["outer_diameter_mm"]
         ), f"{designation}: pitch diameter must lie between bore and OD"
 
     @pytest.mark.parametrize("designation,entry", ENTRIES, ids=ENTRY_IDS)
@@ -84,12 +82,12 @@ class TestCatalogGeometryValidity:
         """Balls must fit between bore and OD around the pitch circle."""
         pitch = entry["pitch_diameter_mm"]
         bd = entry["ball_diameter_mm"]
-        assert pitch - bd > entry["bore_mm"], (
-            f"{designation}: balls would intersect the bore"
-        )
-        assert pitch + bd < entry["outer_diameter_mm"], (
-            f"{designation}: balls would intersect the outer diameter"
-        )
+        assert (
+            pitch - bd > entry["bore_mm"]
+        ), f"{designation}: balls would intersect the bore"
+        assert (
+            pitch + bd < entry["outer_diameter_mm"]
+        ), f"{designation}: balls would intersect the outer diameter"
 
     @pytest.mark.parametrize("designation,entry", ENTRIES, ids=ENTRY_IDS)
     def test_rolling_elements_fit_circumferentially(self, designation, entry):

--- a/tests/test_ci_gates.py
+++ b/tests/test_ci_gates.py
@@ -1,0 +1,213 @@
+"""Every check in tests.yml must be able to turn CI red.
+
+``continue-on-error: true`` makes a check decorative: the step runs, the log
+shows the failure in full, and the checkmark is green regardless. Nobody
+reads a log under a green tick, so the check stops existing while still
+looking like it exists.
+
+This repo has now met that shape four times (three are written up in
+``docs/solutions/architecture-patterns/global-config-you-cannot-win-and-claims-only-running-can-verify-2026-08-08.md``).
+Two were literally this line: the mypy job, and the Black job that reported
+green over a tree where 70 of 91 files would have been reformatted.
+
+A guard against it is the same shape again. If :func:`non_blocking` quietly
+stopped finding anything -- a key renamed, a workflow it can no longer
+parse, a walk that skips steps -- it would report "everything blocks" on a
+workflow made entirely of ``continue-on-error``. So its failing paths are
+tested too, and none of that rests on the real file:
+
+* :class:`TestTheExtractor` drives the pure function against synthetic
+  workflows that *do* carry the defect, at job level and at step level;
+* :func:`test_the_real_workflow_actually_parsed` establishes that the real
+  file was read into jobs and steps, before any "found nothing" result from
+  it is believed;
+* :func:`test_the_allowlist_has_no_stale_entries` stops the allowlist from
+  outliving the thing it excuses.
+
+The workflow is read with a real YAML parser rather than by string matching
+for the same reason: a text window that stopped matching would also fail
+silently, in the passing direction.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "tests.yml"
+
+#: Marks a ``continue-on-error`` on the job itself rather than on one step.
+JOB_LEVEL = "<job>"
+
+# The only place a non-blocking check is legitimate here. Codecov's upload is
+# a call to a third-party service, not a check of this repo's code: an outage
+# or a rate limit there must not fail a PR. Everything else in this workflow
+# is a claim about the tree, and a claim about the tree has to be able to be
+# wrong.
+ALLOWED_NON_BLOCKING = {("test", "Upload coverage to Codecov")}
+
+
+def non_blocking(workflow):
+    """Locate every ``continue-on-error`` in a parsed workflow.
+
+    Returns ``(job_id, where)`` pairs, where *where* is the step's name or
+    :data:`JOB_LEVEL`. Only a literal ``false`` counts as blocking -- an
+    expression such as ``${{ inputs.soft }}`` is reported, because whether it
+    blocks is then decided somewhere this test cannot read.
+    """
+    found = set()
+    for job_id, job in (workflow.get("jobs") or {}).items():
+        if job.get("continue-on-error", False) is not False:
+            found.add((job_id, JOB_LEVEL))
+        for index, step in enumerate(job.get("steps") or []):
+            if step.get("continue-on-error", False) is not False:
+                label = step.get("name") or step.get("uses") or f"step {index}"
+                found.add((job_id, label))
+    return found
+
+
+@pytest.fixture(scope="module")
+def workflow():
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def job_script(workflow, job_id):
+    """Everything a job runs, concatenated -- for ``in`` assertions."""
+    return "\n".join(step.get("run", "") for step in workflow["jobs"][job_id]["steps"])
+
+
+AT_JOB_LEVEL = """\
+jobs:
+  format-check:
+    continue-on-error: true
+    steps:
+      - run: black --check src tests
+"""
+
+AT_STEP_LEVEL = """\
+jobs:
+  format-check:
+    steps:
+      - name: Check code formatting
+        run: black --check src tests
+        continue-on-error: true
+"""
+
+UNNAMED_STEPS = """\
+jobs:
+  test:
+    steps:
+      - uses: codecov/codecov-action@v4
+        continue-on-error: true
+      - run: echo hi
+        continue-on-error: true
+"""
+
+EXPLICITLY_FALSE = """\
+jobs:
+  lint:
+    continue-on-error: false
+    steps:
+      - run: flake8 src
+        continue-on-error: false
+"""
+
+AN_EXPRESSION = """\
+jobs:
+  lint:
+    continue-on-error: ${{ github.event_name == 'push' }}
+    steps:
+      - run: flake8 src
+"""
+
+A_JOB_THIS_FILE_HAS_NEVER_HEARD_OF = """\
+jobs:
+  brand-new-job:
+    steps:
+      - name: Something nobody has written yet
+        run: ./whatever
+        continue-on-error: true
+"""
+
+
+class TestTheExtractor:
+    """The guard's own failing paths. Without these it can only pass."""
+
+    def test_a_non_blocking_job_is_found(self):
+        assert non_blocking(yaml.safe_load(AT_JOB_LEVEL)) == {
+            ("format-check", JOB_LEVEL)
+        }
+
+    def test_a_non_blocking_step_is_found(self):
+        """The shape the Black job actually had: the flag under the step."""
+        assert non_blocking(yaml.safe_load(AT_STEP_LEVEL)) == {
+            ("format-check", "Check code formatting")
+        }
+
+    def test_an_unnamed_step_is_still_located(self):
+        """A finding nobody can find in the file is barely a finding."""
+        assert non_blocking(yaml.safe_load(UNNAMED_STEPS)) == {
+            ("test", "codecov/codecov-action@v4"),
+            ("test", "step 1"),
+        }
+
+    def test_an_explicit_false_is_blocking(self):
+        """Spelling out the default must not force an allowlist entry."""
+        assert non_blocking(yaml.safe_load(EXPLICITLY_FALSE)) == set()
+
+    def test_an_expression_is_reported_rather_than_trusted(self):
+        """Whether ``${{ ... }}`` blocks is decided outside this file."""
+        assert non_blocking(yaml.safe_load(AN_EXPRESSION)) == {("lint", JOB_LEVEL)}
+
+    def test_every_job_is_swept_not_just_the_known_ones(self):
+        """A job added tomorrow is covered without editing this file."""
+        assert non_blocking(yaml.safe_load(A_JOB_THIS_FILE_HAS_NEVER_HEARD_OF)) == {
+            ("brand-new-job", "Something nobody has written yet")
+        }
+
+
+def test_the_real_workflow_actually_parsed(workflow):
+    """Anchor for the rest: "found nothing" has to mean something.
+
+    An empty or reshaped parse would make every assertion below pass
+    vacuously -- the exact failure mode this module exists to prevent.
+    """
+    jobs = workflow.get("jobs") or {}
+    missing = {"test", "lint", "type-check", "format-check"} - set(jobs)
+    assert not missing, (
+        f"tests.yml no longer defines the jobs this guard was written against: "
+        f"{sorted(missing)} absent from {sorted(jobs)}"
+    )
+    assert all(
+        job.get("steps") for job in jobs.values()
+    ), "a job parsed with no steps -- step-level flags would be invisible"
+
+
+def test_no_check_is_non_blocking_outside_the_allowlist(workflow):
+    """The guard itself. Covers every job, including ones added later.
+
+    Re-adding one line to the workflow switches a check off with every other
+    check still green, which is why this is asserted rather than trusted.
+    """
+    unexpected = non_blocking(workflow) - ALLOWED_NON_BLOCKING
+    assert not unexpected, (
+        f"these checks pass whatever they find, so they are decorative: "
+        f"{sorted(unexpected)}. Remove the `continue-on-error`, or add it to "
+        f"ALLOWED_NON_BLOCKING with a reason it is not a claim about this tree."
+    )
+
+
+def test_the_allowlist_has_no_stale_entries(workflow):
+    """An excuse for a step that no longer exists excuses nothing."""
+    gone = ALLOWED_NON_BLOCKING - non_blocking(workflow)
+    assert not gone, f"ALLOWED_NON_BLOCKING outlived what it excused: {sorted(gone)}"
+
+
+def test_the_type_check_job_still_runs_the_mypy_gate(workflow):
+    """Blocking is only half of it -- the job must still run the gate."""
+    assert "tools/check_mypy_baseline.py" in job_script(workflow, "type-check")
+
+
+def test_the_format_check_job_still_runs_black(workflow):
+    assert "black --check" in job_script(workflow, "format-check")

--- a/tests/test_cli_transport.py
+++ b/tests/test_cli_transport.py
@@ -39,6 +39,7 @@ def _build_parser(env_transport="stdio", env_host="127.0.0.1", env_port="8000"):
 
 # ── Default values ─────────────────────────────────────────────────────────
 
+
 class TestCLIDefaults:
 
     def test_default_transport_stdio(self):
@@ -55,6 +56,7 @@ class TestCLIDefaults:
 
 
 # ── Explicit flags ─────────────────────────────────────────────────────────
+
 
 class TestCLIExplicitFlags:
 
@@ -83,15 +85,16 @@ class TestCLIExplicitFlags:
         assert args.port == 7777
 
     def test_all_flags_combined(self):
-        args = _build_parser().parse_args([
-            "-t", "sse", "--host", "10.0.0.1", "-p", "3000"
-        ])
+        args = _build_parser().parse_args(
+            ["-t", "sse", "--host", "10.0.0.1", "-p", "3000"]
+        )
         assert args.transport == "sse"
         assert args.host == "10.0.0.1"
         assert args.port == 3000
 
 
 # ── Invalid arguments ──────────────────────────────────────────────────────
+
 
 class TestCLIInvalidArgs:
 
@@ -105,6 +108,7 @@ class TestCLIInvalidArgs:
 
 
 # ── Environment variable fallbacks ─────────────────────────────────────────
+
 
 class TestCLIEnvVars:
 
@@ -140,13 +144,15 @@ class TestCLIEnvVars:
 
 # ── main() integration (smoke test) ───────────────────────────────────────
 
+
 def test_main_help_exits_cleanly():
     """Verify --help works without crashing (exercises the real main parser)."""
     import sys
     from unittest.mock import patch as _patch
 
-    with _patch.object(sys, 'argv', ['test', '--help']):
+    with _patch.object(sys, "argv", ["test", "--help"]):
         with pytest.raises(SystemExit) as exc_info:
             from predictive_maintenance_mcp.server import main
+
             main()
         assert exc_info.value.code == 0

--- a/tests/test_decision_support_tools.py
+++ b/tests/test_decision_support_tools.py
@@ -13,10 +13,10 @@ from mcp.server.mcpserver import MCPServer
 
 from predictive_maintenance_mcp.mcp_tools.decision_support_tools import register
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mcp():
@@ -42,6 +42,7 @@ def mock_ctx():
 # Surface: the alert tools are gone (merged into assess_severity)
 # ---------------------------------------------------------------------------
 
+
 class TestAlertToolsMerged:
     def test_alert_tools_not_registered(self, tools):
         assert "check_vibration_alert" not in tools
@@ -52,6 +53,7 @@ class TestAlertToolsMerged:
 # ---------------------------------------------------------------------------
 # generate_maintenance_recommendations
 # ---------------------------------------------------------------------------
+
 
 class TestGenerateMaintenanceRecommendations:
     """Tests for generate_maintenance_recommendations tool."""
@@ -108,9 +110,7 @@ class TestGenerateMaintenanceRecommendations:
         assert len(result) > 0
 
     @pytest.mark.asyncio
-    async def test_unknown_fault_type_raises_with_vocabulary(
-        self, tools, mock_ctx
-    ):
+    async def test_unknown_fault_type_raises_with_vocabulary(self, tools, mock_ctx):
         """U9 loop closure: an acronym like 'BPFO' is NOT silently dropped —
         the error names the canonical vocabulary and the acronym mapping."""
         with pytest.raises(ValueError) as exc:

--- a/tests/test_diagnosis_pipeline.py
+++ b/tests/test_diagnosis_pipeline.py
@@ -131,7 +131,10 @@ class TestISOSeverityRefusal:
         """No unit → status='refused' with reason + remedy; other blocks run."""
         signal, fs = healthy_signal
         result = diagnose_vibration(
-            signal, fs, rpm=1500, signal_id="no_unit",
+            signal,
+            fs,
+            rpm=1500,
+            signal_id="no_unit",
             anomaly_model_name="nonexistent_model_u5",
         )
         iso = result["iso_severity"]
@@ -164,7 +167,10 @@ class TestISOSeverityRefusal:
         # With declared unit 'mm/s' → assessed without integration, zone C
         # (group 2 rigid: 2.8 < 4.0 <= 4.5)
         result2 = diagnose_vibration(
-            signal, fs, rpm=3000, signal_unit="mm/s",
+            signal,
+            fs,
+            rpm=3000,
+            signal_unit="mm/s",
             anomaly_model_name="nonexistent_model_u5",
         )
         iso2 = result2["iso_severity"]
@@ -189,7 +195,10 @@ class TestISOSeverityRefusal:
         t = np.linspace(0, 1.0, fs, endpoint=False)
         signal = 0.5 * np.sin(2 * np.pi * 50 * t)
         result = diagnose_vibration(
-            signal, fs, rpm=3000, signal_unit="g",
+            signal,
+            fs,
+            rpm=3000,
+            signal_unit="g",
             anomaly_model_name="nonexistent_model_u5",
         )
         iso = result["iso_severity"]
@@ -259,7 +268,10 @@ class TestRecommendations:
         """
         signal, fs = healthy_signal
         result = diagnose_vibration(
-            signal, fs, rpm=1500, signal_unit="g",
+            signal,
+            fs,
+            rpm=1500,
+            signal_unit="g",
             anomaly_model_name="nonexistent_model_u4",
         )
         assert result["iso_severity"]["zone"] == "A"
@@ -272,7 +284,10 @@ class TestRecommendations:
         t = np.linspace(0, 1.0, fs, endpoint=False)
         signal = 0.01 * np.sin(2 * np.pi * 60 * t)
         result = diagnose_vibration(
-            signal, fs, rpm=rpm, signal_unit="g",
+            signal,
+            fs,
+            rpm=rpm,
+            signal_unit="g",
             anomaly_model_name="nonexistent_model_u4",
         )
         assert result["iso_severity"]["zone"] == "A"
@@ -295,7 +310,10 @@ class TestAnomalyDetection:
     def test_with_real_model(self, healthy_signal):
         """If bearing_health_model exists, anomaly detection should run."""
         from pathlib import Path
-        model_path = Path(__file__).parent.parent / "models" / "bearing_health_model_model.pkl"
+
+        model_path = (
+            Path(__file__).parent.parent / "models" / "bearing_health_model_model.pkl"
+        )
         if not model_path.exists():
             pytest.skip("No trained model available")
         signal, fs = healthy_signal
@@ -313,8 +331,17 @@ class TestFeatureExtraction:
         segment = np.random.randn(1000)
         features = _extract_time_domain_features(segment)
         assert len(features) == 17
-        expected_keys = {"mean", "std", "var", "rms", "kurtosis", "skewness",
-                         "crest_factor", "entropy", "zero_crossing_rate"}
+        expected_keys = {
+            "mean",
+            "std",
+            "var",
+            "rms",
+            "kurtosis",
+            "skewness",
+            "crest_factor",
+            "entropy",
+            "zero_crossing_rate",
+        }
         assert expected_keys.issubset(set(features.keys()))
 
     def test_features_deterministic(self):
@@ -354,7 +381,10 @@ class TestSynthesisEdgeCases:
         """
         signal, fs = self._make_signal(10.0, 70)  # 70 Hz ≠ 1x/2x of 50 Hz shaft
         result = diagnose_vibration(
-            signal, fs, rpm=3000, signal_unit="mm/s",
+            signal,
+            fs,
+            rpm=3000,
+            signal_unit="mm/s",
             anomaly_model_name="nonexistent_model_u4",
         )
         assert result["iso_severity"]["zone"] == "D"
@@ -429,7 +459,10 @@ class TestEvidenceStrengthUpperBranches:
         signal = self._modulated_carrier(t) + 0.02 * rng.standard_normal(t.size)
 
         result = diagnose_vibration(
-            signal, fs, rpm=self.RPM, signal_id="moderate_case",
+            signal,
+            fs,
+            rpm=self.RPM,
+            signal_id="moderate_case",
             bearing_id="6205",
             anomaly_model_name="nonexistent_model_evidence",
         )
@@ -454,7 +487,10 @@ class TestEvidenceStrengthUpperBranches:
         signal = shaft + self._modulated_carrier(t) + 0.02 * rng.standard_normal(t.size)
 
         result = diagnose_vibration(
-            signal, fs, rpm=self.RPM, signal_id="strong_case",
+            signal,
+            fs,
+            rpm=self.RPM,
+            signal_id="strong_case",
             bearing_id="6205",
             anomaly_model_name="nonexistent_model_evidence",
         )

--- a/tests/test_diagnostics_tools.py
+++ b/tests/test_diagnostics_tools.py
@@ -16,10 +16,10 @@ from mcp.server.mcpserver import MCPServer
 from predictive_maintenance_mcp.mcp_tools.diagnostics_tools import register
 from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mcp():
@@ -61,17 +61,26 @@ def data_dir(tmp_path, monkeypatch):
     # RESOURCES_DIR — DATA_DIR/REPORTS_DIR/CACHE_DIR imports were dead and
     # removed in the U9b naming/import sweep).
     monkeypatch.setattr("predictive_maintenance_mcp.config.DATA_DIR", signals_dir)
-    monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", signals_dir)
-    monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.repository.DATA_DIR", signals_dir)
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", signals_dir
+    )
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.signal_acquisition.repository.DATA_DIR", signals_dir
+    )
 
     models_dir = tmp_path / "models"
     models_dir.mkdir()
-    monkeypatch.setattr("predictive_maintenance_mcp.mcp_tools.diagnostics_tools.MODELS_DIR", models_dir)
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.mcp_tools.diagnostics_tools.MODELS_DIR", models_dir
+    )
 
     resources_dir = tmp_path / "resources"
     resources_dir.mkdir()
     (resources_dir / "machine_manuals").mkdir()
-    monkeypatch.setattr("predictive_maintenance_mcp.mcp_tools.diagnostics_tools.RESOURCES_DIR", resources_dir)
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.mcp_tools.diagnostics_tools.RESOURCES_DIR",
+        resources_dir,
+    )
 
     return signals_dir
 
@@ -89,7 +98,7 @@ def repo(data_dir):
     """Repository with the diagnostics signals loaded; cleaned afterwards."""
     repo = get_repository()
     repo.clear_all()
-    repo.load_signal("normal.csv")    # metadata: fs=10000, unit 'g'
+    repo.load_signal("normal.csv")  # metadata: fs=10000, unit 'g'
     repo.load_signal("iso_test.csv")  # metadata: fs=10000, unit 'g'
     yield repo
     repo.clear_all()
@@ -98,6 +107,7 @@ def repo(data_dir):
 # ---------------------------------------------------------------------------
 # ISO 20816 evaluation
 # ---------------------------------------------------------------------------
+
 
 class TestAssessSeverity:
     """Tests for the unified assess_severity tool (U9 merge)."""
@@ -141,6 +151,7 @@ class TestAssessSeverity:
 # Bearing diagnostics
 # ---------------------------------------------------------------------------
 
+
 class TestBearingTools:
     """Tests for bearing fault detection tools."""
 
@@ -162,7 +173,10 @@ class TestBearingTools:
 
     @pytest.mark.asyncio
     async def test_check_bearing_faults_catalog_route(self, tools, data_dir, mock_ctx):
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
+
         repo = get_repository()
         repo.load_signal("normal.csv", signal_id="bearing_test", sampling_rate=10000)
         try:
@@ -182,6 +196,7 @@ class TestBearingTools:
 # Anomaly detection (train + predict)
 # ---------------------------------------------------------------------------
 
+
 class TestAnomalyDetection:
     """Tests for train_anomaly_model and predict_anomalies tools."""
 
@@ -193,7 +208,9 @@ class TestAnomalyDetection:
         for i in range(5):
             t = np.linspace(0, 1.0, fs, endpoint=False)
             sig = 0.05 * np.random.randn(len(t))
-            pd.DataFrame(sig).to_csv(data_dir / f"train_{i}.csv", index=False, header=False)
+            pd.DataFrame(sig).to_csv(
+                data_dir / f"train_{i}.csv", index=False, header=False
+            )
             with open(data_dir / f"train_{i}_metadata.json", "w") as f:
                 json.dump({"sampling_rate": fs}, f)
             files.append(f"train_{i}.csv")
@@ -232,6 +249,7 @@ class TestAnomalyDetection:
 # Integrated diagnosis
 # ---------------------------------------------------------------------------
 
+
 class TestDiagnoseVibration:
     """Tests for diagnose_vibration tool."""
 
@@ -240,7 +258,10 @@ class TestDiagnoseVibration:
         if "diagnose_vibration" not in tools:
             pytest.skip("diagnose_vibration not registered")
 
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
+
         repo = get_repository()
         repo.load_signal("normal.csv", signal_id="diag_test", sampling_rate=10000)
         try:
@@ -257,6 +278,7 @@ class TestDiagnoseVibration:
 # ---------------------------------------------------------------------------
 # Extended ISO 20816 tests
 # ---------------------------------------------------------------------------
+
 
 class TestAssessSeverityExtended:
     """Additional coverage for assess_severity (signal route)."""
@@ -334,7 +356,9 @@ class TestAssessSeverityExtended:
         fs = 10000
         t = np.linspace(0, 2.0, 2 * fs, endpoint=False)
         vel_signal = 3.0 * np.sin(2 * np.pi * 50 * t)  # ~2.12 mm/s RMS
-        pd.DataFrame(vel_signal).to_csv(data_dir / "vel_signal.csv", index=False, header=False)
+        pd.DataFrame(vel_signal).to_csv(
+            data_dir / "vel_signal.csv", index=False, header=False
+        )
         with open(data_dir / "vel_signal_metadata.json", "w") as f:
             json.dump({"sampling_rate": fs, "signal_unit": "mm/s"}, f)
         repo.load_signal("vel_signal.csv")
@@ -374,7 +398,9 @@ class TestAssessSeverityExtended:
         assert "2-1000" in result.frequency_range
 
     @pytest.mark.asyncio
-    async def test_stored_signal_without_rate_raises(self, tools, data_dir, repo, mock_ctx):
+    async def test_stored_signal_without_rate_raises(
+        self, tools, data_dir, repo, mock_ctx
+    ):
         """Signal stored without a rate → structured error, no silent 10 kHz."""
         fs = 10000
         t = np.linspace(0, 1.0, fs, endpoint=False)
@@ -408,7 +434,9 @@ class TestAssessSeverityExtended:
             )
 
     @pytest.mark.asyncio
-    async def test_velocity_declared_unit_no_integration(self, tools, data_dir, repo, mock_ctx):
+    async def test_velocity_declared_unit_no_integration(
+        self, tools, data_dir, repo, mock_ctx
+    ):
         """mm/s declared → severity without acc→vel integration, correct zone."""
         fs = 10000
         t = np.linspace(0, 2.0, 2 * fs, endpoint=False)
@@ -434,6 +462,7 @@ class TestAssessSeverityExtended:
 # Extended bearing diagnostics tests
 # ---------------------------------------------------------------------------
 
+
 class TestBearingToolsExtended:
     """Extended tests for the unified check_bearing_faults tool."""
 
@@ -443,7 +472,10 @@ class TestBearingToolsExtended:
     ):
         """The former single-fault check is the frequencies route with one
         labeled entry."""
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
+
         repo = get_repository()
         repo.load_signal("normal.csv", signal_id="peak_test", sampling_rate=10000)
         try:
@@ -463,7 +495,10 @@ class TestBearingToolsExtended:
     @pytest.mark.asyncio
     async def test_catalog_route_returns_summary(self, tools, data_dir, mock_ctx):
         """Catalog route returns a BearingFaultsSummary with all 4 checks."""
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
+
         repo = get_repository()
         repo.load_signal("normal.csv", signal_id="faults_all", sampling_rate=10000)
         try:
@@ -489,7 +524,10 @@ class TestBearingToolsExtended:
     async def test_designation_with_prefix(self, tools, data_dir, mock_ctx):
         """Manufacturer-prefixed designations resolve via the catalog
         (former lookup_bearing_and_compute_tool path)."""
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
+
         repo = get_repository()
         repo.load_signal("normal.csv", signal_id="lookup_test", sampling_rate=10000)
         try:
@@ -507,7 +545,10 @@ class TestBearingToolsExtended:
     @pytest.mark.asyncio
     async def test_unknown_bearing_raises(self, tools, data_dir, mock_ctx):
         """Unknown bearing ID should raise ValueError."""
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
+
         repo = get_repository()
         repo.load_signal("normal.csv", signal_id="unknown_brg", sampling_rate=10000)
         try:
@@ -531,10 +572,10 @@ class TestBearingToolsExtended:
             assert old not in tools
 
 
-
 # ---------------------------------------------------------------------------
 # Extended anomaly detection tests
 # ---------------------------------------------------------------------------
+
 
 class TestAnomalyDetectionExtended:
     """Additional coverage for anomaly detection tools."""
@@ -547,7 +588,9 @@ class TestAnomalyDetectionExtended:
         for i in range(5):
             t = np.linspace(0, 1.0, fs, endpoint=False)
             sig = 0.05 * np.random.randn(len(t))
-            pd.DataFrame(sig).to_csv(data_dir / f"train_{i}.csv", index=False, header=False)
+            pd.DataFrame(sig).to_csv(
+                data_dir / f"train_{i}.csv", index=False, header=False
+            )
             with open(data_dir / f"train_{i}_metadata.json", "w") as f:
                 json.dump({"sampling_rate": fs}, f)
             files.append(f"train_{i}.csv")
@@ -563,7 +606,9 @@ class TestAnomalyDetectionExtended:
             t = np.linspace(0, 1.0, fs, endpoint=False)
             # Much higher amplitude + periodic component to simulate fault
             sig = 2.0 * np.random.randn(len(t)) + 5.0 * np.sin(2 * np.pi * 100 * t)
-            pd.DataFrame(sig).to_csv(data_dir / f"fault_{i}.csv", index=False, header=False)
+            pd.DataFrame(sig).to_csv(
+                data_dir / f"fault_{i}.csv", index=False, header=False
+            )
             with open(data_dir / f"fault_{i}_metadata.json", "w") as f:
                 json.dump({"sampling_rate": fs}, f)
             files.append(f"fault_{i}.csv")
@@ -587,7 +632,9 @@ class TestAnomalyDetectionExtended:
         assert result.model_type == "LocalOutlierFactor"
 
     @pytest.mark.asyncio
-    async def test_train_invalid_model_type(self, tools, data_dir, mock_ctx, training_signals):
+    async def test_train_invalid_model_type(
+        self, tools, data_dir, mock_ctx, training_signals
+    ):
         """Invalid model type should raise ValueError."""
         if "train_anomaly_model" not in tools:
             pytest.skip("train_anomaly_model not registered")
@@ -629,7 +676,9 @@ class TestAnomalyDetectionExtended:
             )
 
     @pytest.mark.asyncio
-    async def test_predict_missing_signal(self, tools, data_dir, mock_ctx, training_signals):
+    async def test_predict_missing_signal(
+        self, tools, data_dir, mock_ctx, training_signals
+    ):
         """Predicting on an unloaded signal_id should raise the standard error."""
         if "train_anomaly_model" not in tools or "predict_anomalies" not in tools:
             pytest.skip("tools not registered")
@@ -650,7 +699,9 @@ class TestAnomalyDetectionExtended:
             )
 
     @pytest.mark.asyncio
-    async def test_train_semi_supervised_svm(self, tools, data_dir, mock_ctx, training_signals, fault_signals):
+    async def test_train_semi_supervised_svm(
+        self, tools, data_dir, mock_ctx, training_signals, fault_signals
+    ):
         """Semi-supervised SVM training with fault signals for hyperparameter tuning."""
         if "train_anomaly_model" not in tools:
             pytest.skip("train_anomaly_model not registered")
@@ -667,7 +718,9 @@ class TestAnomalyDetectionExtended:
         assert result.validation_accuracy is not None
 
     @pytest.mark.asyncio
-    async def test_train_semi_supervised_lof(self, tools, data_dir, mock_ctx, training_signals, fault_signals):
+    async def test_train_semi_supervised_lof(
+        self, tools, data_dir, mock_ctx, training_signals, fault_signals
+    ):
         """Semi-supervised LOF training with fault signals."""
         if "train_anomaly_model" not in tools:
             pytest.skip("train_anomaly_model not registered")
@@ -684,7 +737,9 @@ class TestAnomalyDetectionExtended:
         assert result.model_type == "LocalOutlierFactor"
 
     @pytest.mark.asyncio
-    async def test_predict_health_assessment(self, tools, data_dir, mock_ctx, training_signals):
+    async def test_predict_health_assessment(
+        self, tools, data_dir, mock_ctx, training_signals
+    ):
         """Predict on healthy signal should give 'Healthy' or 'Suspicious' health."""
         if "train_anomaly_model" not in tools or "predict_anomalies" not in tools:
             pytest.skip("tools not registered")
@@ -719,6 +774,7 @@ class TestAnomalyDetectionExtended:
 # Documentation / manual tools
 # ---------------------------------------------------------------------------
 
+
 class TestDocumentationTools:
     """Tests for list_machine_manuals, read_manual_excerpt, extract_manual_specs."""
 
@@ -732,7 +788,9 @@ class TestDocumentationTools:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_list_machine_manuals_with_txt(self, tools, data_dir, mock_ctx, tmp_path):
+    async def test_list_machine_manuals_with_txt(
+        self, tools, data_dir, mock_ctx, tmp_path
+    ):
         """Text file manuals should appear in the listing."""
         if "list_machine_manuals" not in tools:
             pytest.skip("list_machine_manuals not registered")
@@ -740,7 +798,9 @@ class TestDocumentationTools:
         # Write a .txt manual to the resources/machine_manuals dir
         manuals_dir = tmp_path / "resources" / "machine_manuals"
         manuals_dir.mkdir(parents=True, exist_ok=True)
-        (manuals_dir / "test_manual.txt").write_text("Bearing 6205 installed on drive end.", encoding="utf-8")
+        (manuals_dir / "test_manual.txt").write_text(
+            "Bearing 6205 installed on drive end.", encoding="utf-8"
+        )
 
         result = await tools["list_machine_manuals"](ctx=mock_ctx)
         filenames = [m["filename"] for m in result]
@@ -754,7 +814,9 @@ class TestDocumentationTools:
 
         manuals_dir = tmp_path / "resources" / "machine_manuals"
         manuals_dir.mkdir(parents=True, exist_ok=True)
-        manual_content = "Bearing: SKF 6205-2RS\nOperating speed: 1800 RPM\nPower: 15 kW"
+        manual_content = (
+            "Bearing: SKF 6205-2RS\nOperating speed: 1800 RPM\nPower: 15 kW"
+        )
         (manuals_dir / "pump_manual.txt").write_text(manual_content, encoding="utf-8")
 
         result = await tools["read_manual_excerpt"](
@@ -792,6 +854,7 @@ class TestDocumentationTools:
 # ---------------------------------------------------------------------------
 # Bearing catalog tools
 # ---------------------------------------------------------------------------
+
 
 class TestBearingCatalogTools:
     """Tests for search_bearing_catalog and calculate_bearing_characteristic_frequencies."""
@@ -869,6 +932,7 @@ class TestBearingCatalogTools:
 # Diagnose vibration with bearing
 # ---------------------------------------------------------------------------
 
+
 class TestDiagnoseVibrationExtended:
     """Extended tests for diagnose_vibration tool."""
 
@@ -878,7 +942,10 @@ class TestDiagnoseVibrationExtended:
         if "diagnose_vibration" not in tools:
             pytest.skip("diagnose_vibration not registered")
 
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
+
         repo = get_repository()
         repo.load_signal("normal.csv", signal_id="diag_brg", sampling_rate=10000)
         try:
@@ -914,13 +981,17 @@ class TestDiagnoseVibrationExtended:
 # Assess vibration severity extended
 # ---------------------------------------------------------------------------
 
+
 class TestAssessSeverityUnitsExtended:
     """Unit/rate discipline tests for assess_severity (signal route)."""
 
     @pytest.mark.asyncio
     async def test_group1_boundaries(self, tools, data_dir, mock_ctx):
         """machine_group=1 uses the large-machine boundaries (A/B at 2.3 mm/s)."""
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
+
         repo = get_repository()
         repo.load_signal("iso_test.csv", signal_id="class_test", sampling_rate=10000)
         try:
@@ -942,7 +1013,10 @@ class TestAssessSeverityUnitsExtended:
     @pytest.mark.asyncio
     async def test_machine_class_parameter_removed(self, tools, data_dir, mock_ctx):
         """The invented machine_class vocabulary is gone from the tool."""
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
+
         repo = get_repository()
         repo.load_signal("iso_test.csv", signal_id="class_test", sampling_rate=10000)
         try:
@@ -956,9 +1030,13 @@ class TestAssessSeverityUnitsExtended:
             repo.clear_all()
 
     @pytest.mark.asyncio
-    async def test_signal_without_metadata_sampling_rate(self, tools, data_dir, mock_ctx):
+    async def test_signal_without_metadata_sampling_rate(
+        self, tools, data_dir, mock_ctx
+    ):
         """Signal with no metadata and no explicit sampling_rate should raise."""
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
 
         # Create a signal file with NO companion metadata
         fs = 10000
@@ -979,20 +1057,28 @@ class TestAssessSeverityUnitsExtended:
             repo.clear_all()
 
     @pytest.mark.asyncio
-    async def test_undeclared_unit_refused_names_load_signal(self, tools, data_dir, mock_ctx):
+    async def test_undeclared_unit_refused_names_load_signal(
+        self, tools, data_dir, mock_ctx
+    ):
         """Severity on a stored signal without a declared unit → structured
         error naming load_signal(signal_unit=...) — never a silent 'g'."""
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
 
         fs = 10000
         t = np.linspace(0, 1.0, fs, endpoint=False)
         sig = 4.0 * np.sqrt(2) * np.sin(2 * np.pi * 50 * t)  # RMS ~4
-        pd.DataFrame(sig).to_csv(data_dir / "no_unit_sev.csv", index=False, header=False)
+        pd.DataFrame(sig).to_csv(
+            data_dir / "no_unit_sev.csv", index=False, header=False
+        )
         # No metadata → unit undeclared
 
         repo = get_repository()
         try:
-            repo.load_signal("no_unit_sev.csv", signal_id="no_unit_sev", sampling_rate=fs)
+            repo.load_signal(
+                "no_unit_sev.csv", signal_id="no_unit_sev", sampling_rate=fs
+            )
             with pytest.raises(ValueError, match=r"load_signal.*signal_unit="):
                 await tools["assess_severity"](
                     ctx=mock_ctx,
@@ -1002,10 +1088,14 @@ class TestAssessSeverityUnitsExtended:
             repo.clear_all()
 
     @pytest.mark.asyncio
-    async def test_metadata_unit_g_assessed_without_confirmation(self, tools, data_dir, mock_ctx):
+    async def test_metadata_unit_g_assessed_without_confirmation(
+        self, tools, data_dir, mock_ctx
+    ):
         """Unit 'g' from _metadata.json → acc→vel integration and a verdict,
         no fake confirmation step."""
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
 
         repo = get_repository()
         try:
@@ -1027,17 +1117,23 @@ class TestDiagnoseVibrationRefusedISO:
     @pytest.mark.asyncio
     async def test_diagnosis_without_unit_iso_refused(self, tools, data_dir, mock_ctx):
         from predictive_maintenance_mcp.models import ISOSeverityRefusal
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
 
         fs = 10000
         t = np.linspace(0, 1.0, fs, endpoint=False)
         sig = 0.5 * np.sin(2 * np.pi * 50 * t)
-        pd.DataFrame(sig).to_csv(data_dir / "diag_no_unit.csv", index=False, header=False)
+        pd.DataFrame(sig).to_csv(
+            data_dir / "diag_no_unit.csv", index=False, header=False
+        )
         # No metadata → unit undeclared
 
         repo = get_repository()
         try:
-            repo.load_signal("diag_no_unit.csv", signal_id="diag_no_unit", sampling_rate=fs)
+            repo.load_signal(
+                "diag_no_unit.csv", signal_id="diag_no_unit", sampling_rate=fs
+            )
             result = await tools["diagnose_vibration"](
                 ctx=mock_ctx,
                 signal_id="diag_no_unit",
@@ -1057,16 +1153,22 @@ class TestDiagnoseVibrationRefusedISO:
             repo.clear_all()
 
     @pytest.mark.asyncio
-    async def test_diagnosis_nyquist_too_low_iso_refused(self, tools, data_dir, mock_ctx):
+    async def test_diagnosis_nyquist_too_low_iso_refused(
+        self, tools, data_dir, mock_ctx
+    ):
         """fs < 2 kHz (Nyquist below the ISO band, U2 refusal) → ISO block
         refused with reason, while the diagnosis itself succeeds."""
         from predictive_maintenance_mcp.models import ISOSeverityRefusal
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
 
         fs = 1600
         t = np.linspace(0, 1.0, fs, endpoint=False)
         sig = 0.5 * np.sin(2 * np.pi * 50 * t)
-        pd.DataFrame(sig).to_csv(data_dir / "diag_low_fs.csv", index=False, header=False)
+        pd.DataFrame(sig).to_csv(
+            data_dir / "diag_low_fs.csv", index=False, header=False
+        )
         with open(data_dir / "diag_low_fs_metadata.json", "w") as f:
             json.dump({"sampling_rate": fs, "signal_unit": "g"}, f)
 
@@ -1085,10 +1187,14 @@ class TestDiagnoseVibrationRefusedISO:
             repo.clear_all()
 
     @pytest.mark.asyncio
-    async def test_diagnosis_with_declared_unit_assessed(self, tools, data_dir, mock_ctx):
+    async def test_diagnosis_with_declared_unit_assessed(
+        self, tools, data_dir, mock_ctx
+    ):
         """Declared unit → assessed ISO block (status discriminator present)."""
         from predictive_maintenance_mcp.models import VibrationSeverityResult
-        from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
+        from predictive_maintenance_mcp.signal_acquisition.repository import (
+            get_repository,
+        )
 
         repo = get_repository()
         try:
@@ -1108,6 +1214,7 @@ class TestDiagnoseVibrationRefusedISO:
 # ---------------------------------------------------------------------------
 # RAG / documentation search
 # ---------------------------------------------------------------------------
+
 
 class TestSearchDocumentation:
     """Tests for search_documentation tool."""

--- a/tests/test_document_reader.py
+++ b/tests/test_document_reader.py
@@ -18,8 +18,8 @@ from predictive_maintenance_mcp.document_reader import (
     HAS_OCR,
 )
 
-
 # ── Bearing frequency calculations ─────────────────────────────────────────
+
 
 class TestBearingFrequencies:
     """Tests against known bearing geometry values."""
@@ -67,13 +67,17 @@ class TestBearingFrequencies:
     def test_angular_contact_bearing(self):
         """Non-zero contact angle (angular contact bearing)."""
         freqs_zero = calculate_bearing_frequencies(
-            num_balls=16, ball_diameter_mm=12.7,
-            pitch_diameter_mm=71.5, contact_angle_deg=0.0,
+            num_balls=16,
+            ball_diameter_mm=12.7,
+            pitch_diameter_mm=71.5,
+            contact_angle_deg=0.0,
             shaft_speed_rpm=2000,
         )
         freqs_15 = calculate_bearing_frequencies(
-            num_balls=16, ball_diameter_mm=12.7,
-            pitch_diameter_mm=71.5, contact_angle_deg=15.0,
+            num_balls=16,
+            ball_diameter_mm=12.7,
+            pitch_diameter_mm=71.5,
+            contact_angle_deg=15.0,
             shaft_speed_rpm=2000,
         )
         # cos(15°) < cos(0°), so d_ratio*cos(alpha) is smaller
@@ -85,8 +89,10 @@ class TestBearingFrequencies:
     def test_high_contact_angle(self):
         """45° contact angle (thrust bearing)."""
         freqs = calculate_bearing_frequencies(
-            num_balls=12, ball_diameter_mm=10.0,
-            pitch_diameter_mm=60.0, contact_angle_deg=45.0,
+            num_balls=12,
+            ball_diameter_mm=10.0,
+            pitch_diameter_mm=60.0,
+            contact_angle_deg=45.0,
             shaft_speed_rpm=1500,
         )
         assert all(freqs[k] > 0 for k in ("BPFO", "BPFI", "BSF", "FTF"))
@@ -94,16 +100,20 @@ class TestBearingFrequencies:
     def test_frequency_ratios(self):
         """BPFI/BPFO ratio should be > 1 for typical bearings."""
         freqs = calculate_bearing_frequencies(
-            num_balls=8, ball_diameter_mm=10.0,
-            pitch_diameter_mm=50.0, shaft_speed_rpm=1500,
+            num_balls=8,
+            ball_diameter_mm=10.0,
+            pitch_diameter_mm=50.0,
+            shaft_speed_rpm=1500,
         )
         assert freqs["BPFI"] / freqs["BPFO"] > 1.0
 
     def test_input_parameters_returned(self):
         """Verify input parameters are echoed in result dict."""
         freqs = calculate_bearing_frequencies(
-            num_balls=9, ball_diameter_mm=7.94,
-            pitch_diameter_mm=39.04, contact_angle_deg=0.0,
+            num_balls=9,
+            ball_diameter_mm=7.94,
+            pitch_diameter_mm=39.04,
+            contact_angle_deg=0.0,
             shaft_speed_rpm=1797,
         )
         params = freqs.get("input_parameters", {})
@@ -113,12 +123,16 @@ class TestBearingFrequencies:
     def test_different_speeds(self):
         """Frequencies should scale linearly with RPM."""
         freqs_1000 = calculate_bearing_frequencies(
-            num_balls=8, ball_diameter_mm=10.0,
-            pitch_diameter_mm=50.0, shaft_speed_rpm=1000,
+            num_balls=8,
+            ball_diameter_mm=10.0,
+            pitch_diameter_mm=50.0,
+            shaft_speed_rpm=1000,
         )
         freqs_2000 = calculate_bearing_frequencies(
-            num_balls=8, ball_diameter_mm=10.0,
-            pitch_diameter_mm=50.0, shaft_speed_rpm=2000,
+            num_balls=8,
+            ball_diameter_mm=10.0,
+            pitch_diameter_mm=50.0,
+            shaft_speed_rpm=2000,
         )
         # Double RPM → double all frequencies
         assert abs(freqs_2000["BPFO"] / freqs_1000["BPFO"] - 2.0) < 0.01
@@ -127,6 +141,7 @@ class TestBearingFrequencies:
 
 
 # ── PDF text extraction ────────────────────────────────────────────────────
+
 
 class TestExtractTextFromPdf:
 

--- a/tests/test_documented_calls.py
+++ b/tests/test_documented_calls.py
@@ -296,9 +296,7 @@ class TestValidatorMeta:
 
 
 class TestPluginDocumentedCalls:
-    @pytest.mark.parametrize(
-        "md_file", PLUGIN_FILES, ids=PLUGIN_IDS
-    )
+    @pytest.mark.parametrize("md_file", PLUGIN_FILES, ids=PLUGIN_IDS)
     def test_all_calls_executable(self, md_file, endpoints):
         text = md_file.read_text(encoding="utf-8")
         source = str(md_file.relative_to(REPO_ROOT)).replace("\\", "/")
@@ -349,9 +347,7 @@ class TestPromptTemplateCalls:
 
 def _golden_path_texts() -> dict[str, str]:
     texts = {
-        str(p.relative_to(REPO_ROOT)).replace("\\", "/"): p.read_text(
-            encoding="utf-8"
-        )
+        str(p.relative_to(REPO_ROOT)).replace("\\", "/"): p.read_text(encoding="utf-8")
         for p in PLUGIN_FILES
     }
     texts["README.md"] = README.read_text(encoding="utf-8")
@@ -364,9 +360,7 @@ class TestRetiredNamesAbsent:
     def test_no_retired_endpoint_names(self, source):
         text = _golden_path_texts()[source]
         found = sorted(
-            name
-            for name in RETIRED_NAMES
-            if re.search(rf"\b{re.escape(name)}\b", text)
+            name for name in RETIRED_NAMES if re.search(rf"\b{re.escape(name)}\b", text)
         )
         assert found == [], f"{source} still references retired names: {found}"
 

--- a/tests/test_envelope_iso.py
+++ b/tests/test_envelope_iso.py
@@ -14,172 +14,179 @@ import numpy as np
 
 class TestEnvelopeAnalysis:
     """Test suite for analyze_envelope tool."""
-    
+
     def test_envelope_bandpass_filter(self):
         """Test bandpass filter application."""
         from scipy.signal import butter, filtfilt
-        
+
         # Generate signal with multiple frequencies
         fs = 20000  # Must be > 2 * highcut to avoid Wn=1.0
         t = np.linspace(0, 1, fs, endpoint=False)
-        signal = (np.sin(2*np.pi*100*t) +  # Low freq
-                  np.sin(2*np.pi*2000*t) +  # Mid freq (pass)
-                  np.sin(2*np.pi*8000*t))   # High freq
-        
+        signal = (
+            np.sin(2 * np.pi * 100 * t)  # Low freq
+            + np.sin(2 * np.pi * 2000 * t)  # Mid freq (pass)
+            + np.sin(2 * np.pi * 8000 * t)
+        )  # High freq
+
         # Apply bandpass filter (500-5000 Hz)
         lowcut, highcut = 500, 5000
         nyq = fs / 2
         low = lowcut / nyq
         high = highcut / nyq
-        b, a = butter(4, [low, high], btype='band')
+        b, a = butter(4, [low, high], btype="band")
         filtered = filtfilt(b, a, signal)
-        
+
         # Verify: 2000 Hz should pass, 100 Hz and 8000 Hz should be attenuated
         fft_orig = np.abs(np.fft.rfft(signal))
         fft_filt = np.abs(np.fft.rfft(filtered))
-        freqs = np.fft.rfftfreq(len(signal), 1/fs)
-        
+        freqs = np.fft.rfftfreq(len(signal), 1 / fs)
+
         idx_2000 = np.argmin(np.abs(freqs - 2000))
         idx_100 = np.argmin(np.abs(freqs - 100))
-        
+
         # 2000 Hz should be preserved (ratio close to 1)
         ratio_pass = fft_filt[idx_2000] / (fft_orig[idx_2000] + 1e-10)
         assert ratio_pass > 0.5, f"Passband attenuated too much: {ratio_pass}"
-        
+
         # 100 Hz should be attenuated (ratio << 1)
         ratio_stop = fft_filt[idx_100] / (fft_orig[idx_100] + 1e-10)
         assert ratio_stop < 0.3, f"Stopband not attenuated enough: {ratio_stop}"
-    
-    
+
     def test_envelope_hilbert_transform(self):
         """Test Hilbert transform for envelope extraction."""
         from scipy.signal import hilbert
-        
+
         # Generate amplitude-modulated signal
         fs = 10000
         t = np.linspace(0, 1, fs, endpoint=False)
         carrier_freq = 2000  # High frequency carrier
-        mod_freq = 100       # Low frequency modulation
-        
-        signal = (1 + 0.5*np.sin(2*np.pi*mod_freq*t)) * np.sin(2*np.pi*carrier_freq*t)
-        
+        mod_freq = 100  # Low frequency modulation
+
+        signal = (1 + 0.5 * np.sin(2 * np.pi * mod_freq * t)) * np.sin(
+            2 * np.pi * carrier_freq * t
+        )
+
         # Extract envelope
         analytic = hilbert(signal)
         envelope = np.abs(analytic)
-        
+
         # Envelope should follow modulation frequency
         fft_env = np.abs(np.fft.rfft(envelope))
-        freqs_env = np.fft.rfftfreq(len(envelope), 1/fs)
-        
+        freqs_env = np.fft.rfftfreq(len(envelope), 1 / fs)
+
         # Peak should be at modulation frequency
         peak_idx = np.argmax(fft_env[1:]) + 1  # Skip DC
         peak_freq = freqs_env[peak_idx]
-        
-        assert abs(peak_freq - mod_freq) < 5.0, \
-            f"Envelope peak at {peak_freq} Hz, expected {mod_freq} Hz"
-    
-    
+
+        assert (
+            abs(peak_freq - mod_freq) < 5.0
+        ), f"Envelope peak at {peak_freq} Hz, expected {mod_freq} Hz"
+
     def test_envelope_bearing_fault_simulation(self):
         """Test envelope analysis with simulated bearing fault."""
         fs = 10000
         duration = 2.0
         t = np.linspace(0, duration, int(fs * duration), endpoint=False)
-        
+
         # Simulate bearing fault: periodic impulses
         BPFO = 80.0  # Outer race fault frequency
         fault_signal = np.zeros_like(t)
-        
+
         # Add impulses at BPFO intervals
         impulse_spacing = int(fs / BPFO)
         for i in range(0, len(t), impulse_spacing):
             if i < len(t):
                 fault_signal[i] = 1.0
-        
+
         # Add high-frequency resonance
         carrier_freq = 3000
-        signal = fault_signal * np.sin(2*np.pi*carrier_freq*t)
-        
+        signal = fault_signal * np.sin(2 * np.pi * carrier_freq * t)
+
         # Extract envelope
         from scipy.signal import hilbert
+
         analytic = hilbert(signal)
         envelope = np.abs(analytic)
-        
+
         # Envelope FFT
         fft_env = np.abs(np.fft.rfft(envelope))
-        freqs_env = np.fft.rfftfreq(len(envelope), 1/fs)
-        
+        freqs_env = np.fft.rfftfreq(len(envelope), 1 / fs)
+
         # Should detect BPFO frequency
         from scipy.signal import find_peaks
-        peaks, _ = find_peaks(fft_env, height=np.max(fft_env)*0.1)
+
+        peaks, _ = find_peaks(fft_env, height=np.max(fft_env) * 0.1)
         peak_freqs = freqs_env[peaks]
-        
+
         # Find closest peak to BPFO
         if len(peak_freqs) > 0:
             closest = min(peak_freqs, key=lambda f: abs(f - BPFO))
-            assert abs(closest - BPFO) < 5.0, \
-                f"BPFO not detected: closest peak at {closest} Hz"
-    
-    
+            assert (
+                abs(closest - BPFO) < 5.0
+            ), f"BPFO not detected: closest peak at {closest} Hz"
+
     def test_envelope_real_fault_data(self, sample_faulty_signal, sample_metadata):
         """Test envelope analysis on real outer race fault data."""
         from scipy.signal import butter, filtfilt, hilbert
-        
+
         signal = sample_faulty_signal
-        fs = sample_metadata['sampling_rate']
-        BPFO = sample_metadata['BPFO']
-        
+        fs = sample_metadata["sampling_rate"]
+        BPFO = sample_metadata["BPFO"]
+
         # Apply bandpass filter
         lowcut, highcut = 500, 5000
         nyq = fs / 2
         low = lowcut / nyq
         high = highcut / nyq
-        b, a = butter(4, [low, high], btype='band')
-        filtered = filtfilt(b, a, signal[:int(fs*1.0)])  # Use 1s segment
-        
+        b, a = butter(4, [low, high], btype="band")
+        filtered = filtfilt(b, a, signal[: int(fs * 1.0)])  # Use 1s segment
+
         # Extract envelope
         analytic = hilbert(filtered)
         envelope = np.abs(analytic)
-        
+
         # Envelope FFT
         fft_env = np.abs(np.fft.rfft(envelope))
-        freqs_env = np.fft.rfftfreq(len(envelope), 1/fs)
-        
+        freqs_env = np.fft.rfftfreq(len(envelope), 1 / fs)
+
         # Find peaks
         from scipy.signal import find_peaks
-        peaks, _ = find_peaks(fft_env, height=np.max(fft_env)*0.05)
+
+        peaks, _ = find_peaks(fft_env, height=np.max(fft_env) * 0.05)
         peak_freqs = freqs_env[peaks]
-        
+
         # Should detect BPFO or harmonics
         bpfo_harmonics = [BPFO * i for i in range(1, 5)]
         detected_harmonics = []
-        
+
         for harmonic in bpfo_harmonics:
             if any(abs(f - harmonic) < 10.0 for f in peak_freqs):
                 detected_harmonics.append(harmonic)
-        
-        assert len(detected_harmonics) >= 1, \
-            f"No BPFO harmonics detected. Peaks at: {peak_freqs[:5]}"
+
+        assert (
+            len(detected_harmonics) >= 1
+        ), f"No BPFO harmonics detected. Peaks at: {peak_freqs[:5]}"
 
 
 class TestISO20816:
     """Test suite for ISO 20816-3 evaluation."""
-    
+
     def test_rms_calculation(self):
         """Test RMS velocity calculation."""
         # Synthetic signal with known RMS
         fs = 10000
         duration = 1.0
         t = np.linspace(0, duration, int(fs * duration), endpoint=False)
-        
+
         # Sine wave amplitude = 1, RMS = 1/sqrt(2) ≈ 0.707
-        signal = np.sin(2*np.pi*50*t)
+        signal = np.sin(2 * np.pi * 50 * t)
         rms_expected = 1.0 / np.sqrt(2)
         rms_calculated = np.sqrt(np.mean(signal**2))
-        
-        assert abs(rms_calculated - rms_expected) < 0.01, \
-            f"RMS mismatch: {rms_calculated} vs {rms_expected}"
-    
-    
+
+        assert (
+            abs(rms_calculated - rms_expected) < 0.01
+        ), f"RMS mismatch: {rms_calculated} vs {rms_expected}"
+
     def test_iso_zone_classification_group1(self):
         """Zone classification for Group 1 rigid — asserts on production code."""
         from predictive_maintenance_mcp.diagnostics.iso20816 import classify_zone
@@ -190,7 +197,6 @@ class TestISO20816:
         assert classify_zone(5.0, machine_group=1, support_type="rigid")["zone"] == "C"
         assert classify_zone(10.0, machine_group=1, support_type="rigid")["zone"] == "D"
 
-
     def test_iso_zone_classification_group2(self):
         """Zone classification for Group 2 rigid — asserts on production code."""
         from predictive_maintenance_mcp.diagnostics.iso20816 import classify_zone
@@ -200,48 +206,46 @@ class TestISO20816:
         assert classify_zone(2.0, machine_group=2, support_type="rigid")["zone"] == "B"
         assert classify_zone(3.5, machine_group=2, support_type="rigid")["zone"] == "C"
         assert classify_zone(6.0, machine_group=2, support_type="rigid")["zone"] == "D"
-    
-    
+
     def test_iso_velocity_integration(self):
         """Test acceleration to velocity integration."""
         from scipy.integrate import cumulative_trapezoid
-        
+
         # Constant acceleration should give linear velocity
         fs = 1000
         duration = 1.0
         t = np.linspace(0, duration, int(fs * duration), endpoint=False)
-        
+
         # Constant acceleration = 10 m/s²
         acceleration = np.ones_like(t) * 10
-        
+
         # Integrate to get velocity
         velocity = cumulative_trapezoid(acceleration, t, initial=0)
-        
+
         # At t=1s, velocity should be ~10 m/s
-        assert abs(velocity[-1] - 10.0) < 0.5, \
-            f"Integration error: v(1s) = {velocity[-1]}"
-    
-    
+        assert (
+            abs(velocity[-1] - 10.0) < 0.5
+        ), f"Integration error: v(1s) = {velocity[-1]}"
+
     def test_iso_real_healthy_baseline(self, sample_healthy_signal, sample_metadata):
         """Test ISO evaluation on healthy baseline."""
         signal = sample_healthy_signal
-        fs = sample_metadata['sampling_rate']
-        
+        fs = sample_metadata["sampling_rate"]
+
         # Use 1s segment for faster test
-        segment = signal[:int(fs*1.0)]
-        
+        segment = signal[: int(fs * 1.0)]
+
         # Calculate RMS
         rms = np.sqrt(np.mean(segment**2))
-        
+
         # RMS should be reasonable (not zero, not huge)
         assert rms > 0, "RMS is zero - signal may be empty"
         assert rms < 100, f"RMS too high ({rms}) - check signal units"
-        
+
         # For healthy bearing, RMS should typically be in Zone A or B
         # This is a soft assertion - depends on signal units and scaling
         # In practice, check if value is reasonable
-    
-    
+
     def test_iso_support_type_changes_thresholds(self):
         """Rigid and flexible supports have DIFFERENT zone boundaries.
 
@@ -258,14 +262,12 @@ class TestISO20816:
         assert flexible["zone"] == "A"  # 3.0 <= 3.5
         assert rigid["boundaries"] != flexible["boundaries"]
 
-
     def test_iso_error_handling_negative_rms(self):
         """Negative RMS is physically impossible: production code must raise."""
         from predictive_maintenance_mcp.diagnostics.iso20816 import classify_zone
 
         with pytest.raises(ValueError):
             classify_zone(-1.0, machine_group=2, support_type="rigid")
-
 
     def test_iso_error_handling_invalid_machine_group(self):
         """Invalid machine group must be rejected by production code."""

--- a/tests/test_error_contract.py
+++ b/tests/test_error_contract.py
@@ -96,8 +96,7 @@ class TestModuleLevelTools:
         for t in mcp._tool_manager._tools.values():
             module = importlib.import_module(t.fn.__module__)
             assert getattr(module, t.name) is t.fn, (
-                f"Tool '{t.name}' is not importable as "
-                f"{t.fn.__module__}.{t.name}"
+                f"Tool '{t.name}' is not importable as " f"{t.fn.__module__}.{t.name}"
             )
 
     def test_prompts_are_module_level(self, mcp):
@@ -109,9 +108,7 @@ class TestModuleLevelTools:
             assert getattr(module, p.name) is fn
 
     @pytest.mark.asyncio
-    async def test_direct_import_happy_path(
-        self, sandbox_dirs, mock_ctx
-    ):
+    async def test_direct_import_happy_path(self, sandbox_dirs, mock_ctx):
         """load_signal + analyze_fft work via direct import, no MCPServer."""
         from predictive_maintenance_mcp.mcp_tools.analysis_tools import (
             analyze_fft,
@@ -123,9 +120,7 @@ class TestModuleLevelTools:
         fs = 10000
         t = np.linspace(0, 1.0, fs, endpoint=False)
         sig = np.sin(2 * np.pi * 50 * t)
-        pd.DataFrame(sig).to_csv(
-            sandbox_dirs / "direct.csv", index=False, header=False
-        )
+        pd.DataFrame(sig).to_csv(sandbox_dirs / "direct.csv", index=False, header=False)
         with open(sandbox_dirs / "direct_metadata.json", "w") as f:
             json.dump({"sampling_rate": fs, "signal_unit": "g"}, f)
 
@@ -207,9 +202,7 @@ class TestFailuresRaise:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("tool_name", sorted(FAILURE_CASES))
-    async def test_failure_raises(
-        self, tool_name, tools, sandbox_dirs, mock_ctx
-    ):
+    async def test_failure_raises(self, tool_name, tools, sandbox_dirs, mock_ctx):
         tool = tools[tool_name]
         kwargs = dict(FAILURE_CASES[tool_name])
         if "ctx" in inspect.signature(tool.fn).parameters:
@@ -298,8 +291,7 @@ class TestSourceGuards:
             if monolith_name in p.read_text(encoding="utf-8")
         ]
         assert offenders == [], (
-            f"mcp_tools must not import from the deprecated monolith: "
-            f"{offenders}"
+            f"mcp_tools must not import from the deprecated monolith: " f"{offenders}"
         )
 
     def test_no_fstring_json_error_returns(self):
@@ -310,8 +302,7 @@ class TestSourceGuards:
             if pattern.search(p.read_text(encoding="utf-8"))
         ]
         assert offenders == [], (
-            f"JSON must never be built via f-string interpolation: "
-            f"{offenders}"
+            f"JSON must never be built via f-string interpolation: " f"{offenders}"
         )
 
     def test_no_error_key_dict_literals_returned(self):
@@ -336,6 +327,4 @@ class TestSourceGuards:
             )
             if hits:
                 offenders[path.name] = hits
-        assert offenders == {}, (
-            f"error-keyed dict literals found in: {offenders}"
-        )
+        assert offenders == {}, f"error-keyed dict literals found in: {offenders}"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -266,7 +266,9 @@ class TestResolveSamplingRate:
     def test_provided_rate_used(self):
         """When sampling_rate is given, return it directly."""
         resolver = lambda f: None  # should never be called
-        result = resolve_sampling_rate("any_file.csv", 48000.0, metadata_resolver=resolver)
+        result = resolve_sampling_rate(
+            "any_file.csv", 48000.0, metadata_resolver=resolver
+        )
         assert result == 48000.0
 
     def test_metadata_fallback(self, tmp_path):
@@ -285,14 +287,18 @@ class TestResolveSamplingRate:
 
         resolver = lambda _f: empty_meta
         with pytest.raises(ValueError, match="No sampling rate found"):
-            resolve_sampling_rate("signal.csv", None, strict=True, metadata_resolver=resolver)
+            resolve_sampling_rate(
+                "signal.csv", None, strict=True, metadata_resolver=resolver
+            )
 
     def test_strict_missing_file_raises_valueerror(self, tmp_path):
         """strict=True with nonexistent metadata file should raise ValueError."""
         nonexistent = tmp_path / "nonexistent.json"
         resolver = lambda _f: nonexistent
         with pytest.raises(ValueError, match="No sampling rate found"):
-            resolve_sampling_rate("signal.csv", None, strict=True, metadata_resolver=resolver)
+            resolve_sampling_rate(
+                "signal.csv", None, strict=True, metadata_resolver=resolver
+            )
 
     def test_lenient_missing_returns_none(self, tmp_path):
         """strict=False with no rate available should return None."""
@@ -309,7 +315,9 @@ class TestResolveSamplingRate:
         meta_file.write_text(json.dumps({"sampling_rate": 12000}))
 
         resolver = lambda _f: meta_file
-        result = resolve_sampling_rate("signal.csv", 44100.0, metadata_resolver=resolver)
+        result = resolve_sampling_rate(
+            "signal.csv", 44100.0, metadata_resolver=resolver
+        )
         assert result == 44100.0
 
     def test_custom_metadata_resolver(self, tmp_path):
@@ -318,5 +326,7 @@ class TestResolveSamplingRate:
         custom_meta.write_text(json.dumps({"sampling_rate": 96000}))
 
         resolver = lambda _f: custom_meta
-        result = resolve_sampling_rate("irrelevant.csv", None, metadata_resolver=resolver)
+        result = resolve_sampling_rate(
+            "irrelevant.csv", None, metadata_resolver=resolver
+        )
         assert result == 96000

--- a/tests/test_fft_analysis.py
+++ b/tests/test_fft_analysis.py
@@ -32,191 +32,190 @@ def _extract_segment(signal: np.ndarray, segment_duration, sampling_rate: float)
     if segment_samples >= len(signal):
         return signal
     start_idx = (len(signal) - segment_samples) // 2
-    return signal[start_idx:start_idx + segment_samples]
+    return signal[start_idx : start_idx + segment_samples]
 
 
 class TestFFTAnalysis:
     """Test suite for analyze_fft tool."""
-    
+
     def test_fft_synthetic_sine_50hz(self, synthetic_sine_signal):
         """Test FFT detects 50 Hz sine wave correctly."""
         signal, fs, expected_freq = synthetic_sine_signal
-        
+
         # Perform FFT
         frequencies, magnitudes = _analyze_fft_computation(signal, fs)
-        
+
         # Find peak
         peak_idx = np.argmax(magnitudes)
         detected_freq = frequencies[peak_idx]
-        
+
         # Assert: Peak should be at 50 Hz ±1 Hz
-        assert abs(detected_freq - expected_freq) < 1.0, \
-            f"Expected {expected_freq} Hz, got {detected_freq} Hz"
-    
-    
+        assert (
+            abs(detected_freq - expected_freq) < 1.0
+        ), f"Expected {expected_freq} Hz, got {detected_freq} Hz"
+
     def test_fft_segment_processing(self, sample_healthy_signal, sample_metadata):
         """Test segment-based FFT processing."""
         signal = sample_healthy_signal
-        fs = sample_metadata['sampling_rate']
+        fs = sample_metadata["sampling_rate"]
         segment_duration = 1.0
-        
+
         # Extract segment
         segment = _extract_segment(signal, segment_duration, fs)
-        
+
         # Verify segment length
         expected_length = int(segment_duration * fs)
-        assert len(segment) == expected_length, \
-            f"Expected {expected_length} samples, got {len(segment)}"
-    
-    
+        assert (
+            len(segment) == expected_length
+        ), f"Expected {expected_length} samples, got {len(segment)}"
+
     def test_fft_frequency_resolution(self, synthetic_sine_signal):
         """Test frequency resolution calculation."""
         signal, fs, _ = synthetic_sine_signal
         duration = len(signal) / fs
-        
+
         expected_resolution = 1.0 / duration
-        
+
         # FFT resolution = sampling_rate / num_samples = 1 / duration
         calculated_resolution = fs / len(signal)
-        
-        assert abs(calculated_resolution - expected_resolution) < 0.001, \
-            f"Resolution mismatch: {calculated_resolution} vs {expected_resolution}"
-    
-    
+
+        assert (
+            abs(calculated_resolution - expected_resolution) < 0.001
+        ), f"Resolution mismatch: {calculated_resolution} vs {expected_resolution}"
+
     def test_fft_peak_detection_distance(self, synthetic_sine_signal):
         """Test peak detection with minimum distance parameter."""
         from scipy.signal import find_peaks
-        
+
         signal, fs, _ = synthetic_sine_signal
-        
+
         # Compute FFT
         fft_result = np.fft.rfft(signal)
         magnitudes = np.abs(fft_result)
-        
+
         # Find peaks with distance constraint
         peaks, _ = find_peaks(magnitudes, distance=1)
-        
+
         # Verify distance between peaks
         if len(peaks) > 1:
             distances = np.diff(peaks)
-            assert np.all(distances >= 1), \
-                "Peak distance constraint not satisfied"
-    
-    
+            assert np.all(distances >= 1), "Peak distance constraint not satisfied"
+
     def test_fft_with_noise(self):
         """Test FFT with noisy signal."""
         fs = 10000
         duration = 2.0
         freq = 100.0
         noise_level = 0.1
-        
+
         t = np.linspace(0, duration, int(fs * duration), endpoint=False)
         clean_signal = np.sin(2 * np.pi * freq * t)
         noise = np.random.normal(0, noise_level, len(clean_signal))
         noisy_signal = clean_signal + noise
-        
+
         # Compute FFT
         frequencies, magnitudes = _analyze_fft_computation(noisy_signal, fs)
-        
+
         # Find peak
         peak_idx = np.argmax(magnitudes)
         detected_freq = frequencies[peak_idx]
-        
+
         # Should still detect 100 Hz despite noise
-        assert abs(detected_freq - freq) < 2.0, \
-            f"Peak detection failed with noise: {detected_freq} Hz"
-    
-    
+        assert (
+            abs(detected_freq - freq) < 2.0
+        ), f"Peak detection failed with noise: {detected_freq} Hz"
+
     def test_fft_multiple_frequencies(self):
         """Test FFT with multiple frequency components."""
         fs = 10000
         duration = 2.0
         freqs = [50.0, 100.0, 150.0]  # Fundamental + harmonics
-        
+
         t = np.linspace(0, duration, int(fs * duration), endpoint=False)
         signal = sum(np.sin(2 * np.pi * f * t) for f in freqs)
-        
+
         # Compute FFT
         frequencies, magnitudes = _analyze_fft_computation(signal, fs)
-        
+
         # Find top 3 peaks
         from scipy.signal import find_peaks
-        peaks, _ = find_peaks(magnitudes, height=np.max(magnitudes)*0.3)
+
+        peaks, _ = find_peaks(magnitudes, height=np.max(magnitudes) * 0.3)
         top_peaks = sorted(peaks, key=lambda i: magnitudes[i], reverse=True)[:3]
         detected_freqs = [frequencies[p] for p in top_peaks]
-        
+
         # Verify all frequencies detected
         for expected_freq in freqs:
             closest = min(detected_freqs, key=lambda f: abs(f - expected_freq))
-            assert abs(closest - expected_freq) < 2.0, \
-                f"Failed to detect {expected_freq} Hz"
-    
-    
+            assert (
+                abs(closest - expected_freq) < 2.0
+            ), f"Failed to detect {expected_freq} Hz"
+
     def test_fft_segment_vs_full_signal(self, sample_healthy_signal, sample_metadata):
         """Compare FFT results: segment vs full signal."""
         signal = sample_healthy_signal
-        fs = sample_metadata['sampling_rate']
-        
+        fs = sample_metadata["sampling_rate"]
+
         # Full signal FFT
         fft_full = np.fft.rfft(signal)
         mag_full = np.abs(fft_full)
-        
+
         # Segment FFT
         segment = _extract_segment(signal, 1.0, fs)
         fft_segment = np.fft.rfft(segment)
         mag_segment = np.abs(fft_segment)
-        
+
         # Frequency resolution should differ
         res_full = fs / len(signal)
         res_segment = fs / len(segment)
-        
-        assert res_segment > res_full, \
-            "Segment should have coarser frequency resolution"
-    
-    
+
+        assert (
+            res_segment > res_full
+        ), "Segment should have coarser frequency resolution"
+
     def test_fft_error_handling_invalid_sampling_rate(self, synthetic_sine_signal):
         """Test error handling for invalid sampling rate."""
         signal, _, _ = synthetic_sine_signal
-        
+
         # Negative sampling rate: rfftfreq returns negative frequencies
         # but doesn't raise. Verify the result is invalid.
         fs_invalid = -1000
-        freqs = np.fft.rfftfreq(len(signal), 1/fs_invalid)
+        freqs = np.fft.rfftfreq(len(signal), 1 / fs_invalid)
         # With negative fs, frequencies should be non-positive (invalid)
-        assert np.all(freqs <= 0), \
-            "Negative sampling rate should produce non-positive frequencies"
-    
-    
+        assert np.all(
+            freqs <= 0
+        ), "Negative sampling rate should produce non-positive frequencies"
+
     def test_fft_error_handling_empty_signal(self):
         """Test error handling for empty signal."""
         empty_signal = np.array([])
-        
+
         with pytest.raises((ValueError, IndexError)):
             np.fft.rfft(empty_signal)
-    
-    
+
     def test_fft_real_bearing_data(self, sample_healthy_signal, sample_metadata):
         """Test FFT on real bearing data."""
         signal = sample_healthy_signal
-        fs = sample_metadata['sampling_rate']
-        
+        fs = sample_metadata["sampling_rate"]
+
         # Compute FFT
         frequencies, magnitudes = _analyze_fft_computation(signal, fs)
-        
+
         # Basic validation
         assert len(magnitudes) > 0, "FFT result is empty"
         assert np.all(magnitudes >= 0), "Magnitudes should be non-negative"
         assert np.max(magnitudes) > 0, "Signal appears to be all zeros"
-        
+
         # Should detect shaft frequency (25 Hz) or harmonics
-        shaft_freq = sample_metadata['shaft_speed']
+        shaft_freq = sample_metadata["shaft_speed"]
         tolerance = 5.0  # ±5 Hz
-        
+
         # Find peaks near shaft frequency
         from scipy.signal import find_peaks
-        peaks, _ = find_peaks(magnitudes, height=np.max(magnitudes)*0.01)
+
+        peaks, _ = find_peaks(magnitudes, height=np.max(magnitudes) * 0.01)
         peak_freqs = frequencies[peaks]
-        
+
         # Check if any peak is near shaft frequency or its harmonics
         found_shaft_related = False
         for harmonic in [1, 2, 3, 4]:
@@ -224,7 +223,7 @@ class TestFFTAnalysis:
             if any(abs(f - expected) < tolerance for f in peak_freqs):
                 found_shaft_related = True
                 break
-        
+
         # This is a soft check - shaft harmonics may not always be dominant
         # But we should at least have some peaks
         assert len(peak_freqs) > 0, "No peaks detected in spectrum"
@@ -232,21 +231,22 @@ class TestFFTAnalysis:
 
 # Helper function tests
 
+
 def test_extract_segment_center():
     """Test segment extraction from signal center."""
     signal = np.arange(1000)
     fs = 1000
     duration = 0.5  # 0.5 seconds
-    
+
     segment = _extract_segment(signal, duration, fs)
-    
+
     expected_length = int(duration * fs)
     assert len(segment) == expected_length
-    
+
     # Segment should be from center
     start_idx = (len(signal) - expected_length) // 2
-    expected_segment = signal[start_idx:start_idx + expected_length]
-    
+    expected_segment = signal[start_idx : start_idx + expected_length]
+
     np.testing.assert_array_equal(segment, expected_segment)
 
 
@@ -254,7 +254,7 @@ def test_extract_segment_full_signal():
     """Test extraction when duration=None (full signal)."""
     signal = np.arange(1000)
     fs = 1000
-    
+
     segment = _extract_segment(signal, None, fs)
-    
+
     np.testing.assert_array_equal(segment, signal)

--- a/tests/test_figures.py
+++ b/tests/test_figures.py
@@ -92,7 +92,10 @@ class TestMatchAnnotation:
     def test_only_the_matched_band_is_flagged_as_matched(self):
         freqs, mags = _spectrum()
         figure = build_annotated_envelope_figure(
-            freqs, mags, BEARING_FREQS, matched={"fault_type": "BPFO", "measured_hz": 80.5}
+            freqs,
+            mags,
+            BEARING_FREQS,
+            matched={"fault_type": "BPFO", "measured_hz": 80.5},
         )
         matched = [b for b in figure["bands"] if b["matched"]]
         assert [b["label"] for b in matched] == ["BPFO"]
@@ -127,9 +130,7 @@ class TestDegradation:
 
     def test_mismatched_array_lengths_raise(self):
         with pytest.raises(ValueError):
-            build_annotated_envelope_figure(
-                np.linspace(0, 100, 50), np.zeros(20), None
-            )
+            build_annotated_envelope_figure(np.linspace(0, 100, 50), np.zeros(20), None)
 
 
 class TestAxesAndScaling:
@@ -151,7 +152,10 @@ class TestAxesAndScaling:
 
         freqs, mags = _spectrum()
         figure = build_annotated_envelope_figure(
-            freqs, mags, BEARING_FREQS, matched={"fault_type": "BPFO", "measured_hz": 80.5}
+            freqs,
+            mags,
+            BEARING_FREQS,
+            matched={"fault_type": "BPFO", "measured_hz": 80.5},
         )
         json.dumps(figure)
 

--- a/tests/test_golden_merges.py
+++ b/tests/test_golden_merges.py
@@ -91,17 +91,15 @@ def assert_matches(new, old, path="", rel=1e-3, abs_tol=1e-6):
             assert_matches(new[key], old_val, path=f"{path}.{key}")
     elif isinstance(old, list):
         assert isinstance(new, (list, tuple)), f"{path}: expected list"
-        assert len(new) == len(old), (
-            f"{path}: length {len(new)} != golden {len(old)}"
-        )
+        assert len(new) == len(old), f"{path}: length {len(new)} != golden {len(old)}"
         for i, (n, o) in enumerate(zip(new, old)):
             assert_matches(n, o, path=f"{path}[{i}]")
     elif isinstance(old, bool) or old is None or isinstance(old, str):
         assert new == old, f"{path}: {new!r} != golden {old!r}"
     elif isinstance(old, (int, float)):
-        assert new == pytest.approx(old, rel=rel, abs=abs_tol), (
-            f"{path}: {new} != golden {old}"
-        )
+        assert new == pytest.approx(
+            old, rel=rel, abs=abs_tol
+        ), f"{path}: {new} != golden {old}"
     else:  # pragma: no cover - snapshot only holds JSON types
         assert new == old, f"{path}: {new!r} != golden {old!r}"
 
@@ -130,9 +128,7 @@ class TestGoldenAssessSeverity:
         assert_matches(new.model_dump(mode="json"), old, path="signal_route")
 
     @pytest.mark.asyncio
-    async def test_signal_route_group1_flexible(
-        self, golden, golden_repo, mock_ctx
-    ):
+    async def test_signal_route_group1_flexible(self, golden, golden_repo, mock_ctx):
         old = golden["assess_severity"]["signal_route_group1_flexible"]
         new = await assess_severity(
             ctx=mock_ctx,
@@ -143,9 +139,7 @@ class TestGoldenAssessSeverity:
         assert_matches(new.model_dump(mode="json"), old, path="g1_flex")
 
     @pytest.mark.asyncio
-    async def test_signal_route_velocity_signal(
-        self, golden, golden_repo, mock_ctx
-    ):
+    async def test_signal_route_velocity_signal(self, golden, golden_repo, mock_ctx):
         old = golden["assess_severity"]["signal_route_vel3"]
         new = await assess_severity(ctx=mock_ctx, signal_id="golden_vel3")
         assert_matches(new.model_dump(mode="json"), old, path="vel3")
@@ -199,9 +193,7 @@ class TestGoldenAssessSeverity:
         )
         assert new.frequency_range == old["frequency_range"]
         assert "2-1000" in new.frequency_range
-        assert new.rms_velocity_mm_s == pytest.approx(
-            old["rms_velocity"], rel=1e-3
-        )
+        assert new.rms_velocity_mm_s == pytest.approx(old["rms_velocity"], rel=1e-3)
 
     @pytest.mark.asyncio
     async def test_rms_route_matches_check_vibration_alert(
@@ -264,9 +256,7 @@ class TestGoldenAnalyzeEnvelope:
         assert tuple(dump["filter_band"]) == tuple(old["frequency_range"])
 
     @pytest.mark.asyncio
-    async def test_matches_old_tool_on_narrow_band(
-        self, golden, golden_repo, mock_ctx
-    ):
+    async def test_matches_old_tool_on_narrow_band(self, golden, golden_repo, mock_ctx):
         old = golden["analyze_envelope"]["spectrum_route_noise_band"]
         new = await analyze_envelope(
             ctx=mock_ctx,
@@ -310,9 +300,7 @@ class TestGoldenCheckBearingFaults:
         }
 
     @pytest.mark.asyncio
-    async def test_bearing_route_noise_signal(
-        self, golden, golden_repo, mock_ctx
-    ):
+    async def test_bearing_route_noise_signal(self, golden, golden_repo, mock_ctx):
         old = golden["check_bearing_faults"]["bearing_route_noise"]
         new = await check_bearing_faults(
             ctx=mock_ctx,
@@ -351,7 +339,8 @@ class TestGoldenCheckBearingFaults:
             rpm=1800.0,
         )
         bpfo = next(
-            c for c in new.model_dump(mode="json")["fault_checks"]
+            c
+            for c in new.model_dump(mode="json")["fault_checks"]
             if c["fault_type"] == "BPFO"
         )
         assert_matches(bpfo, old, path="single_bpfo")
@@ -376,9 +365,7 @@ class TestGoldenAnalyzeSignalTrend:
         assert_matches(new.model_dump(mode="json"), old, path="trend")
 
     @pytest.mark.asyncio
-    async def test_trend_stationary_preserved(
-        self, golden, golden_repo, mock_ctx
-    ):
+    async def test_trend_stationary_preserved(self, golden, golden_repo, mock_ctx):
         old = golden["analyze_signal_trend"]["trend_stationary"]
         new = await analyze_signal_trend(
             ctx=mock_ctx,
@@ -450,9 +437,7 @@ class TestAssessSeverityScenarios:
         assert stored.rms_velocity_mm_s == pytest.approx(3.0, rel=0.02)
 
     @pytest.mark.asyncio
-    async def test_declared_power_below_scope_refused(
-        self, golden_repo, mock_ctx
-    ):
+    async def test_declared_power_below_scope_refused(self, golden_repo, mock_ctx):
         with pytest.raises(ValueError, match="15 kW"):
             await assess_severity(
                 ctx=mock_ctx, rms_velocity_mm_s=3.0, machine_power_kw=5.0
@@ -479,9 +464,7 @@ class TestAssessSeverityScenarios:
         assert r.machine_power_kw == 90.0
 
     @pytest.mark.asyncio
-    async def test_both_inputs_is_mutual_exclusion_error(
-        self, golden_repo, mock_ctx
-    ):
+    async def test_both_inputs_is_mutual_exclusion_error(self, golden_repo, mock_ctx):
         with pytest.raises(ValueError, match="exactly one"):
             await assess_severity(
                 ctx=mock_ctx, signal_id="golden_vel3", rms_velocity_mm_s=3.0
@@ -498,9 +481,7 @@ class TestAssessSeverityScenarios:
             await assess_severity(ctx=mock_ctx, rms_velocity_mm_s=-1.0)
 
     @pytest.mark.asyncio
-    async def test_invalid_custom_thresholds_rejected(
-        self, golden_repo, mock_ctx
-    ):
+    async def test_invalid_custom_thresholds_rejected(self, golden_repo, mock_ctx):
         # Not strictly increasing
         with pytest.raises(ValueError, match="warning < alarm < danger"):
             await assess_severity(
@@ -517,9 +498,7 @@ class TestAssessSeverityScenarios:
             )
 
     @pytest.mark.asyncio
-    async def test_custom_thresholds_on_signal_route(
-        self, golden_repo, mock_ctx
-    ):
+    async def test_custom_thresholds_on_signal_route(self, golden_repo, mock_ctx):
         """Custom thresholds also apply to the RMS computed from a stored
         signal (golden_vel3 has ~3.0 mm/s -> zone B for 2/4/6)."""
         r = await assess_severity(
@@ -560,9 +539,7 @@ class TestCheckBearingFaultsScenarios:
         assert r.source == "user-provided frequencies"
 
     @pytest.mark.asyncio
-    async def test_geometry_route_matches_catalog_route(
-        self, golden_repo, mock_ctx
-    ):
+    async def test_geometry_route_matches_catalog_route(self, golden_repo, mock_ctx):
         """The 6205 catalog entry IS the CWRU geometry: passing that
         geometry explicitly must produce the same expected frequencies as
         the catalog route."""
@@ -619,9 +596,7 @@ class TestCheckBearingFaultsScenarios:
             )
 
     @pytest.mark.asyncio
-    async def test_empty_or_invalid_frequencies_rejected(
-        self, golden_repo, mock_ctx
-    ):
+    async def test_empty_or_invalid_frequencies_rejected(self, golden_repo, mock_ctx):
         with pytest.raises(ValueError, match="empty"):
             await check_bearing_faults(
                 ctx=mock_ctx,
@@ -655,9 +630,7 @@ class TestCheckBearingFaultsScenarios:
 
 class TestAnalyzeEnvelopeScenarios:
     @pytest.mark.asyncio
-    async def test_band_above_nyquist_raises_no_clamp(
-        self, golden_repo, mock_ctx
-    ):
+    async def test_band_above_nyquist_raises_no_clamp(self, golden_repo, mock_ctx):
         """fs = 10 kHz -> Nyquist 5 kHz: filter_high=6000 is an error, the
         band is never silently clamped."""
         with pytest.raises(ValueError, match="Nyquist"):
@@ -711,9 +684,7 @@ class TestAnalyzeEnvelopeScenarios:
 
 class TestAnalyzeSignalTrendScenarios:
     @pytest.mark.asyncio
-    async def test_returns_trend_and_onset_together(
-        self, golden_repo, mock_ctx
-    ):
+    async def test_returns_trend_and_onset_together(self, golden_repo, mock_ctx):
         r = await analyze_signal_trend(
             ctx=mock_ctx,
             signal_id="golden_trend",

--- a/tests/test_import_provenance.py
+++ b/tests/test_import_provenance.py
@@ -66,9 +66,9 @@ def test_submodules_resolve_inside_this_checkout():
 
     for module in (server, mcp_tools):
         resolved = Path(module.__file__).resolve()
-        assert resolved.is_relative_to(SRC_DIR), (
-            f"{module.__name__} imported from {resolved}, outside {SRC_DIR}"
-        )
+        assert resolved.is_relative_to(
+            SRC_DIR
+        ), f"{module.__name__} imported from {resolved}, outside {SRC_DIR}"
 
 
 @needs_pin
@@ -98,9 +98,9 @@ def test_a_child_process_also_resolves_into_this_checkout():
     )
     assert proc.returncode == 0, proc.stderr
     resolved = Path(proc.stdout.strip()).resolve()
-    assert resolved == (SRC_DIR / "__init__.py").resolve(), (
-        f"child process imported {resolved}, not this checkout"
-    )
+    assert (
+        resolved == (SRC_DIR / "__init__.py").resolve()
+    ), f"child process imported {resolved}, not this checkout"
 
 
 class TestTheGuardItself:
@@ -126,9 +126,9 @@ class TestTheGuardItself:
             (i for i, n in enumerate(names) if "editable" in n.lower()), None
         )
         if editable is not None:
-            assert pin < editable, (
-                f"pin at {pin} sits behind the editable finder at {editable}"
-            )
+            assert (
+                pin < editable
+            ), f"pin at {pin} sits behind the editable finder at {editable}"
 
     def test_the_tripwire_fires_when_the_package_resolves_elsewhere(
         self, tmp_path, monkeypatch
@@ -173,9 +173,9 @@ class TestTheGuardItself:
         from conftest import _LocalTreeFinder
 
         for name in ("numpy", f"{PKG}_extra", f"{PKG}.mcp_tools", "json"):
-            assert _LocalTreeFinder.find_spec(name) is None, (
-                f"the pin claimed {name!r}; it must only claim {PKG!r}"
-            )
+            assert (
+                _LocalTreeFinder.find_spec(name) is None
+            ), f"the pin claimed {name!r}; it must only claim {PKG!r}"
         assert _LocalTreeFinder.find_spec(PKG) is not None
 
 
@@ -218,9 +218,9 @@ def test_pyproject_version_matches_source_version():
         for line in source.splitlines()
         if line.startswith("__version__")
     )
-    assert in_source == declared, (
-        f"src/__init__.py says {in_source}, pyproject.toml says {declared}"
-    )
+    assert (
+        in_source == declared
+    ), f"src/__init__.py says {in_source}, pyproject.toml says {declared}"
 
 
 def test_installed_distribution_is_not_stale():

--- a/tests/test_integrated_report.py
+++ b/tests/test_integrated_report.py
@@ -261,7 +261,8 @@ class TestPdfRendering:
         try:
             extracted = _pdf_text(path)
             missing = [
-                s for s in collect_statements(advisory)
+                s
+                for s in collect_statements(advisory)
                 if _normalise(s) not in extracted
             ]
             assert missing == [], f"PDF dropped authored statements: {missing}"
@@ -290,9 +291,9 @@ class TestPdfRendering:
             for statement in collect_statements(advisory):
                 in_html = html.escape(statement) in rendered_html
                 in_pdf = _normalise(statement) in extracted_pdf
-                assert in_html == in_pdf is True, (
-                    f"statement present in one rendering only: {statement}"
-                )
+                assert (
+                    in_html == in_pdf is True
+                ), f"statement present in one rendering only: {statement}"
         finally:
             html_path.unlink()
             pdf_path.unlink()
@@ -304,9 +305,7 @@ class TestFormatValidation:
             save_integrated_diagnostic_report(advisory, figure, formats=["docx"])
 
     @pytest.mark.skipif(HAS_PDF, reason="PDF extra installed")
-    def test_missing_pdf_dependency_raises_with_an_install_hint(
-        self, advisory, figure
-    ):
+    def test_missing_pdf_dependency_raises_with_an_install_hint(self, advisory, figure):
         with pytest.raises(ValueError, match=r"\[pdf\]"):
             save_integrated_diagnostic_report(advisory, figure, formats=["pdf"])
 

--- a/tests/test_iso20816.py
+++ b/tests/test_iso20816.py
@@ -55,9 +55,9 @@ class TestThresholdTable:
         ids=lambda v: str(v),
     )
     def test_boundaries_match_iso_10816_3_2009(self, group, support):
-        assert get_zone_boundaries(group, support) == EXPECTED_BOUNDARIES[
-            (group, support)
-        ]
+        assert (
+            get_zone_boundaries(group, support) == EXPECTED_BOUNDARIES[(group, support)]
+        )
 
     @pytest.mark.parametrize(
         "group,support",
@@ -373,7 +373,10 @@ class TestResultStructure:
     def test_boundaries_dict(self):
         signal = make_velocity_signal(1.0)
         result = assess_severity_with_axis(
-            signal, fs=10000, machine_group=2, support_type="rigid",
+            signal,
+            fs=10000,
+            machine_group=2,
+            support_type="rigid",
             signal_unit="mm/s",
         )
         assert "AB" in result["boundaries"]

--- a/tests/test_kalman_rul.py
+++ b/tests/test_kalman_rul.py
@@ -23,9 +23,7 @@ def _reference_filter_covariance(
     dt = sampling_interval
     F = np.array([[1.0, dt], [0.0, 1.0]])
     H = np.array([[1.0, 0.0]])
-    Q = process_noise * np.array(
-        [[dt**3 / 3.0, dt**2 / 2.0], [dt**2 / 2.0, dt]]
-    )
+    Q = process_noise * np.array([[dt**3 / 3.0, dt**2 / 2.0], [dt**2 / 2.0, dt]])
     R = np.array([[measurement_noise]])
 
     x = np.array([y[0], (y[1] - y[0]) / dt])
@@ -131,8 +129,12 @@ class TestKalmanRUL:
     def test_sampling_interval_scaling(self):
         """RUL should scale with the sampling interval."""
         series = [float(i) for i in range(50)]
-        result_1 = estimate_rul_kalman(series, failure_threshold=200.0, sampling_interval=1.0)
-        result_2 = estimate_rul_kalman(series, failure_threshold=200.0, sampling_interval=2.0)
+        result_1 = estimate_rul_kalman(
+            series, failure_threshold=200.0, sampling_interval=1.0
+        )
+        result_2 = estimate_rul_kalman(
+            series, failure_threshold=200.0, sampling_interval=2.0
+        )
 
         assert result_1 is not None and result_2 is not None
         # With 2x sampling interval, RUL (in time units) should roughly double.
@@ -170,9 +172,7 @@ class TestKalmanRUL:
         gap = threshold - level
 
         full_var = (
-            var_l / rate**2
-            + gap**2 * var_r / rate**4
-            + 2.0 * gap * cov_lr / rate**3
+            var_l / rate**2 + gap**2 * var_r / rate**4 + 2.0 * gap * cov_lr / rate**3
         )
         without_cov = var_l / rate**2 + gap**2 * var_r / rate**4
 
@@ -182,6 +182,4 @@ class TestKalmanRUL:
         # The cross-covariance is non-zero for this filter, so omitting it
         # must give a measurably different standard deviation.
         assert abs(cov_lr) > 0
-        assert result["rul_std"] != pytest.approx(
-            math.sqrt(without_cov), rel=1e-3
-        )
+        assert result["rul_std"] != pytest.approx(math.sqrt(without_cov), rel=1e-3)

--- a/tests/test_ml_tools.py
+++ b/tests/test_ml_tools.py
@@ -18,283 +18,291 @@ import json
 
 class TestFeatureExtraction:
     """Test suite for extract_features_from_signal tool."""
-    
+
     def test_feature_extraction_synthetic(self):
         """Test feature extraction on synthetic signal."""
         # Generate synthetic signal
         fs = 10000
         duration = 1.0
         t = np.linspace(0, duration, int(fs * duration), endpoint=False)
-        signal = np.sin(2*np.pi*50*t) + 0.1*np.random.randn(len(t))
-        
+        signal = np.sin(2 * np.pi * 50 * t) + 0.1 * np.random.randn(len(t))
+
         # Extract features from full signal
         features = self._extract_time_domain_features(signal)
-        
+
         # Verify feature dictionary
         expected_features = [
-            'mean', 'std', 'rms', 'peak', 'peak_to_peak',
-            'crest_factor', 'kurtosis', 'skewness', 'clearance_factor',
-            'shape_factor', 'impulse_factor', 'power', 'entropy'
+            "mean",
+            "std",
+            "rms",
+            "peak",
+            "peak_to_peak",
+            "crest_factor",
+            "kurtosis",
+            "skewness",
+            "clearance_factor",
+            "shape_factor",
+            "impulse_factor",
+            "power",
+            "entropy",
         ]
-        
+
         for feat in expected_features:
             assert feat in features, f"Missing feature: {feat}"
-            assert isinstance(features[feat], (int, float)), \
-                f"Feature {feat} is not numeric: {type(features[feat])}"
-    
-    
+            assert isinstance(
+                features[feat], (int, float)
+            ), f"Feature {feat} is not numeric: {type(features[feat])}"
+
     def test_feature_rms_calculation(self):
         """Test RMS feature calculation."""
         # Signal with known RMS
         signal = np.array([1.0, -1.0, 1.0, -1.0])
         rms_expected = 1.0
         rms_calculated = np.sqrt(np.mean(signal**2))
-        
+
         assert abs(rms_calculated - rms_expected) < 0.001
-    
-    
+
     def test_feature_kurtosis(self):
         """Test kurtosis calculation."""
         from scipy.stats import kurtosis
-        
+
         # Normal distribution has kurtosis ~ 0 (excess kurtosis)
         signal_normal = np.random.randn(1000)
         kurt = kurtosis(signal_normal)
-        
+
         # Excess kurtosis should be close to 0 for normal distribution
         assert abs(kurt) < 1.0, f"Kurtosis for normal: {kurt}"
-        
+
         # Signal with outliers should have high kurtosis
-        signal_outliers = np.concatenate([np.random.randn(990), np.array([10]*10)])
+        signal_outliers = np.concatenate([np.random.randn(990), np.array([10] * 10)])
         kurt_outliers = kurtosis(signal_outliers)
-        
+
         assert kurt_outliers > kurt, "Outliers should increase kurtosis"
-    
-    
+
     def test_feature_crest_factor(self):
         """Test crest factor calculation."""
         # Sine wave: peak = 1, RMS = 1/sqrt(2), crest factor = sqrt(2)
-        signal = np.sin(np.linspace(0, 2*np.pi, 1000))
+        signal = np.sin(np.linspace(0, 2 * np.pi, 1000))
         peak = np.max(np.abs(signal))
         rms = np.sqrt(np.mean(signal**2))
         crest_factor = peak / rms
-        
+
         expected_crest = np.sqrt(2)
-        assert abs(crest_factor - expected_crest) < 0.01, \
-            f"Crest factor: {crest_factor} vs expected {expected_crest}"
-    
-    
+        assert (
+            abs(crest_factor - expected_crest) < 0.01
+        ), f"Crest factor: {crest_factor} vs expected {expected_crest}"
+
     def test_feature_segmentation(self):
         """Test sliding window segmentation."""
         signal = np.arange(1000)
         fs = 1000
         segment_duration = 0.2  # 200 samples
         overlap_ratio = 0.5  # 50% overlap
-        
+
         segment_length = int(segment_duration * fs)  # 200
         hop_length = int(segment_length * (1 - overlap_ratio))  # 100
-        
+
         segments = []
         for start in range(0, len(signal) - segment_length + 1, hop_length):
-            segment = signal[start:start + segment_length]
+            segment = signal[start : start + segment_length]
             segments.append(segment)
-        
+
         # Verify number of segments
         expected_segments = (len(signal) - segment_length) // hop_length + 1
-        assert len(segments) == expected_segments, \
-            f"Expected {expected_segments} segments, got {len(segments)}"
-        
+        assert (
+            len(segments) == expected_segments
+        ), f"Expected {expected_segments} segments, got {len(segments)}"
+
         # Verify segment overlap
         if len(segments) > 1:
-            overlap = segments[0][hop_length:] 
-            next_start = segments[1][:segment_length - hop_length]
+            overlap = segments[0][hop_length:]
+            next_start = segments[1][: segment_length - hop_length]
             np.testing.assert_array_equal(overlap, next_start)
-    
-    
+
     def test_feature_extraction_real_data(self, sample_healthy_signal):
         """Test feature extraction on real bearing data."""
         signal = sample_healthy_signal[:10000]  # Use 10k samples for speed
-        
+
         features = self._extract_time_domain_features(signal)
-        
+
         # All features should be finite
         for key, value in features.items():
             assert np.isfinite(value), f"Feature {key} is not finite: {value}"
-        
+
         # RMS should be positive
-        assert features['rms'] > 0, "RMS should be positive"
-        
+        assert features["rms"] > 0, "RMS should be positive"
+
         # Crest factor should be > 1 for real signals
-        assert features['crest_factor'] > 1.0, \
-            f"Crest factor should be > 1, got {features['crest_factor']}"
-    
-    
+        assert (
+            features["crest_factor"] > 1.0
+        ), f"Crest factor should be > 1, got {features['crest_factor']}"
+
     def _extract_time_domain_features(self, signal):
         """Helper: Extract time-domain features."""
         from scipy.stats import kurtosis, skew, entropy
-        
+
         mean_val = np.mean(signal)
         std_val = np.std(signal)
         rms_val = np.sqrt(np.mean(signal**2))
         peak_val = np.max(np.abs(signal))
         peak_to_peak_val = np.ptp(signal)
-        
+
         crest_factor_val = peak_val / (rms_val + 1e-10)
         kurtosis_val = kurtosis(signal)
         skewness_val = skew(signal)
-        
+
         shape_factor_val = rms_val / (np.mean(np.abs(signal)) + 1e-10)
         impulse_factor_val = peak_val / (np.mean(np.abs(signal)) + 1e-10)
-        clearance_factor_val = peak_val / (np.mean(np.sqrt(np.abs(signal)))**2 + 1e-10)
-        
+        clearance_factor_val = peak_val / (
+            np.mean(np.sqrt(np.abs(signal))) ** 2 + 1e-10
+        )
+
         power_val = np.mean(signal**2)
         hist, _ = np.histogram(signal, bins=50)
         hist = hist / (np.sum(hist) + 1e-10)
         entropy_val = entropy(hist + 1e-10)
-        
+
         return {
-            'mean': mean_val,
-            'std': std_val,
-            'rms': rms_val,
-            'peak': peak_val,
-            'peak_to_peak': peak_to_peak_val,
-            'crest_factor': crest_factor_val,
-            'kurtosis': kurtosis_val,
-            'skewness': skewness_val,
-            'shape_factor': shape_factor_val,
-            'impulse_factor': impulse_factor_val,
-            'clearance_factor': clearance_factor_val,
-            'power': power_val,
-            'entropy': entropy_val
+            "mean": mean_val,
+            "std": std_val,
+            "rms": rms_val,
+            "peak": peak_val,
+            "peak_to_peak": peak_to_peak_val,
+            "crest_factor": crest_factor_val,
+            "kurtosis": kurtosis_val,
+            "skewness": skewness_val,
+            "shape_factor": shape_factor_val,
+            "impulse_factor": impulse_factor_val,
+            "clearance_factor": clearance_factor_val,
+            "power": power_val,
+            "entropy": entropy_val,
         }
 
 
 class TestMLTraining:
     """Test suite for train_anomaly_model tool."""
-    
+
     def test_oneclass_svm_training(self):
         """Test OneClassSVM model training."""
         from sklearn.svm import OneClassSVM
         from sklearn.preprocessing import StandardScaler
-        
+
         # Generate training data (healthy)
         X_train = np.random.randn(100, 5)
-        
+
         # Standardize
         scaler = StandardScaler()
         X_scaled = scaler.fit_transform(X_train)
-        
+
         # Train model
-        model = OneClassSVM(kernel='rbf', gamma='auto', nu=0.1)
+        model = OneClassSVM(kernel="rbf", gamma="auto", nu=0.1)
         model.fit(X_scaled)
-        
+
         # Predict on training data (should mostly be +1)
         predictions = model.predict(X_scaled)
         inlier_ratio = np.sum(predictions == 1) / len(predictions)
-        
-        assert inlier_ratio >= 0.8, \
-            f"Too many outliers in training data: {inlier_ratio}"
-    
-    
+
+        assert (
+            inlier_ratio >= 0.8
+        ), f"Too many outliers in training data: {inlier_ratio}"
+
     def test_local_outlier_factor(self):
         """Test LocalOutlierFactor model."""
         from sklearn.neighbors import LocalOutlierFactor
-        
+
         # Generate training data
         X_train = np.random.randn(100, 5)
-        
+
         # Train model (novelty=True for prediction)
         model = LocalOutlierFactor(novelty=True, contamination=0.1)
         model.fit(X_train)
-        
+
         # Predict on similar data (should be inliers)
         X_test = np.random.randn(20, 5)
         predictions = model.predict(X_test)
-        
+
         # Most should be inliers (+1)
         inlier_ratio = np.sum(predictions == 1) / len(predictions)
         assert inlier_ratio > 0.5
-    
-    
+
     def test_pca_dimensionality_reduction(self):
         """Test PCA for feature reduction."""
         from sklearn.decomposition import PCA
-        
+
         # Generate high-dimensional data
         X = np.random.randn(100, 17)  # 17 features
-        
+
         # Apply PCA
         pca = PCA(n_components=0.95)  # Keep 95% variance
         X_reduced = pca.fit_transform(X)
-        
+
         # Reduced dimensions should be < 17
-        assert X_reduced.shape[1] < X.shape[1], \
-            f"PCA didn't reduce dimensions: {X_reduced.shape[1]}"
-        
+        assert (
+            X_reduced.shape[1] < X.shape[1]
+        ), f"PCA didn't reduce dimensions: {X_reduced.shape[1]}"
+
         # Variance explained should be >= 0.95
         var_explained = np.sum(pca.explained_variance_ratio_)
-        assert var_explained >= 0.95, \
-            f"Variance explained: {var_explained}"
-    
-    
+        assert var_explained >= 0.95, f"Variance explained: {var_explained}"
+
     def test_model_persistence(self):
         """Test model save/load with pickle."""
         import pickle
         from sklearn.svm import OneClassSVM
-        
+
         # Train model
         X_train = np.random.randn(100, 5)
         model = OneClassSVM()
         model.fit(X_train)
-        
+
         # Save to temporary file
-        with tempfile.NamedTemporaryFile(delete=False, suffix='.pkl') as f:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pkl") as f:
             pickle.dump(model, f)
             temp_path = f.name
-        
+
         try:
             # Load model
-            with open(temp_path, 'rb') as f:
+            with open(temp_path, "rb") as f:
                 model_loaded = pickle.load(f)
-            
+
             # Predictions should match
             X_test = np.random.randn(10, 5)
             pred_original = model.predict(X_test)
             pred_loaded = model_loaded.predict(X_test)
-            
+
             np.testing.assert_array_equal(pred_original, pred_loaded)
         finally:
             # Cleanup
             Path(temp_path).unlink()
-    
-    
-    def test_training_validation_split(self, sample_healthy_signal, sample_faulty_signal):
+
+    def test_training_validation_split(
+        self, sample_healthy_signal, sample_faulty_signal
+    ):
         """Test model training with validation."""
         from sklearn.svm import OneClassSVM
         from sklearn.preprocessing import StandardScaler
-        
+
         # Extract features from healthy (simplified)
         healthy_features = self._simple_features(sample_healthy_signal[:50000])
         faulty_features = self._simple_features(sample_faulty_signal[:50000])
-        
+
         # Train on healthy
         scaler = StandardScaler()
         X_train = scaler.fit_transform([healthy_features])
-        
+
         model = OneClassSVM()
         model.fit(X_train)
-        
+
         # Validate: healthy should be +1, faulty should be -1
         healthy_pred = model.predict(scaler.transform([healthy_features]))[0]
         faulty_pred = model.predict(scaler.transform([faulty_features]))[0]
-        
+
         # This is probabilistic, but generally should work
         # With OneClassSVM on a single sample, results may vary
         # Soft check: healthy might also be -1 with 1 training sample
         # assert healthy_pred == 1, "Healthy data misclassified"
         # Faulty might still be +1 if features are similar, so soft check
-    
-    
+
     def _simple_features(self, signal):
         """Helper: Extract simple features."""
         return [
@@ -302,83 +310,81 @@ class TestMLTraining:
             np.std(signal),
             np.sqrt(np.mean(signal**2)),
             np.max(np.abs(signal)),
-            np.ptp(signal)
+            np.ptp(signal),
         ]
 
 
 class TestMLPrediction:
     """Test suite for predict_anomalies tool."""
-    
+
     def test_anomaly_prediction_healthy(self):
         """Test prediction on healthy-like data."""
         from sklearn.svm import OneClassSVM
         from sklearn.preprocessing import StandardScaler
-        
+
         # Train on healthy
         np.random.seed(42)  # Reproducible
         X_train = np.random.randn(100, 5)
         scaler = StandardScaler()
         X_scaled = scaler.fit_transform(X_train)
-        
+
         model = OneClassSVM(nu=0.1)
         model.fit(X_scaled)
-        
+
         # Test on similar healthy data
         X_test = np.random.randn(20, 5)
         X_test_scaled = scaler.transform(X_test)
         predictions = model.predict(X_test_scaled)
-        
+
         # Calculate anomaly ratio
         anomaly_count = np.sum(predictions == -1)
         anomaly_ratio = anomaly_count / len(predictions)
-        
+
         # Should be mostly normal (low anomaly ratio)
         # OneClassSVM default nu=0.5 means up to 50% can be outliers
         # Use nu=0.1 for tighter boundary
         assert anomaly_ratio < 0.6, f"Too many anomalies: {anomaly_ratio}"
-    
-    
+
     def test_anomaly_prediction_faulty(self):
         """Test prediction on faulty-like data."""
         from sklearn.svm import OneClassSVM
         from sklearn.preprocessing import StandardScaler
-        
+
         # Train on healthy
         X_train = np.random.randn(100, 5)
         scaler = StandardScaler()
         X_scaled = scaler.fit_transform(X_train)
-        
+
         model = OneClassSVM(nu=0.1)
         model.fit(X_scaled)
-        
+
         # Test on anomalous data (shifted distribution)
         X_test = np.random.randn(20, 5) + 5  # Shifted by 5 std devs
         X_test_scaled = scaler.transform(X_test)
         predictions = model.predict(X_test_scaled)
-        
+
         # Should detect many anomalies
         anomaly_count = np.sum(predictions == -1)
         anomaly_ratio = anomaly_count / len(predictions)
-        
+
         # Should have high anomaly ratio
         assert anomaly_ratio > 0.5, f"Anomalies not detected: {anomaly_ratio}"
-    
-    
+
     def test_health_status_classification(self):
         """Test overall health status determination."""
         # Test different anomaly ratios
         test_cases = [
-            (0.05, "Healthy"),      # 5% anomalies
-            (0.15, "Suspicious"),   # 15% anomalies
-            (0.40, "Faulty"),       # 40% anomalies
+            (0.05, "Healthy"),  # 5% anomalies
+            (0.15, "Suspicious"),  # 15% anomalies
+            (0.40, "Faulty"),  # 40% anomalies
         ]
-        
+
         for anomaly_ratio, expected_status in test_cases:
             status = self._classify_health(anomaly_ratio)
-            assert status == expected_status, \
-                f"Ratio {anomaly_ratio}: expected {expected_status}, got {status}"
-    
-    
+            assert (
+                status == expected_status
+            ), f"Ratio {anomaly_ratio}: expected {expected_status}, got {status}"
+
     def _classify_health(self, anomaly_ratio):
         """Helper: Classify health based on anomaly ratio."""
         if anomaly_ratio < 0.1:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,13 +25,15 @@ from predictive_maintenance_mcp.models import (
     AnomalyPredictionResult,
 )
 
-
 # ── SpectralPeak ───────────────────────────────────────────────────────────
+
 
 class TestSpectralPeak:
 
     def test_creation(self):
-        p = SpectralPeak(frequency_hz=120.5, magnitude=0.015, magnitude_db=5.2, note="1x")
+        p = SpectralPeak(
+            frequency_hz=120.5, magnitude=0.015, magnitude_db=5.2, note="1x"
+        )
         assert p.frequency_hz == 120.5
         assert p.note == "1x"
 
@@ -47,6 +49,7 @@ class TestSpectralPeak:
 
 
 # ── FFTResult ──────────────────────────────────────────────────────────────
+
 
 class TestFFTResult:
 
@@ -88,6 +91,7 @@ class TestFFTResult:
 
 # ── EnvelopeResult ─────────────────────────────────────────────────────────
 
+
 class TestEnvelopeResult:
 
     def test_creation(self):
@@ -114,14 +118,21 @@ class TestEnvelopeResult:
 
 # ── StatisticalResult ──────────────────────────────────────────────────────
 
+
 class TestStatisticalResult:
 
     def test_creation_with_declared_unit(self):
         r = StatisticalResult(
-            rms=5.234, peak_to_peak=18.5, peak=9.25,
-            crest_factor=1.77, kurtosis=3.0, skewness=0.01,
-            mean=0.001, std_dev=5.234,
-            signal_unit="g", unit_note="Signal unit declared as 'g' in metadata.",
+            rms=5.234,
+            peak_to_peak=18.5,
+            peak=9.25,
+            crest_factor=1.77,
+            kurtosis=3.0,
+            skewness=0.01,
+            mean=0.001,
+            std_dev=5.234,
+            signal_unit="g",
+            unit_note="Signal unit declared as 'g' in metadata.",
         )
         assert r.rms == 5.234
         assert r.signal_unit == "g"
@@ -129,9 +140,14 @@ class TestStatisticalResult:
     def test_undeclared_unit_is_none(self):
         """The unit is None when not declared — never guessed from amplitude."""
         r = StatisticalResult(
-            rms=5.234, peak_to_peak=18.5, peak=9.25,
-            crest_factor=1.77, kurtosis=3.0, skewness=0.01,
-            mean=0.001, std_dev=5.234,
+            rms=5.234,
+            peak_to_peak=18.5,
+            peak=9.25,
+            crest_factor=1.77,
+            kurtosis=3.0,
+            skewness=0.01,
+            mean=0.001,
+            std_dev=5.234,
             unit_note="Signal unit NOT declared.",
         )
         assert r.signal_unit is None
@@ -142,13 +158,17 @@ class TestStatisticalResult:
 # (Replaces the removed orphaned SignalInfo model — StoredSignalInfo is the
 #  live signal-metadata contract.)
 
+
 class TestStoredSignalInfo:
 
     def _make(self, **kwargs):
         base = dict(
-            signal_id="sig1", filepath="/data/test.csv",
-            load_timestamp="2026-07-13T00:00:00", shape=[10000],
-            num_samples=10000, size_bytes=80000,
+            signal_id="sig1",
+            filepath="/data/test.csv",
+            load_timestamp="2026-07-13T00:00:00",
+            shape=[10000],
+            num_samples=10000,
+            size_bytes=80000,
         )
         base.update(kwargs)
         return StoredSignalInfo(**base)
@@ -171,6 +191,7 @@ class TestStoredSignalInfo:
 
 
 # ── Canonical fault vocabulary (drift guard) ───────────────────────────────
+
 
 class TestFaultVocabularySync:
 
@@ -200,14 +221,19 @@ class TestFaultVocabularySync:
 
 # ── VibrationSeverityResult (unified severity model) ─────────────────────
 
+
 class TestVibrationSeverityResult:
 
     def _make(self, zone="B", **kwargs):
         base = dict(
-            signal_id="s", rms_velocity_mm_s=2.0, machine_group=2,
+            signal_id="s",
+            rms_velocity_mm_s=2.0,
+            machine_group=2,
             support_type="rigid",
-            zone=zone, zone_description="desc",
-            severity_level="Acceptable", color_code="yellow",
+            zone=zone,
+            zone_description="desc",
+            severity_level="Acceptable",
+            color_code="yellow",
             boundaries={"AB": 1.4, "BC": 2.8, "CD": 4.5},
             frequency_range="10-1000 Hz",
             unit_conversion_performed=False,
@@ -236,6 +262,7 @@ class TestVibrationSeverityResult:
     def test_old_iso20816result_model_removed(self):
         """U9 clean cut: the duplicate ISO result model is gone."""
         import predictive_maintenance_mcp.models as models
+
         assert not hasattr(models, "ISO20816Result")
         assert not hasattr(models, "AlertResult")
         assert not hasattr(models, "EnvelopeSpectrumResult")
@@ -243,6 +270,7 @@ class TestVibrationSeverityResult:
 
 
 # ── ISOSeverityRefusal ────────────────────────────────────────────────────
+
 
 class TestISOSeverityRefusal:
 
@@ -263,7 +291,9 @@ class TestISOSeverityRefusal:
 
     def test_json_roundtrip(self):
         r = ISOSeverityRefusal(
-            signal_id="s", reason="why", remedy="how",
+            signal_id="s",
+            reason="why",
+            remedy="how",
         )
         restored = ISOSeverityRefusal.model_validate_json(r.model_dump_json())
         assert restored.status == "refused"
@@ -272,10 +302,15 @@ class TestISOSeverityRefusal:
     def test_assessed_result_discriminates(self):
         """VibrationSeverityResult carries status='assessed'."""
         r = VibrationSeverityResult(
-            signal_id="s", rms_velocity_mm_s=2.0, machine_group=2,
-            support_type="rigid", axis="vertical",
-            zone="B", zone_description="Acceptable",
-            severity_level="Acceptable", color_code="yellow",
+            signal_id="s",
+            rms_velocity_mm_s=2.0,
+            machine_group=2,
+            support_type="rigid",
+            axis="vertical",
+            zone="B",
+            zone_description="Acceptable",
+            severity_level="Acceptable",
+            color_code="yellow",
             boundaries={"AB": 1.4, "BC": 2.8, "CD": 4.5},
             frequency_range="10-1000 Hz",
             unit_conversion_performed=False,
@@ -286,15 +321,26 @@ class TestISOSeverityRefusal:
 
 # ── FeatureExtractionResult ────────────────────────────────────────────────
 
+
 class TestFeatureExtractionResult:
 
     def test_creation(self):
         r = FeatureExtractionResult(
-            num_segments=50, segment_length_samples=1024,
-            segment_duration_s=0.1024, overlap_ratio=0.5,
+            num_segments=50,
+            segment_length_samples=1024,
+            segment_duration_s=0.1024,
+            overlap_ratio=0.5,
             features_shape=[50, 8],
-            feature_names=["rms", "peak", "crest_factor", "kurtosis",
-                           "skewness", "std", "p2p", "shape_factor"],
+            feature_names=[
+                "rms",
+                "peak",
+                "crest_factor",
+                "kurtosis",
+                "skewness",
+                "std",
+                "p2p",
+                "shape_factor",
+            ],
             features_preview=[{"rms": 5.0, "peak": 10.0}],
         )
         assert r.num_segments == 50
@@ -302,6 +348,7 @@ class TestFeatureExtractionResult:
 
 
 # ── AnomalyModelResult ────────────────────────────────────────────────────
+
 
 class TestAnomalyModelResult:
 
@@ -327,10 +374,13 @@ class TestAnomalyModelResult:
             model_name="lof",
             model_type="LocalOutlierFactor",
             num_training_samples=100,
-            num_features_original=8, num_features_pca=4,
+            num_features_original=8,
+            num_features_pca=4,
             variance_explained=0.90,
             model_params={"n_neighbors": 20},
-            model_path="m.pkl", scaler_path="s.pkl", pca_path="p.pkl",
+            model_path="m.pkl",
+            scaler_path="s.pkl",
+            pca_path="p.pkl",
         )
         assert r.validation_accuracy is None
         assert r.validation_details is None
@@ -339,12 +389,16 @@ class TestAnomalyModelResult:
 
 # ── AnomalyPredictionResult ───────────────────────────────────────────────
 
+
 class TestAnomalyPredictionResult:
 
     def test_healthy(self):
         r = AnomalyPredictionResult(
-            model_name="m", num_segments=100, anomaly_count=2,
-            anomaly_ratio=0.02, segment_duration_s=0.1,
+            model_name="m",
+            num_segments=100,
+            anomaly_count=2,
+            anomaly_ratio=0.02,
+            segment_duration_s=0.1,
             overall_health="Healthy",
         )
         assert r.overall_health == "Healthy"
@@ -352,8 +406,11 @@ class TestAnomalyPredictionResult:
 
     def test_faulty(self):
         r = AnomalyPredictionResult(
-            model_name="m", num_segments=100, anomaly_count=90,
-            anomaly_ratio=0.90, segment_duration_s=0.1,
+            model_name="m",
+            num_segments=100,
+            anomaly_count=90,
+            anomaly_ratio=0.90,
+            segment_duration_s=0.1,
             overall_health="Faulty",
         )
         assert r.overall_health == "Faulty"
@@ -361,8 +418,11 @@ class TestAnomalyPredictionResult:
     def test_confidence_field_removed(self):
         """The invented High/Medium 'confidence' label no longer exists."""
         r = AnomalyPredictionResult(
-            model_name="m", num_segments=10, anomaly_count=0,
-            anomaly_ratio=0.0, segment_duration_s=0.1,
+            model_name="m",
+            num_segments=10,
+            anomaly_count=0,
+            anomaly_ratio=0.0,
+            segment_duration_s=0.1,
             overall_health="Healthy",
         )
         assert "confidence" not in AnomalyPredictionResult.model_fields
@@ -377,8 +437,11 @@ class TestAnomalyPredictionResult:
 
     def test_optional_scores(self):
         r = AnomalyPredictionResult(
-            model_name="m", num_segments=10, anomaly_count=0,
-            anomaly_ratio=0.0, segment_duration_s=0.1,
+            model_name="m",
+            num_segments=10,
+            anomaly_count=0,
+            anomaly_ratio=0.0,
+            segment_duration_s=0.1,
             overall_health="Healthy",
         )
         assert r.score_percentiles is None
@@ -386,13 +449,20 @@ class TestAnomalyPredictionResult:
 
     def test_json_roundtrip(self):
         r = AnomalyPredictionResult(
-            model_name="m", num_segments=50, anomaly_count=5,
-            anomaly_ratio=0.1, segment_duration_s=0.1,
+            model_name="m",
+            num_segments=50,
+            anomaly_count=5,
+            anomaly_ratio=0.1,
+            segment_duration_s=0.1,
             overall_health="Suspicious",
-            score_percentiles={"p5": -0.5, "p25": -0.1, "p50": 0.1,
-                               "p75": 0.3, "p95": 0.6},
-            worst_segments=[{"segment_index": 3, "start_time_s": 0.15,
-                             "score": -0.5}],
+            score_percentiles={
+                "p5": -0.5,
+                "p25": -0.1,
+                "p50": 0.1,
+                "p75": 0.3,
+                "p95": 0.6,
+            },
+            worst_segments=[{"segment_index": 3, "start_time_s": 0.15, "score": -0.5}],
         )
         restored = AnomalyPredictionResult.model_validate_json(r.model_dump_json())
         assert restored.anomaly_count == 5

--- a/tests/test_monolith_removed.py
+++ b/tests/test_monolith_removed.py
@@ -80,9 +80,9 @@ def _iter_scan_targets():
 
 class TestMonolithRemoved:
     def test_monolith_file_does_not_exist(self):
-        assert not (SRC / (MONOLITH + ".py")).exists(), (
-            f"src/{MONOLITH}.py must stay removed (deleted in v0.9.0)"
-        )
+        assert not (
+            SRC / (MONOLITH + ".py")
+        ).exists(), f"src/{MONOLITH}.py must stay removed (deleted in v0.9.0)"
 
     def test_root_shims_do_not_exist(self):
         present = [f for f in REMOVED_SRC_FILES if (SRC / f).exists()]
@@ -150,9 +150,7 @@ class TestIsoCitationPrecision:
             stripped = self._ALLOWED.sub("", text)
             for m in self._ANY.finditer(stripped):
                 snippet = stripped[max(0, m.start() - 30) : m.end() + 30]
-                offenders.append(
-                    f"{p.relative_to(ROOT)}: ...{snippet!r}..."
-                )
+                offenders.append(f"{p.relative_to(ROOT)}: ...{snippet!r}...")
         assert offenders == [], (
             "Imprecise 'ISO 10816' citations found (only the provenance "
             "form 'ISO 10816-3:2009' is allowed):\n" + "\n".join(offenders)

--- a/tests/test_mypy_baseline_gate.py
+++ b/tests/test_mypy_baseline_gate.py
@@ -11,6 +11,10 @@ So the failing paths are tested, not the passing one. Everything here drives
 the pure functions against in-memory fixtures; nothing invokes mypy, so the
 suite stays fast and these tests cannot be broken by the tree's actual type
 debt.
+
+The other half -- that the CI job wiring still lets mypy fail the build --
+moved to ``tests/test_ci_gates.py``, which now makes that assertion for
+every job in the workflow rather than this one.
 """
 
 import importlib.util
@@ -227,25 +231,3 @@ class TestTheComparison:
         )
         assert code == 0
         assert "OK" in out
-
-
-def test_the_ci_job_still_blocks():
-    """No `continue-on-error` may come back to the type-check job.
-
-    This is the literal defect the gate replaced, and re-adding one line to a
-    workflow would undo it with every other check still green.
-    """
-    workflow = (REPO_ROOT / ".github" / "workflows" / "tests.yml").read_text(
-        encoding="utf-8"
-    )
-    # From the job's name to the start of the next top-level job key, so the
-    # window cannot miss the `run:` line however long the comments grow.
-    start = workflow.index("Type check with mypy")
-    rest = workflow[start:]
-    end = rest.find("\n  format-check:")
-    job = rest if end == -1 else rest[:end]
-    assert "continue-on-error" not in job, (
-        "the mypy job is non-blocking again — see tools/check_mypy_baseline.py "
-        "for why it was made blocking"
-    )
-    assert "tools/check_mypy_baseline.py" in job

--- a/tests/test_no_client_logging.py
+++ b/tests/test_no_client_logging.py
@@ -91,9 +91,7 @@ class _ClientLogCalls(ast.NodeVisitor):
         names = set(self._ctx_names[-1])
         args = node.args
         for arg in [*args.posonlyargs, *args.args, *args.kwonlyargs]:
-            if arg.annotation is not None and "Context" in ast.unparse(
-                arg.annotation
-            ):
+            if arg.annotation is not None and "Context" in ast.unparse(arg.annotation):
                 names.add(arg.arg)
         self._ctx_names.append(names)
         self.generic_visit(node)
@@ -179,9 +177,12 @@ async def clean(ctx: Context):
     finder = _ClientLogCalls()
     finder.visit(ast.parse(source))
     caught = {line for line, _ in finder.offenders}
-    assert caught == {3, 6, 9, 12}, (
-        f"guard missed a reintroduction shape; caught lines {sorted(caught)}"
-    )
+    assert caught == {
+        3,
+        6,
+        9,
+        12,
+    }, f"guard missed a reintroduction shape; caught lines {sorted(caught)}"
 
 
 def test_every_tool_that_had_ctx_injected_still_does():
@@ -199,17 +200,13 @@ def test_every_tool_that_had_ctx_injected_still_does():
 
     reference = json.loads(INVENTORY.read_text(encoding="utf-8"))
     expected = {
-        name
-        for name, spec in reference["tools"].items()
-        if spec.get("context_kwarg")
+        name for name, spec in reference["tools"].items() if spec.get("context_kwarg")
     }
 
     mcp = MCPServer("ctx-injection-guard")
     register_all(mcp)
     actual = {
-        tool.name
-        for tool in mcp._tool_manager._tools.values()
-        if tool.context_kwarg
+        tool.name for tool in mcp._tool_manager._tools.values() if tool.context_kwarg
     }
 
     assert actual == expected, (

--- a/tests/test_prognostics_tools.py
+++ b/tests/test_prognostics_tools.py
@@ -24,10 +24,10 @@ from predictive_maintenance_mcp.models import (
     TrendAnalysisResult,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mcp():
@@ -54,7 +54,9 @@ def data_dir(tmp_path, monkeypatch):
     rng = np.random.default_rng(42)
     stationary = 0.1 * rng.standard_normal(n_samples)
     pd.DataFrame(stationary).to_csv(
-        signals_dir / "stationary.csv", index=False, header=False,
+        signals_dir / "stationary.csv",
+        index=False,
+        header=False,
     )
     with open(signals_dir / "stationary_metadata.json", "w") as f:
         json.dump({"sampling_rate": fs}, f)
@@ -64,15 +66,21 @@ def data_dir(tmp_path, monkeypatch):
     envelope = 0.05 + 0.5 * (t / n_samples)
     degrading = envelope * rng.standard_normal(n_samples)
     pd.DataFrame(degrading).to_csv(
-        signals_dir / "degrading.csv", index=False, header=False,
+        signals_dir / "degrading.csv",
+        index=False,
+        header=False,
     )
     with open(signals_dir / "degrading_metadata.json", "w") as f:
         json.dump({"sampling_rate": fs}, f)
 
     # Patch DATA_DIR
     monkeypatch.setattr("predictive_maintenance_mcp.config.DATA_DIR", signals_dir)
-    monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", signals_dir)
-    monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.repository.DATA_DIR", signals_dir)
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", signals_dir
+    )
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.signal_acquisition.repository.DATA_DIR", signals_dir
+    )
 
     return signals_dir
 
@@ -122,6 +130,7 @@ def mock_ctx():
 # ---------------------------------------------------------------------------
 # estimate_rul — refusal paths
 # ---------------------------------------------------------------------------
+
 
 class TestEstimateRULRefusals:
     """estimate_rul must refuse anything that is not a multi-measure series."""
@@ -242,6 +251,7 @@ class TestEstimateRULRefusals:
 # ---------------------------------------------------------------------------
 # estimate_rul — outcomes
 # ---------------------------------------------------------------------------
+
 
 class TestEstimateRULOutcomes:
     """estimate_rul outcomes on valid multi-measure series."""
@@ -374,6 +384,7 @@ class TestEstimateRULOutcomes:
     @pytest.mark.asyncio
     async def test_exponential_method(self, tools, mock_ctx):
         import math
+
         timestamps = [float(t) for t in range(10)]
         values = [0.5 * math.exp(0.2 * t) for t in timestamps]
         result = await tools["estimate_rul"](
@@ -411,6 +422,7 @@ class TestEstimateRULOutcomes:
 # ---------------------------------------------------------------------------
 # analyze_signal_trend (within-recording screening)
 # ---------------------------------------------------------------------------
+
 
 class TestAnalyzeSignalTrend:
     """Tests for the analyze_signal_trend screening tool (signal_id handle)."""
@@ -490,6 +502,7 @@ class TestAnalyzeSignalTrend:
 # ---------------------------------------------------------------------------
 # Degradation onset (merged into analyze_signal_trend in U9)
 # ---------------------------------------------------------------------------
+
 
 class TestDegradationOnsetMerged:
     """Onset detection now lives inside analyze_signal_trend (U9 merge)."""

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -21,8 +21,8 @@ from predictive_maintenance_mcp.rag import (
     backend_name,
 )
 
-
 # ── chunk_text ──────────────────────────────────────────────────────────────
+
 
 class TestChunkText:
 
@@ -80,6 +80,7 @@ class TestChunkText:
 
 # ── chunk_text_by_paragraphs ───────────────────────────────────────────────
 
+
 class TestChunkByParagraphs:
 
     def test_basic_paragraphs(self):
@@ -100,7 +101,9 @@ class TestChunkByParagraphs:
         assert chunk_text_by_paragraphs("") == []
 
     def test_single_paragraph(self):
-        chunks = chunk_text_by_paragraphs("Single paragraph only.", max_chunk_chars=1024)
+        chunks = chunk_text_by_paragraphs(
+            "Single paragraph only.", max_chunk_chars=1024
+        )
         assert len(chunks) == 1
         assert chunks[0]["text"] == "Single paragraph only."
 
@@ -119,6 +122,7 @@ class TestChunkByParagraphs:
 
 # ── DocumentIndex (TF-IDF backend) ─────────────────────────────────────────
 
+
 @pytest.fixture(autouse=True)
 def _force_tfidf(monkeypatch):
     """Force TF-IDF backend even if FAISS is installed."""
@@ -131,9 +135,15 @@ class TestDocumentIndexTFIDF:
         idx = DocumentIndex()
         if docs is None:
             docs = [
-                {"text": "bearing fault diagnosis vibration analysis", "source": "doc1.pdf"},
+                {
+                    "text": "bearing fault diagnosis vibration analysis",
+                    "source": "doc1.pdf",
+                },
                 {"text": "gearbox oil temperature monitoring", "source": "doc2.pdf"},
-                {"text": "motor current signature analysis electrical fault", "source": "doc3.pdf"},
+                {
+                    "text": "motor current signature analysis electrical fault",
+                    "source": "doc3.pdf",
+                },
             ]
         idx.build(docs)
         return idx
@@ -196,7 +206,7 @@ class TestDocumentIndexTFIDF:
 
         # Patch cache path to use tmp_path
         cache_file = tmp_path / "test_index.pkl"
-        with patch.object(DocumentIndex, '_cache_path', return_value=cache_file):
+        with patch.object(DocumentIndex, "_cache_path", return_value=cache_file):
             idx.save()
             assert cache_file.exists()
 
@@ -211,7 +221,7 @@ class TestDocumentIndexTFIDF:
 
     def test_load_nonexistent_cache(self, tmp_path):
         cache_file = tmp_path / "nonexistent.pkl"
-        with patch.object(DocumentIndex, '_cache_path', return_value=cache_file):
+        with patch.object(DocumentIndex, "_cache_path", return_value=cache_file):
             assert DocumentIndex.load() is None
 
     def test_num_chunks_property(self):
@@ -221,6 +231,7 @@ class TestDocumentIndexTFIDF:
 
 
 # ── backend_name ───────────────────────────────────────────────────────────
+
 
 def test_backend_name_returns_string():
     name = backend_name()

--- a/tests/test_real_data.py
+++ b/tests/test_real_data.py
@@ -14,50 +14,45 @@ from predictive_maintenance_mcp.signal_acquisition.loaders import load_signal_da
 from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
 
 # Paths relative to data/signals/
-BASELINE_TRAIN = [
-    "real_train/baseline_1.csv",
-    "real_train/baseline_2.csv"
-]
+BASELINE_TRAIN = ["real_train/baseline_1.csv", "real_train/baseline_2.csv"]
 
-INNER_FAULT_TRAIN = [
-    "real_train/InnerRaceFault_vload_1.csv"
-]
+INNER_FAULT_TRAIN = ["real_train/InnerRaceFault_vload_1.csv"]
 
-OUTER_FAULT_TRAIN = [
-    "real_train/OuterRaceFault_1.csv"
-]
+OUTER_FAULT_TRAIN = ["real_train/OuterRaceFault_1.csv"]
 
 
 def get_sampling_rate(csv_file):
     """Read sampling rate from metadata JSON"""
-    metadata_file = csv_file.replace('.csv', '_metadata.json')
+    metadata_file = csv_file.replace(".csv", "_metadata.json")
     metadata_path = Path("data/signals") / metadata_file
 
     if metadata_path.exists():
-        with open(metadata_path, 'r') as f:
+        with open(metadata_path, "r") as f:
             metadata = json.load(f)
-            return metadata.get('sampling_rate', 25000.0)
+            return metadata.get("sampling_rate", 25000.0)
     return 25000.0  # fallback
 
 
 def test_real_data():
     """Test complete workflow with real data (statistic analysis only - sync)."""
-    print("="*70)
+    print("=" * 70)
     print("MODULE-LEVEL TOOL TEST WITH REAL BEARING DATA")
-    print("="*70)
+    print("=" * 70)
     print("\nDataset: Rolling Element Bearing Fault Diagnosis")
     print("License: CC BY-NC-SA 4.0\n")
 
     # Test 1: Statistical Analysis (only sync tool)
     print("\n[TEST 1] STATISTICAL ANALYSIS")
-    print("-"*70)
+    print("-" * 70)
 
     repo = get_repository()
     loaded_ids = []
     try:
-        for name, file in [("Baseline", BASELINE_TRAIN[0]),
-                           ("Inner Fault", INNER_FAULT_TRAIN[0]),
-                           ("Outer Fault", OUTER_FAULT_TRAIN[0])]:
+        for name, file in [
+            ("Baseline", BASELINE_TRAIN[0]),
+            ("Inner Fault", INNER_FAULT_TRAIN[0]),
+            ("Outer Fault", OUTER_FAULT_TRAIN[0]),
+        ]:
             print(f"\n{name}: {file}")
             sid = repo.load_signal(file, overwrite=True)["signal_id"]
             loaded_ids.append(sid)
@@ -73,7 +68,7 @@ def test_real_data():
 
     # Test 2: Signal loading and FFT computation (non-MCP)
     print("\n\n[TEST 2] FFT SPECTRUM ANALYSIS (direct computation)")
-    print("-"*70)
+    print("-" * 70)
 
     print(f"\nBaseline: {BASELINE_TRAIN[0]}")
     sr_base = get_sampling_rate(BASELINE_TRAIN[0])
@@ -81,16 +76,16 @@ def test_real_data():
     assert signal_data is not None, "Failed to load baseline signal"
 
     fft_result = np.fft.rfft(signal_data)
-    frequencies = np.fft.rfftfreq(len(signal_data), 1/sr_base)
+    frequencies = np.fft.rfftfreq(len(signal_data), 1 / sr_base)
     magnitudes = np.abs(fft_result)
     peak_idx = np.argmax(magnitudes[1:]) + 1  # Skip DC
     print(f"  Sampling rate: {sr_base:.0f} Hz")
     print(f"  Peak freq: {frequencies[peak_idx]:.2f} Hz")
     print(f"  Samples: {len(signal_data)}")
 
-    print("\n\n" + "="*70)
+    print("\n\n" + "=" * 70)
     print("ALL TESTS COMPLETED!")
-    print("="*70)
+    print("=" * 70)
 
 
 if __name__ == "__main__":

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -16,7 +16,10 @@ class TestGenerateRecommendations:
 
         assert len(recs) == 1
         assert recs[0]["urgency"] == "low"
-        assert "normal" in recs[0]["action"].lower() or "monitoring" in recs[0]["action"].lower()
+        assert (
+            "normal" in recs[0]["action"].lower()
+            or "monitoring" in recs[0]["action"].lower()
+        )
 
     def test_zone_d_recommendations(self):
         """Zone D should produce a critical-urgency recommendation."""

--- a/tests/test_report_docx.py
+++ b/tests/test_report_docx.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 # Check availability before importing
 try:
     from docx import Document as DocxDocument
+
     HAS_DOCX = True
 except ImportError:
     HAS_DOCX = False
@@ -25,8 +26,8 @@ from predictive_maintenance_mcp.report_generator import (
     REPORTS_DIR,
 )
 
-
 # ── DOCX generation ───────────────────────────────────────────────────────
+
 
 @pytest.mark.skipif(not HAS_DOCX, reason="python-docx not installed")
 class TestDocxReportGeneration:
@@ -66,7 +67,8 @@ class TestDocxReportGeneration:
     def test_full_report(self, tmp_path):
         """Generate report with all sections."""
         with patch.object(
-            type(REPORTS_DIR), '__fspath__',
+            type(REPORTS_DIR),
+            "__fspath__",
             return_value=str(tmp_path),
             create=True,
         ):
@@ -149,6 +151,7 @@ class TestDocxReportGeneration:
 
 
 # ── Missing python-docx ───────────────────────────────────────────────────
+
 
 def test_missing_docx_raises():
     """When HAS_DOCX is False, raise ValueError (never an error dict)."""

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -47,6 +47,7 @@ def _logged(caplog, needle: str) -> bool:
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def mcp():
     server = MCPServer("test-reports")
@@ -72,8 +73,12 @@ def data_dir(tmp_path, monkeypatch):
         json.dump({"sampling_rate": fs, "signal_unit": "g"}, f)
 
     monkeypatch.setattr("predictive_maintenance_mcp.config.DATA_DIR", signals_dir)
-    monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", signals_dir)
-    monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.repository.DATA_DIR", signals_dir)
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", signals_dir
+    )
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.signal_acquisition.repository.DATA_DIR", signals_dir
+    )
     return signals_dir
 
 
@@ -91,11 +96,15 @@ def repo(data_dir):
 def reports_dir(tmp_path, monkeypatch):
     rd = tmp_path / "reports"
     rd.mkdir()
-    monkeypatch.setattr("predictive_maintenance_mcp.mcp_tools.report_tools.REPORTS_DIR", rd)
+    monkeypatch.setattr(
+        "predictive_maintenance_mcp.mcp_tools.report_tools.REPORTS_DIR", rd
+    )
     monkeypatch.setattr("predictive_maintenance_mcp.report_generator.REPORTS_DIR", rd)
     # Also patch the REPORTS_DIR_PATH alias used in diagnostics import
     try:
-        monkeypatch.setattr("predictive_maintenance_mcp.mcp_tools.report_tools.REPORTS_DIR_PATH", rd)
+        monkeypatch.setattr(
+            "predictive_maintenance_mcp.mcp_tools.report_tools.REPORTS_DIR_PATH", rd
+        )
     except AttributeError:
         pass
     return rd
@@ -109,8 +118,16 @@ def mock_ctx():
     return ctx
 
 
-def _load_extra_signal(repo, signals_dir, name, fs=10000, duration=1.0,
-                       freq=50.0, noise=0.0, with_meta=True):
+def _load_extra_signal(
+    repo,
+    signals_dir,
+    name,
+    fs=10000,
+    duration=1.0,
+    freq=50.0,
+    noise=0.0,
+    with_meta=True,
+):
     """Helper: create a CSV signal file and load it into the repository."""
     t = np.linspace(0, duration, int(fs * duration), endpoint=False)
     sig = np.sin(2 * np.pi * freq * t) + noise * np.random.randn(len(t))
@@ -125,6 +142,7 @@ def _load_extra_signal(repo, signals_dir, name, fs=10000, duration=1.0,
 # ---------------------------------------------------------------------------
 # Plot signal
 # ---------------------------------------------------------------------------
+
 
 class TestPlotSignal:
     """Tests for plot_signal tool (signal_id handle)."""
@@ -185,6 +203,7 @@ class TestPlotSignal:
 # Merged plot tools are gone (absorbed by the generate_* reports)
 # ---------------------------------------------------------------------------
 
+
 class TestPlotToolsMerged:
     """U9b clean cut: plot_spectrum/plot_envelope/plot_iso_20816_chart and
     get_report_info are no longer registered — their capability lives in
@@ -204,6 +223,7 @@ class TestPlotToolsMerged:
 # ---------------------------------------------------------------------------
 # List reports
 # ---------------------------------------------------------------------------
+
 
 class TestListReports:
     """Tests for list_html_reports tool."""
@@ -225,10 +245,10 @@ class TestListReports:
         # Create a fake HTML report with embedded metadata
         metadata = {"report_type": "fft_spectrum", "signal_file": "test.csv"}
         html_content = (
-            '<html><head>'
+            "<html><head>"
             '<script type="application/json" id="report-metadata">'
-            f'{json.dumps(metadata)}'
-            '</script></head><body>report</body></html>'
+            f"{json.dumps(metadata)}"
+            "</script></head><body>report</body></html>"
         )
         (reports_dir / "fft_test_report.html").write_text(html_content)
         result = tools["list_html_reports"]()
@@ -248,6 +268,7 @@ class TestListReports:
 # Single-report metadata route (merged get_report_info)
 # ---------------------------------------------------------------------------
 
+
 class TestListReportsFileNameRoute:
     """list_html_reports(file_name=...) — the absorbed get_report_info."""
 
@@ -258,12 +279,16 @@ class TestListReportsFileNameRoute:
             tools["list_html_reports"](file_name="nonexistent.html")
 
     def test_report_found_with_metadata(self, tools, reports_dir):
-        metadata = {"report_type": "envelope", "signal_file": "sig.csv", "num_peaks": 10}
+        metadata = {
+            "report_type": "envelope",
+            "signal_file": "sig.csv",
+            "num_peaks": 10,
+        }
         html = (
-            '<html><head>'
+            "<html><head>"
             '<script type="application/json" id="report-metadata">'
-            f'{json.dumps(metadata)}'
-            '</script></head><body></body></html>'
+            f"{json.dumps(metadata)}"
+            "</script></head><body></body></html>"
         )
         (reports_dir / "env_report.html").write_text(html)
         result = tools["list_html_reports"](file_name="env_report.html")
@@ -301,14 +326,13 @@ class TestListReportsFileNameRoute:
         evil.mkdir()
         (evil / "x.html").write_text("<html></html>")
         with pytest.raises(ValueError, match="Invalid report filename"):
-            tools["list_html_reports"](
-                file_name=f"../{reports_dir.name}_evil/x.html"
-            )
+            tools["list_html_reports"](file_name=f"../{reports_dir.name}_evil/x.html")
 
 
 # ---------------------------------------------------------------------------
 # Generate FFT report
 # ---------------------------------------------------------------------------
+
 
 class TestGenerateFFTReport:
     """Tests for generate_fft_report tool (signal_id handle)."""
@@ -350,7 +374,9 @@ class TestGenerateFFTReport:
         assert {r1["file_name"], r2["file_name"]} <= listed
 
     @pytest.mark.asyncio
-    async def test_fft_report_signal_without_rate(self, tools, data_dir, repo, reports_dir):
+    async def test_fft_report_signal_without_rate(
+        self, tools, data_dir, repo, reports_dir
+    ):
         """A stored signal without a sampling rate → structured error."""
         sig = np.sin(2 * np.pi * 50 * np.linspace(0, 1, 1000, endpoint=False))
         pd.DataFrame(sig).to_csv(data_dir / "no_meta.csv", index=False, header=False)
@@ -379,6 +405,7 @@ class TestGenerateFFTReport:
 # ---------------------------------------------------------------------------
 # Generate envelope report
 # ---------------------------------------------------------------------------
+
 
 class TestGenerateEnvelopeReport:
     """Tests for generate_envelope_report tool (signal_id handle)."""
@@ -450,7 +477,9 @@ class TestGenerateEnvelopeReport:
     ):
         """Stored signal without a rate → structured error."""
         sig = np.random.randn(5000)
-        pd.DataFrame(sig).to_csv(data_dir / "no_meta_env.csv", index=False, header=False)
+        pd.DataFrame(sig).to_csv(
+            data_dir / "no_meta_env.csv", index=False, header=False
+        )
         repo.load_signal("no_meta_env.csv")
         with pytest.raises(ValueError, match="No sampling rate"):
             await tools["generate_envelope_report"](signal_id="no_meta_env")
@@ -479,6 +508,7 @@ class TestGenerateEnvelopeReport:
 # Generate ISO report
 # ---------------------------------------------------------------------------
 
+
 class TestGenerateISOReport:
     """Tests for generate_iso_report tool (signal_id handle)."""
 
@@ -498,7 +528,9 @@ class TestGenerateISOReport:
         self, tools, data_dir, repo, reports_dir
     ):
         sig = np.random.randn(5000)
-        pd.DataFrame(sig).to_csv(data_dir / "no_meta_iso.csv", index=False, header=False)
+        pd.DataFrame(sig).to_csv(
+            data_dir / "no_meta_iso.csv", index=False, header=False
+        )
         repo.load_signal("no_meta_iso.csv")
         with pytest.raises(ValueError, match="No sampling rate"):
             await tools["generate_iso_report"](signal_id="no_meta_iso")
@@ -509,7 +541,9 @@ class TestGenerateISOReport:
     ):
         """Rate known but unit undeclared → structured error naming the fix."""
         sig = np.random.randn(20000)
-        pd.DataFrame(sig).to_csv(data_dir / "no_unit_iso.csv", index=False, header=False)
+        pd.DataFrame(sig).to_csv(
+            data_dir / "no_unit_iso.csv", index=False, header=False
+        )
         repo.load_signal("no_unit_iso.csv", sampling_rate=10000)
         with pytest.raises(ValueError, match="unit not declared"):
             await tools["generate_iso_report"](signal_id="no_unit_iso")
@@ -518,6 +552,7 @@ class TestGenerateISOReport:
 # ---------------------------------------------------------------------------
 # Load → analyze → report round-trip (R7 golden path)
 # ---------------------------------------------------------------------------
+
 
 class TestSignalIdRoundTrip:
     """R7: load → analyze → report is walkable with ONE idiom (signal_id)."""
@@ -553,6 +588,7 @@ class TestSignalIdRoundTrip:
 # Generate PCA visualization report
 # ---------------------------------------------------------------------------
 
+
 class TestGeneratePCAReport:
     """Tests for generate_pca_visualization_report tool (signal_id handles)."""
 
@@ -561,7 +597,9 @@ class TestGeneratePCAReport:
         """Create a fake trained model with scaler, PCA, and metadata."""
         md = tmp_path / "models"
         md.mkdir()
-        monkeypatch.setattr("predictive_maintenance_mcp.mcp_tools.report_tools.MODELS_DIR", md)
+        monkeypatch.setattr(
+            "predictive_maintenance_mcp.mcp_tools.report_tools.MODELS_DIR", md
+        )
 
         # Build a small model from synthetic features
         rng = np.random.RandomState(42)
@@ -587,7 +625,9 @@ class TestGeneratePCAReport:
         return md
 
     @pytest.mark.asyncio
-    async def test_pca_report_no_test_signals(self, tools, repo, reports_dir, models_dir, mock_ctx):
+    async def test_pca_report_no_test_signals(
+        self, tools, repo, reports_dir, models_dir, mock_ctx
+    ):
         """PCA report with no test signals should still produce a report."""
         result = await tools["generate_pca_visualization_report"](
             model_name="test_pca_model",
@@ -598,7 +638,9 @@ class TestGeneratePCAReport:
         assert result["summary"]["total_segments"] == 0
 
     @pytest.mark.asyncio
-    async def test_pca_report_with_test_signals(self, tools, repo, reports_dir, models_dir, mock_ctx):
+    async def test_pca_report_with_test_signals(
+        self, tools, repo, reports_dir, models_dir, mock_ctx
+    ):
         """PCA report with test signal_ids should segment, predict, and report."""
         result = await tools["generate_pca_visualization_report"](
             model_name="test_pca_model",
@@ -611,7 +653,9 @@ class TestGeneratePCAReport:
         assert result["summary"]["total_segments"] > 0
 
     @pytest.mark.asyncio
-    async def test_pca_report_with_true_labels(self, tools, repo, reports_dir, models_dir, mock_ctx):
+    async def test_pca_report_with_true_labels(
+        self, tools, repo, reports_dir, models_dir, mock_ctx
+    ):
         """PCA report with true_labels (keyed by signal_id) computes metrics."""
         result = await tools["generate_pca_visualization_report"](
             model_name="test_pca_model",
@@ -625,14 +669,18 @@ class TestGeneratePCAReport:
         assert "overall_accuracy" in result["summary"]["validation_metrics"]
 
     @pytest.mark.asyncio
-    async def test_pca_report_model_not_found(self, tools, repo, reports_dir, models_dir):
+    async def test_pca_report_model_not_found(
+        self, tools, repo, reports_dir, models_dir
+    ):
         with pytest.raises(FileNotFoundError):
             await tools["generate_pca_visualization_report"](
                 model_name="nonexistent_model",
             )
 
     @pytest.mark.asyncio
-    async def test_pca_report_signal_not_loaded(self, tools, repo, reports_dir, models_dir):
+    async def test_pca_report_signal_not_loaded(
+        self, tools, repo, reports_dir, models_dir
+    ):
         """Unknown test signal_id → fail fast, no silent skipping."""
         with pytest.raises(ValueError, match="load_signal"):
             await tools["generate_pca_visualization_report"](
@@ -645,6 +693,7 @@ class TestGeneratePCAReport:
 # Generate feature comparison report
 # ---------------------------------------------------------------------------
 
+
 class TestGenerateFeatureComparisonReport:
     """Tests for generate_feature_comparison_report tool (signal_id handles)."""
 
@@ -652,14 +701,22 @@ class TestGenerateFeatureComparisonReport:
     def multi_signal_ids(self, repo, data_dir):
         """Load two signal groups for comparison."""
         ids = {
-            "healthy_1": _load_extra_signal(repo, data_dir, "healthy_1.csv", freq=50.0, noise=0.01),
-            "healthy_2": _load_extra_signal(repo, data_dir, "healthy_2.csv", freq=50.0, noise=0.02),
-            "faulty_1": _load_extra_signal(repo, data_dir, "faulty_1.csv", freq=50.0, noise=1.0),
+            "healthy_1": _load_extra_signal(
+                repo, data_dir, "healthy_1.csv", freq=50.0, noise=0.01
+            ),
+            "healthy_2": _load_extra_signal(
+                repo, data_dir, "healthy_2.csv", freq=50.0, noise=0.02
+            ),
+            "faulty_1": _load_extra_signal(
+                repo, data_dir, "faulty_1.csv", freq=50.0, noise=1.0
+            ),
         }
         return ids
 
     @pytest.mark.asyncio
-    async def test_feature_comparison_basic(self, tools, multi_signal_ids, reports_dir, mock_ctx):
+    async def test_feature_comparison_basic(
+        self, tools, multi_signal_ids, reports_dir, mock_ctx
+    ):
         result = await tools["generate_feature_comparison_report"](
             signal_groups={
                 "Healthy": ["healthy_1", "healthy_2"],
@@ -674,7 +731,9 @@ class TestGenerateFeatureComparisonReport:
         assert "Healthy" in result["metadata"]["groups"]
 
     @pytest.mark.asyncio
-    async def test_feature_comparison_subset_features(self, tools, multi_signal_ids, reports_dir):
+    async def test_feature_comparison_subset_features(
+        self, tools, multi_signal_ids, reports_dir
+    ):
         """Only plot a subset of features."""
         result = await tools["generate_feature_comparison_report"](
             signal_groups={"A": ["healthy_1"], "B": ["faulty_1"]},
@@ -683,7 +742,9 @@ class TestGenerateFeatureComparisonReport:
         assert len(result["metadata"]["features_plotted"]) == 3
 
     @pytest.mark.asyncio
-    async def test_feature_comparison_unknown_id_raises(self, tools, multi_signal_ids, reports_dir):
+    async def test_feature_comparison_unknown_id_raises(
+        self, tools, multi_signal_ids, reports_dir
+    ):
         """Unknown signal_ids fail fast — no silent skipping (U8 contract)."""
         with pytest.raises(ValueError, match="load_signal"):
             await tools["generate_feature_comparison_report"](
@@ -697,9 +758,11 @@ class TestGenerateFeatureComparisonReport:
 # DOCX report generation
 # ---------------------------------------------------------------------------
 
+
 def _docx_installed() -> bool:
     try:
         import docx  # noqa: F401
+
         return True
     except ImportError:
         return False
@@ -781,6 +844,7 @@ class TestDocxReport:
 # ---------------------------------------------------------------------------
 # Tool registration completeness
 # ---------------------------------------------------------------------------
+
 
 class TestToolRegistration:
     """Verify all expected tools are registered."""

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -15,7 +15,7 @@ from predictive_maintenance_mcp.report_generator import (
     save_envelope_report,
     save_iso_report,
     list_reports,
-    REPORTS_DIR
+    REPORTS_DIR,
 )
 import numpy as np
 
@@ -53,7 +53,7 @@ async def run_report_tests():
             magnitudes=magnitudes,
             signal_data=signal,
             max_freq=5000,
-            num_peaks=15
+            num_peaks=15,
         )
 
         print(f"✓ {report_result['message']}")
@@ -85,7 +85,7 @@ async def run_report_tests():
         nyq = sampling_rate / 2.0
         low = filter_low / nyq
         high = filter_high / nyq
-        b, a = butter(4, [low, high], btype='band')
+        b, a = butter(4, [low, high], btype="band")
         filtered_signal = filtfilt(b, a, signal)
 
         # Hilbert envelope
@@ -95,7 +95,7 @@ async def run_report_tests():
         # FFT of envelope
         N = len(envelope)
         env_fft = fft(envelope)
-        env_freqs = fftfreq(N, 1/sampling_rate)
+        env_freqs = fftfreq(N, 1 / sampling_rate)
 
         # Keep only positive frequencies
         pos_mask = env_freqs > 0
@@ -103,12 +103,7 @@ async def run_report_tests():
         env_magnitudes = np.abs(env_fft[pos_mask]) / N * 2
 
         # 6205 (CWRU geometry) at 1797 RPM
-        bearing_freqs = {
-            'BPFO': 107.36,
-            'BPFI': 162.19,
-            'BSF': 70.58,
-            'FTF': 11.93
-        }
+        bearing_freqs = {"BPFO": 107.36, "BPFI": 162.19, "BSF": 70.58, "FTF": 11.93}
 
         report_result = save_envelope_report(
             signal_file=signal_file,
@@ -120,7 +115,7 @@ async def run_report_tests():
             env_magnitudes=env_magnitudes,
             bearing_freqs=bearing_freqs,
             max_freq=500,
-            num_peaks=15
+            num_peaks=15,
         )
 
         print(f"✓ {report_result['message']}")
@@ -151,10 +146,7 @@ async def run_report_tests():
     )
 
     sev = await assess_severity(
-        ctx=None,
-        signal_id=info["signal_id"],
-        machine_group=2,
-        support_type="rigid"
+        ctx=None, signal_id=info["signal_id"], machine_group=2, support_type="rigid"
     )
     repo.clear_signal(info["signal_id"])
 
@@ -173,10 +165,7 @@ async def run_report_tests():
         "frequency_range": sev.frequency_range,
     }
 
-    report_result = save_iso_report(
-        signal_file=signal_file,
-        iso_result=iso_dict
-    )
+    report_result = save_iso_report(signal_file=signal_file, iso_result=iso_dict)
 
     print(f"✓ {report_result['message']}")
     print(f"  Path: {report_result['file_path']}")
@@ -192,7 +181,9 @@ async def run_report_tests():
     reports = list_reports()
     print(f"✓ Found {len(reports)} reports in {REPORTS_DIR}")
     for report in reports:
-        print(f"  - {report['file_name']} ({report['file_size_kb']:.1f} KB) - {report['report_type']}")
+        print(
+            f"  - {report['file_name']} ({report['file_size_kb']:.1f} KB) - {report['report_type']}"
+        )
     print()
 
     print("=" * 70)
@@ -201,6 +192,7 @@ async def run_report_tests():
     print()
     print(f"Reports saved to: {REPORTS_DIR}")
     print("Open the HTML files in your browser to view interactive charts!")
+
 
 if __name__ == "__main__":
     asyncio.run(run_report_tests())

--- a/tests/test_rul_estimator.py
+++ b/tests/test_rul_estimator.py
@@ -94,7 +94,9 @@ class TestExponentialRUL:
         series = [math.exp(0.1 * t) for t in range(30)]
         threshold = math.exp(0.1 * 50)  # threshold at t=50
 
-        result = estimate_rul_exponential(series, timestamps, failure_threshold=threshold)
+        result = estimate_rul_exponential(
+            series, timestamps, failure_threshold=threshold
+        )
 
         assert result is not None
         assert result["method"] == "exponential"
@@ -120,7 +122,9 @@ class TestExponentialRUL:
     def test_non_positive_threshold_returns_none(self):
         timestamps = [0.0, 1.0, 2.0]
         series = [1.0, 2.0, 4.0]
-        assert estimate_rul_exponential(series, timestamps, failure_threshold=0.0) is None
+        assert (
+            estimate_rul_exponential(series, timestamps, failure_threshold=0.0) is None
+        )
 
 
 class TestWeibullRemoved:

--- a/tests/test_security_paths.py
+++ b/tests/test_security_paths.py
@@ -149,12 +149,16 @@ def diagnostics_tools(models_sandbox):
 
 def _no_files_written(tmp_path: Path) -> bool:
     """No pickle/json artifact escaped into any directory under the sandbox."""
-    return not list(tmp_path.rglob("*.pkl")) and not list(tmp_path.rglob("*_metadata.json"))
+    return not list(tmp_path.rglob("*.pkl")) and not list(
+        tmp_path.rglob("*_metadata.json")
+    )
 
 
 class TestModularTrainWriteSide:
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("name", ["../../evil", "../models_evil/x", "/tmp/evil", ".."])
+    @pytest.mark.parametrize(
+        "name", ["../../evil", "../models_evil/x", "/tmp/evil", ".."]
+    )
     async def test_train_rejects_unsafe_model_name(
         self, diagnostics_tools, models_sandbox, mock_ctx, name
     ):
@@ -205,7 +209,9 @@ class TestReportMetadataReadSide:
         assert "secret" not in str(exc_info.value).replace(name, "")
         assert "available" not in str(exc_info.value)
 
-    @pytest.mark.skipif(os.name != "nt", reason="backslash is a separator only on Windows")
+    @pytest.mark.skipif(
+        os.name != "nt", reason="backslash is a separator only on Windows"
+    )
     def test_read_report_metadata_rejects_windows_backslash(self, reports_sandbox):
         from predictive_maintenance_mcp.report_generator import read_report_metadata
 
@@ -286,12 +292,16 @@ class TestSignalReadContainment:
         monkeypatch.setattr(
             "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", data_dir
         )
-        from predictive_maintenance_mcp.signal_acquisition.loaders import load_signal_data
+        from predictive_maintenance_mcp.signal_acquisition.loaders import (
+            load_signal_data,
+        )
 
         # Traversal is contained: the outside file's contents are never returned.
         assert load_signal_data(name) is None
 
-    def test_load_signal_data_allows_contained_relative_path(self, tmp_path, monkeypatch):
+    def test_load_signal_data_allows_contained_relative_path(
+        self, tmp_path, monkeypatch
+    ):
         import pandas as pd
 
         data_dir = tmp_path / "data" / "signals"
@@ -302,7 +312,9 @@ class TestSignalReadContainment:
         monkeypatch.setattr(
             "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", data_dir
         )
-        from predictive_maintenance_mcp.signal_acquisition.loaders import load_signal_data
+        from predictive_maintenance_mcp.signal_acquisition.loaders import (
+            load_signal_data,
+        )
 
         # A legitimate relative path inside DATA_DIR still loads (no over-rejection).
         result = load_signal_data("sub/good.csv")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -152,9 +152,7 @@ class TestMainArgParser:
 
         srv.main()
 
-        mock_run.assert_called_once_with(
-            transport="sse", host="127.0.0.1", port=8000
-        )
+        mock_run.assert_called_once_with(transport="sse", host="127.0.0.1", port=8000)
 
     def test_blank_env_host_does_not_become_a_wildcard_bind(self, monkeypatch):
         """MCP_HOST set-but-empty must not resolve to INADDR_ANY.
@@ -175,13 +173,9 @@ class TestMainArgParser:
 
         srv.main()
 
-        mock_run.assert_called_once_with(
-            transport="sse", host="127.0.0.1", port=8000
-        )
+        mock_run.assert_called_once_with(transport="sse", host="127.0.0.1", port=8000)
 
-    def test_invalid_env_transport_exits_instead_of_reaching_run(
-        self, monkeypatch
-    ):
+    def test_invalid_env_transport_exits_instead_of_reaching_run(self, monkeypatch):
         """argparse validates `choices` only for command-line values.
 
         The env var is the configuration channel in every container, so an
@@ -212,15 +206,14 @@ class TestMainArgParser:
         monkeypatch.delenv("MCP_PORT", raising=False)
 
         monkeypatch.setattr(
-            sys, "argv",
+            sys,
+            "argv",
             ["server", "--transport", "sse", "--host", "0.0.0.0", "--port", "9090"],
         )
 
         srv.main()
 
-        mock_run.assert_called_once_with(
-            transport="sse", host="0.0.0.0", port=9090
-        )
+        mock_run.assert_called_once_with(transport="sse", host="0.0.0.0", port=9090)
 
     def test_env_var_overrides(self, monkeypatch):
         """Environment variables MCP_TRANSPORT / MCP_HOST / MCP_PORT override defaults."""

--- a/tests/test_signal_acquisition_init.py
+++ b/tests/test_signal_acquisition_init.py
@@ -10,20 +10,28 @@ class TestSignalAcquisitionImports:
 
     def test_import_load_signal_data(self):
         from predictive_maintenance_mcp.signal_acquisition import load_signal_data
+
         assert callable(load_signal_data)
 
     def test_import_extract_segment(self):
         from predictive_maintenance_mcp.signal_acquisition import extract_segment
+
         assert callable(extract_segment)
 
     def test_import_get_metadata_path(self):
         from predictive_maintenance_mcp.signal_acquisition import get_metadata_path
+
         assert callable(get_metadata_path)
 
     def test_import_signal_repository(self):
-        from predictive_maintenance_mcp.signal_acquisition import SignalRepository, get_repository
+        from predictive_maintenance_mcp.signal_acquisition import (
+            SignalRepository,
+            get_repository,
+        )
+
         assert callable(get_repository)
 
     def test_import_supported_extensions(self):
         from predictive_maintenance_mcp.signal_acquisition import SUPPORTED_EXTENSIONS
+
         assert isinstance(SUPPORTED_EXTENSIONS, (list, tuple, set, frozenset))

--- a/tests/test_signal_loader.py
+++ b/tests/test_signal_loader.py
@@ -22,8 +22,8 @@ from predictive_maintenance_mcp.signal_acquisition.loaders import (
     DATA_DIR,
 )
 
-
 # ── load_signal_data ───────────────────────────────────────────────────────
+
 
 class TestLoadSignalData:
 
@@ -33,7 +33,9 @@ class TestLoadSignalData:
         csv_file = tmp_path / "test.csv"
         pd.DataFrame(data).to_csv(csv_file, header=False, index=False)
 
-        monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path)
+        monkeypatch.setattr(
+            "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path
+        )
         signal = load_signal_data("test.csv")
         np.testing.assert_array_almost_equal(signal, data)
 
@@ -42,17 +44,22 @@ class TestLoadSignalData:
         data = np.array([1.1, 2.2, 3.3, 4.4])
         np.save(tmp_path / "test.npy", data)
 
-        monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path)
+        monkeypatch.setattr(
+            "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path
+        )
         signal = load_signal_data("test.npy")
         np.testing.assert_array_equal(signal, data)
 
     def test_load_mat(self, tmp_path, monkeypatch):
         """Load a MATLAB .mat file."""
         from scipy.io import savemat
+
         data = np.array([10.0, 20.0, 30.0])
         savemat(str(tmp_path / "test.mat"), {"signal": data})
 
-        monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path)
+        monkeypatch.setattr(
+            "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path
+        )
         signal = load_signal_data("test.mat")
         assert signal is not None
         np.testing.assert_array_almost_equal(signal, data)
@@ -60,11 +67,14 @@ class TestLoadSignalData:
     def test_load_wav(self, tmp_path, monkeypatch):
         """Load a WAV audio file."""
         from scipy.io import wavfile
+
         fs = 16000
         data = (np.sin(np.linspace(0, 2 * np.pi * 440, fs)) * 32767).astype(np.int16)
         wavfile.write(str(tmp_path / "test.wav"), fs, data)
 
-        monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path)
+        monkeypatch.setattr(
+            "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path
+        )
         signal = load_signal_data("test.wav")
         assert signal is not None
         assert len(signal) == len(data)
@@ -73,7 +83,10 @@ class TestLoadSignalData:
         assert np.max(np.abs(signal)) <= 1.0 + 1e-6
 
     @pytest.mark.skipif(
-        not any(__import__("importlib").util.find_spec(e) for e in ("pyarrow", "fastparquet")),
+        not any(
+            __import__("importlib").util.find_spec(e)
+            for e in ("pyarrow", "fastparquet")
+        ),
         reason="pyarrow/fastparquet not installed",
     )
     def test_load_parquet(self, tmp_path, monkeypatch):
@@ -81,30 +94,39 @@ class TestLoadSignalData:
         data = np.array([1.5, 2.5, 3.5, 4.5, 5.5])
         pd.DataFrame({"signal": data}).to_parquet(tmp_path / "test.parquet")
 
-        monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path)
+        monkeypatch.setattr(
+            "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path
+        )
         signal = load_signal_data("test.parquet")
         assert signal is not None
         np.testing.assert_array_almost_equal(signal, data)
 
     def test_missing_file_returns_none(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path)
+        monkeypatch.setattr(
+            "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path
+        )
         assert load_signal_data("nonexistent.csv") is None
 
     def test_unsupported_extension_returns_none(self, tmp_path, monkeypatch):
         (tmp_path / "test.xyz").write_text("data")
-        monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path)
+        monkeypatch.setattr(
+            "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path
+        )
         assert load_signal_data("test.xyz") is None
 
     def test_wav_stereo_uses_first_channel(self, tmp_path, monkeypatch):
         """Stereo WAV should use first channel only."""
         from scipy.io import wavfile
+
         fs = 8000
         ch1 = (np.sin(np.linspace(0, 2 * np.pi * 300, fs)) * 32767).astype(np.int16)
         ch2 = (np.sin(np.linspace(0, 2 * np.pi * 600, fs)) * 32767).astype(np.int16)
         stereo = np.column_stack([ch1, ch2])
         wavfile.write(str(tmp_path / "stereo.wav"), fs, stereo)
 
-        monkeypatch.setattr("predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path)
+        monkeypatch.setattr(
+            "predictive_maintenance_mcp.signal_acquisition.loaders.DATA_DIR", tmp_path
+        )
         signal = load_signal_data("stereo.wav")
         assert signal is not None
         assert signal.ndim == 1
@@ -121,6 +143,7 @@ class TestLoadSignalData:
 
 
 # ── extract_segment ────────────────────────────────────────────────────────
+
 
 class TestExtractSegment:
 
@@ -169,6 +192,7 @@ class TestExtractSegment:
 
 
 # ── get_metadata_path ──────────────────────────────────────────────────────
+
 
 class TestGetMetadataPath:
 

--- a/tests/test_signal_repository.py
+++ b/tests/test_signal_repository.py
@@ -215,6 +215,7 @@ class TestEdgeCases:
     def test_load_mat_direct(self, repo, tmp_path):
         """Test loading a .mat file via direct fallback loader."""
         from scipy.io import savemat
+
         data = np.random.randn(500)
         mat_path = tmp_path / "test_mat.mat"
         savemat(str(mat_path), {"vibration": data})
@@ -398,9 +399,7 @@ class TestBatchLoad:
         # Only the pre-existing signal remains — none of the batch landed.
         assert repo.signal_count == 1
 
-    def test_batch_collision_with_overwrite_succeeds(
-        self, repo, data_dir, batch_files
-    ):
+    def test_batch_collision_with_overwrite_succeeds(self, repo, data_dir, batch_files):
         repo.load_signal(batch_files[0])
         infos = repo.load_signals(batch_files, overwrite=True)
         assert len(infos) == 3

--- a/tests/test_spectral.py
+++ b/tests/test_spectral.py
@@ -138,9 +138,7 @@ class TestComputeEnvelopeSpectrum:
 
     def test_envelope_handles_narrow_band(self, bearing_fault_signal):
         signal, fs = bearing_fault_signal
-        result = compute_envelope_spectrum(
-            signal, fs, frequency_range=(1500, 2500)
-        )
+        result = compute_envelope_spectrum(signal, fs, frequency_range=(1500, 2500))
         assert len(result["top_peaks"]) > 0
 
     def test_envelope_num_samples(self, sine_signal):
@@ -209,9 +207,7 @@ class TestBandValidation:
         carrier = np.sin(2 * np.pi * 2000 * t)
         signal = carrier * (1.0 + 0.5 * np.sin(2 * np.pi * 81 * t))
         default = compute_envelope_spectrum(signal, fs)
-        explicit = compute_envelope_spectrum(
-            signal, fs, frequency_range=(500, 5000)
-        )
+        explicit = compute_envelope_spectrum(signal, fs, frequency_range=(500, 5000))
         assert default["top_peaks"] == explicit["top_peaks"]
 
 
@@ -240,8 +236,7 @@ class TestEnvelopeDetrendWindow:
         )
         freqs = [p["frequency_hz"] for p in result["top_peaks"]]
         assert any(abs(f - 11.0) < 2.0 for f in freqs), (
-            f"Expected the 11 Hz FTF-zone modulation in the top peaks, "
-            f"got {freqs}"
+            f"Expected the 11 Hz FTF-zone modulation in the top peaks, " f"got {freqs}"
         )
 
     def test_unmodulated_carrier_no_low_freq_peaks(self):

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -21,7 +21,7 @@ def test_imports():
         import mcp
         from pydantic import BaseModel
         from importlib.metadata import version as pkg_version
-        
+
         print("✅ All dependencies imported successfully")
         print(f"   - NumPy: {np.__version__}")
         print(f"   - SciPy: {scipy.__version__}")
@@ -37,30 +37,31 @@ def test_signal_generation():
     try:
         import numpy as np
         from pathlib import Path
-        
+
         # Create directory if it doesn't exist
         data_dir = Path(__file__).parent / "data" / "signals"
         data_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # Generate a simple sine wave signal
         fs = 1000  # Hz
         duration = 1.0  # seconds
         freq = 50  # Hz
-        
+
         t = np.linspace(0, duration, int(fs * duration))
         signal = np.sin(2 * np.pi * freq * t)
-        
+
         # Save
         import pandas as pd
+
         filepath = data_dir / "test_sine_50Hz.csv"
         pd.DataFrame(signal).to_csv(filepath, index=False, header=False)
-        
+
         print(f"✅ Test signal generated: {filepath.name}")
         print(f"   - Frequency: {freq} Hz")
         print(f"   - Sampling rate: {fs} Hz")
         print(f"   - Duration: {duration} s")
         print(f"   - Samples: {len(signal)}")
-        
+
     except Exception as e:
         pytest.fail(f"Signal generation error: {e}")
 
@@ -71,30 +72,30 @@ def test_fft():
     try:
         import numpy as np
         from scipy.fft import fft, fftfreq
-        
+
         # Create test signal
         fs = 1000
         t = np.linspace(0, 1, fs)
         signal = np.sin(2 * np.pi * 50 * t) + 0.5 * np.sin(2 * np.pi * 120 * t)
-        
+
         # FFT
         N = len(signal)
         fft_vals = fft(signal)
-        freqs = fftfreq(N, 1/fs)
-        
+        freqs = fftfreq(N, 1 / fs)
+
         # Only positive frequencies
         pos_idx = freqs > 0
         freqs = freqs[pos_idx]
         mags = np.abs(fft_vals[pos_idx])
-        
+
         # Find peaks
         peak_idx = np.argmax(mags)
         peak_freq = freqs[peak_idx]
-        
+
         print(f"✅ FFT analysis successful")
         print(f"   - Peak frequency: {peak_freq:.1f} Hz (expected: 50 Hz)")
         print(f"   - Frequency resolution: {fs/N:.2f} Hz")
-        
+
     except Exception as e:
         pytest.fail(f"FFT test error: {e}")
 
@@ -105,23 +106,23 @@ def test_statistics():
     try:
         import numpy as np
         from scipy.stats import kurtosis, skew
-        
+
         # Test signal
         signal = np.random.randn(1000)
-        
+
         # Calculate statistics
         rms = np.sqrt(np.mean(signal**2))
         peak = np.max(np.abs(signal))
         cf = peak / rms
         kurt = kurtosis(signal, fisher=True)
         skewness = skew(signal)
-        
+
         print(f"✅ Statistical analysis successful")
         print(f"   - RMS: {rms:.3f}")
         print(f"   - Crest Factor: {cf:.2f}")
         print(f"   - Kurtosis: {kurt:.2f}")
         print(f"   - Skewness: {skewness:.2f}")
-        
+
     except Exception as e:
         pytest.fail(f"Statistics test error: {e}")
 
@@ -132,48 +133,48 @@ def print_project_info():
     print("🔧 MACHINERY DIAGNOSTICS MCP SERVER")
     print("=" * 70)
     print("\n📁 Project Structure:")
-    
+
     root = Path(__file__).parent.parent
     print(f"   Root: {root}")
     print(f"   Src:  {root / 'src'}")
     print(f"   Data: {root / 'data' / 'signals'}")
-    
+
     print("\n🚀 Quick Start:")
     print("   1. Test server:  uv run predictive-maintenance-mcp")
     print("   2. Run tests:    uv run python test_suite.py")
     print("   3. Read docs:    type README.md")
-    
+
     print("\n🔧 Available Tools:")
     print("   - analyze_fft:         Fast Fourier Transform analysis")
     print("   - analyze_envelope:    Envelope analysis for bearing faults")
     print("   - analyze_statistics:  Statistical parameters (RMS, Kurtosis, CF)")
     print("   - generate_test_signal: Generate test signals")
-    
+
     print("\n📚 Resources:")
     print("   - signal://list:           List all available signals")
     print("   - signal://read/{filename}: Read specific signal file")
-    
+
     print("\n💡 Prompts:")
     print("   - diagnose_bearing:        Complete bearing diagnostic workflow")
     print("   - diagnose_gear:          Gear diagnostic workflow")
     print("   - quick_diagnostic_report: Quick machinery screening")
-    
+
     print("\n" + "=" * 70 + "\n")
 
 
 def main():
     """Run all tests."""
     print_project_info()
-    
+
     print("🧪 Running Test Suite...\n")
-    
+
     tests = [
         ("Import Test", test_imports),
         ("Signal Generation", test_signal_generation),
         ("FFT Analysis", test_fft),
         ("Statistical Analysis", test_statistics),
     ]
-    
+
     results = []
     for name, test_func in tests:
         try:
@@ -182,29 +183,29 @@ def main():
         except Exception as e:
             print(f"❌ {name} failed with exception: {e}")
             results.append((name, False))
-    
+
     # Summary
     print("\n" + "=" * 70)
     print("📊 TEST SUMMARY")
     print("=" * 70)
-    
+
     passed = sum(1 for _, result in results if result)
     total = len(results)
-    
+
     for name, result in results:
         status = "✅ PASSED" if result else "❌ FAILED"
         print(f"   {status}: {name}")
-    
+
     print(f"\n   Total: {passed}/{total} tests passed")
-    
+
     if passed == total:
         print("\n🎉 All tests passed! Server is ready to use.")
         print("\n   Start with: uv run predictive-maintenance-mcp")
     else:
         print("\n⚠️  Some tests failed. Please check the errors above.")
-    
+
     print("=" * 70 + "\n")
-    
+
     return passed == total
 
 

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -24,7 +24,6 @@ from mcp.server.mcpserver import MCPServer
 
 from predictive_maintenance_mcp.mcp_tools import register_all
 
-
 # ---------------------------------------------------------------------------
 # The migration table. Keys: every endpoint name that existed in v0.8.x
 # (46 tools, 4 resources, 4 prompts). Values: (destination, note) where
@@ -76,7 +75,10 @@ OLD_TO_NEW: dict[str, tuple[str | None, str]] = {
     # ----- diagnostics -----------------------------------------------------
     "evaluate_iso_20816": ("assess_severity", "merged (U9a) — signal route"),
     "assess_vibration_severity": ("assess_severity", "merged (U9a) — signal route"),
-    "check_vibration_alert": ("assess_severity", "merged (U9a) — rms_velocity_mm_s route"),
+    "check_vibration_alert": (
+        "assess_severity",
+        "merged (U9a) — rms_velocity_mm_s route",
+    ),
     "check_custom_vibration_alert": (
         "assess_severity",
         "merged (U9a) — thresholds={'warning','alarm','danger'} parameter",
@@ -85,7 +87,10 @@ OLD_TO_NEW: dict[str, tuple[str | None, str]] = {
         "check_bearing_faults",
         "merged (U9a) — frequencies={label: hz} route with one entry",
     ),
-    "check_bearing_faults_direct": ("check_bearing_faults", "merged (U9a) — bearing_id route"),
+    "check_bearing_faults_direct": (
+        "check_bearing_faults",
+        "merged (U9a) — bearing_id route",
+    ),
     "lookup_bearing_and_compute_tool": (
         "check_bearing_faults",
         "merged (U9a) — bearing_id route resolves prefixed designations",
@@ -129,20 +134,35 @@ OLD_TO_NEW: dict[str, tuple[str | None, str]] = {
         "generate_iso_report",
         "merged — the ISO report embeds the color-coded A-D zone bar chart",
     ),
-    "generate_fft_report": ("generate_fft_report", "kept — rotation_freq (Hz) renamed to rpm"),
+    "generate_fft_report": (
+        "generate_fft_report",
+        "kept — rotation_freq (Hz) renamed to rpm",
+    ),
     "generate_envelope_report": ("generate_envelope_report", "kept"),
-    "generate_iso_report": ("generate_iso_report", "kept — delegates to assess_severity"),
+    "generate_iso_report": (
+        "generate_iso_report",
+        "kept — delegates to assess_severity",
+    ),
     "generate_diagnostic_report_docx": ("generate_diagnostic_report_docx", "kept"),
     "generate_pca_visualization_report": ("generate_pca_visualization_report", "kept"),
-    "generate_feature_comparison_report": ("generate_feature_comparison_report", "kept"),
+    "generate_feature_comparison_report": (
+        "generate_feature_comparison_report",
+        "kept",
+    ),
     "list_html_reports": ("list_html_reports", "kept — absorbs get_report_info"),
     "get_report_info": (
         "list_html_reports",
         "merged — list_html_reports(file_name=...) via safe_resolve read path",
     ),
     # ----- prognostics -----------------------------------------------------
-    "analyze_signal_trend": ("analyze_signal_trend", "kept — THE unified screening tool"),
-    "detect_signal_degradation_onset": ("analyze_signal_trend", "merged (U9a) — onset block"),
+    "analyze_signal_trend": (
+        "analyze_signal_trend",
+        "kept — THE unified screening tool",
+    ),
+    "detect_signal_degradation_onset": (
+        "analyze_signal_trend",
+        "merged (U9a) — onset block",
+    ),
     "estimate_rul": ("estimate_rul", "kept — multi-measurement contract (U4)"),
     # ----- decision --------------------------------------------------------
     "generate_maintenance_recommendations": (
@@ -155,13 +175,19 @@ OLD_TO_NEW: dict[str, tuple[str | None, str]] = {
         "get_signal_info",
         "resource dropped — get_signal_info exposes metadata incl. source_metadata",
     ),
-    "manual://list": ("list_machine_manuals", "resource dropped — duplicate of the tool"),
+    "manual://list": (
+        "list_machine_manuals",
+        "resource dropped — duplicate of the tool",
+    ),
     "manual://read/{filename}": (
         "read_manual_excerpt",
         "resource dropped — duplicate of the tool",
     ),
     # ----- prompts ---------------------------------------------------------
-    "diagnose_bearing": ("diagnose_bearing", "kept — call templates fixed to valid kwargs"),
+    "diagnose_bearing": (
+        "diagnose_bearing",
+        "kept — call templates fixed to valid kwargs",
+    ),
     "diagnose_gear": ("diagnose_gear", "kept — call templates fixed to valid kwargs"),
     "quick_diagnostic_report": ("quick_diagnostic_report", "kept"),
     "generate_iso_diagnostic_report": (
@@ -242,9 +268,9 @@ class TestMappingCompleteness:
             destination, note = entry
             assert note and isinstance(note, str), f"{old}: motivation missing"
             if destination is None:
-                assert "dropped" in note.lower(), (
-                    f"{old}: a None destination requires a drop motivation"
-                )
+                assert (
+                    "dropped" in note.lower()
+                ), f"{old}: a None destination requires a drop motivation"
 
 
 # ---------------------------------------------------------------------------
@@ -257,12 +283,12 @@ class TestDestinationsExist:
         tools, _, _ = registered
         for old in sorted(OLD_TOOLS | OLD_RESOURCES):
             destination, _ = OLD_TO_NEW[old]
-            assert destination is not None, (
-                f"{old}: tools/resources must map into the tool surface"
-            )
-            assert destination in tools, (
-                f"{old} -> {destination}: destination not registered"
-            )
+            assert (
+                destination is not None
+            ), f"{old}: tools/resources must map into the tool surface"
+            assert (
+                destination in tools
+            ), f"{old} -> {destination}: destination not registered"
 
     def test_prompt_destinations_are_registered_prompts(self, registered):
         _, _, prompts = registered
@@ -270,9 +296,9 @@ class TestDestinationsExist:
             destination, _ = OLD_TO_NEW[old]
             if destination is None:
                 continue  # motivated drop
-            assert destination in prompts, (
-                f"{old} -> {destination}: destination prompt not registered"
-            )
+            assert (
+                destination in prompts
+            ), f"{old} -> {destination}: destination prompt not registered"
 
     def test_every_current_tool_is_migrated_or_declared(self, registered):
         """No orphan tools.
@@ -311,9 +337,7 @@ class TestDestinationsExist:
 
 
 class TestFinalSurface:
-    def test_counts_are_the_migrated_surface_plus_declared_additions(
-        self, registered
-    ):
+    def test_counts_are_the_migrated_surface_plus_declared_additions(self, registered):
         tools, resources, prompts = registered
         assert len(tools) == 33 + len(POST_U9_ADDITIONS)
         assert resources == []

--- a/tests/test_tool_inventory.py
+++ b/tests/test_tool_inventory.py
@@ -77,10 +77,7 @@ def build_inventory() -> dict:
         },
         "resources": sorted(
             [str(uri) for uri in mcp._resource_manager._resources.keys()]
-            + [
-                str(t.uri_template)
-                for t in mcp._resource_manager._templates.values()
-            ]
+            + [str(t.uri_template) for t in mcp._resource_manager._templates.values()]
         ),
         "prompts": {
             p.name: sorted(a.name for a in (p.arguments or []))

--- a/tests/test_version_alignment.py
+++ b/tests/test_version_alignment.py
@@ -183,8 +183,7 @@ class TestEndpointCountClaims:
         text = _read(readme)
         expected = component_counts[kind]
         wrong = [
-            f"{readme}: claims '{snippet}' but plugin/ contains "
-            f"{expected} {kind}"
+            f"{readme}: claims '{snippet}' but plugin/ contains " f"{expected} {kind}"
             for value, snippet in _claims(text, kind)
             if value != expected
         ]
@@ -203,9 +202,9 @@ class TestEndpointCountClaims:
     def test_plugin_readme_states_component_counts(self):
         text = _read("plugin/README.md")
         for kind in ("skills", "agents", "commands"):
-            assert _claims(text, kind), (
-                f"plugin/README.md: no recognizable '{kind}' count claim"
-            )
+            assert _claims(
+                text, kind
+            ), f"plugin/README.md: no recognizable '{kind}' count claim"
 
     def test_expected_final_surface(self, surface_counts):
         """The current surface, restated here so a surface change makes
@@ -255,7 +254,7 @@ class TestLockfileAgreesWithManifest:
         for name, spec in declared.items():
             # The lock echoes each requirement verbatim in [package.metadata]
             # requires-dist as `specifier = "<constraint>"`.
-            constraint = spec[len(spec.split(name)[0]) + len(name):].strip()
+            constraint = spec[len(spec.split(name)[0]) + len(name) :].strip()
             constraint = constraint.lstrip("]").strip()
             if constraint.startswith("["):
                 constraint = constraint.split("]", 1)[-1].strip()

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -28,7 +28,6 @@ from mcp.server.mcpserver import MCPServer
 from predictive_maintenance_mcp.mcp_tools import register_all
 from predictive_maintenance_mcp.signal_acquisition.repository import get_repository
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -289,9 +288,7 @@ async def test_w5_reports_walkable(tools, sandbox, mock_ctx):
 async def test_w6_trend_to_rul_walkable(tools, sandbox, mock_ctx):
     fs = 5000
     t = np.linspace(0, 2.0, 2 * fs, endpoint=False)
-    growing = (0.5 + 0.5 * t / t[-1]) * np.random.default_rng(1).standard_normal(
-        len(t)
-    )
+    growing = (0.5 + 0.5 * t / t[-1]) * np.random.default_rng(1).standard_normal(len(t))
     _write_signal(sandbox["signals"], "w6.csv", growing, fs)
     info = await tools["load_signal"](ctx=mock_ctx, filepath="w6.csv")
 
@@ -329,9 +326,7 @@ async def test_w7_documentation_walkable(tools, sandbox, mock_ctx):
     listing = await tools["list_machine_manuals"](ctx=mock_ctx)
     assert [m["filename"] for m in listing] == ["pump_manual.txt"]
 
-    text = await tools["read_manual_excerpt"](
-        ctx=mock_ctx, file_name="pump_manual.txt"
-    )
+    text = await tools["read_manual_excerpt"](ctx=mock_ctx, file_name="pump_manual.txt")
     assert "SKF 6205-2RS" in text
 
     catalog_hit = await tools["search_bearing_catalog"](
@@ -355,19 +350,13 @@ async def test_w8_signal_management_walkable(tools, sandbox, mock_ctx):
     assert disk["count"] >= 1
 
     memory = await tools["list_signals"](ctx=mock_ctx, scope="memory")
-    assert any(
-        s["signal_id"] == generated.signal_id for s in memory["signals"]
-    )
+    assert any(s["signal_id"] == generated.signal_id for s in memory["signals"])
 
-    info = await tools["get_signal_info"](
-        ctx=mock_ctx, signal_id=generated.signal_id
-    )
+    info = await tools["get_signal_info"](ctx=mock_ctx, signal_id=generated.signal_id)
     assert info.source_metadata["signal_type"] == "normal"
     assert info.signal_unit == "g"
 
-    one = await tools["clear_signals"](
-        ctx=mock_ctx, signal_id=generated.signal_id
-    )
+    one = await tools["clear_signals"](ctx=mock_ctx, signal_id=generated.signal_id)
     assert one["status"] == "removed"
 
     remaining = await tools["clear_signals"](ctx=mock_ctx)


### PR DESCRIPTION
The `format-check` job ran `black --check` with `continue-on-error: true`, so it reported pass unconditionally — the same decorative-check defect PR #39 removed from the mypy job, and the fifth instance of that pattern in this repo this week.

Three commits, deliberately separable:

1. **`style: apply black to src and tests`** — formatting only, 70 files.
2. **`ci(format): make the Black check blocking`** — drops `continue-on-error`.
3. **`test(ci): guard every job in the workflow against going decorative`** — generalises the mypy-only guard from `test_mypy_baseline_gate.py` into `tests/test_ci_gates.py`, covering every job with an explicit allowlist.

## Verification

Not reviewed by personas; verified mechanically, which is the stronger check for a diff of this shape.

**The `style:` commit is provably semantics-preserving.** Every changed `.py` file was AST-compared against `main`:

```
python files in diff : 72
AST-compared         : 71
genuinely new files  : 1  (tests/test_ci_gates.py)
AST differences      : 12
  ... of which docstring re-indentation : 11
  ... genuine                           : 1  (tests/test_mypy_baseline_gate.py)
```

The 11 are Black normalising docstring indentation, which changes the string value and therefore the AST — expected. The 1 genuine change is **not** in the `style:` commit: it is in commit 3, which moves `test_the_ci_job_still_blocks` out to the new file and leaves a docstring note saying where it went. Correct attribution.

**The new guard is mutation-tested.** Re-injecting `continue-on-error: true` into `format-check`:

```
FAILED tests/test_ci_gates.py::test_no_check_is_non_blocking_outside_the_allowlist
E   assert not {('format-check', 'Check code formatting')}
```

**Everything else holds.** `black --check --line-length=88 src tests` → 92 files unchanged. `tools/check_mypy_baseline.py` → OK, 33 within baseline. Suite: **1024 passed, 20 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)