### PR TITLE
feat(docs): audience funnel, guarded claims, and adapter guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,8 @@ docs/plans/
 docs/residual-review-findings/
 docs/solutions/
 docs/AUDIT-*.md
+docs/issue-drafts/
+docs/distribution-kit/
 
 # Claude Code per-agent worktrees
 .claude/worktrees/

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -23,8 +23,7 @@
     "FFT-analysis",
     "envelope-analysis",
     "industry-4.0",
-    "claude-ai",
-    
+    "claude-ai"
   ],
   "license": "MIT",
   "upload_type": "software",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,22 @@ metadata into the declaration is the user's (or an external adapter's) job.
   was never implemented and is too low for legitimate captures (1 h at
   25.6 kHz float32 ≈ 368 MB). Extending the cap to the other formats is
   follow-up work.
+- **`docs/TOOL_CATALOG.md` — the complete endpoint reference.** The full
+  tool/prompt catalog migrated out of the README onto a dedicated page,
+  guarded by CI against the registered surface: the set of listed names
+  must equal the registered endpoints exactly, so the catalog can neither
+  list a phantom endpoint nor silently omit a real one.
+- **`docs/ADAPTER_GUIDE.md` — external adapter guide.** Documents how an
+  external adapter translates vendor metadata into the `load_signal`
+  declaration and companion-file parameters. The guide's parameter table —
+  names, allowed values, defaults, required flags — is guarded by CI
+  against the code's own exports, in both directions.
+
+### Changed
+- **README restructured around audience entry paths.** Readers are routed
+  by goal (use, evaluate, extend, contribute), with the measured-benchmark
+  section above the fold; the full tool catalog moved to its own page
+  (`docs/TOOL_CATALOG.md`), leaving the README a short guarded summary.
 
 ### Fixed
 - **`.dat` was listed but unloadable.** The extension sat in
@@ -64,6 +80,12 @@ metadata into the declaration is the user's (or an external adapter's) job.
   files — but no loader branch existed, so every load failed. `.dat` is now
   raw-eligible on the same terms as `.bin`/`.raw`: it loads with a declared
   decode contract and is refused with the full remedy message without one.
+- **Stale public claims corrected and guarded.** Endpoint counts, the
+  plugin skill count, the landing page's software version, and the test
+  coverage figure (now stated as the CI-enforced minimum rather than a
+  measured snapshot) had drifted on public surfaces; the CI guards now
+  scan every copy on every public surface, so the next drift goes red
+  instead of shipping.
 
 ### Security
 - Path-containment tests extended to raw reads: relative traversal,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ Not everyone contributes in the same way, and **all contributions are equally va
 **The architecture is clean and extensible.** Adding a new MCP tool is as simple as writing a Python function with a decorator.
 
 - Add new diagnostic tools
+- Write an adapter for a vendor or DAQ data format
 - Improve ML models
 - Build Docker support
 - Enhance the report system
@@ -133,12 +134,13 @@ Browse [**Issues**](https://github.com/LGDiMaggio/predictive-maintenance-mcp/iss
 
 **Can't find a matching issue?** [Open a discussion](https://github.com/LGDiMaggio/predictive-maintenance-mcp/discussions) to propose your idea first.
 
-**Before you start:** `docs/solutions/` holds write-ups of problems this project
-has already hit — bugs, security fixes, and durable patterns — organized by
-category with YAML frontmatter (`module`, `tags`, `problem_type`) so you can
-search it. Worth a look when you're implementing or debugging in an area it
-covers; several entries exist because the obvious approach turned out to be
-wrong in a way that isn't visible from the code alone.
+**Before you start:** search the existing
+[issues](https://github.com/LGDiMaggio/predictive-maintenance-mcp/issues) and
+[discussions](https://github.com/LGDiMaggio/predictive-maintenance-mcp/discussions) —
+the problem you're about to solve may already be mapped, in progress, or
+explained. The guides in `docs/` (quickstarts, tool catalog, adapter guide,
+deployment, benchmark methodology) are the fastest way to pick up the
+project's conventions in the area you're touching.
 
 ### 2. Claim the Issue
 
@@ -279,7 +281,7 @@ flake8 src/ --max-line-length=120
 python tools/check_mypy_baseline.py
 
 # Commit with clear messages
-git commit -m "feat: Add parquet file reading support
+git commit -m "feat(acquisition): add parquet file reading support
 
 - Add load_parquet() function in signal loading
 - Support both single and multi-column parquet files
@@ -309,6 +311,12 @@ Summary:
 3. Add tests in `tests/`
 4. Update `EXAMPLES.md` if the tool adds a new workflow
 5. Submit PR
+
+### Write an Adapter
+
+The server loads headerless raw binary files (`.bin`/`.raw`/`.dat`) through an **explicit decode declaration** — it ships no vendor parsers and infers nothing from file content or names. An adapter is any script that translates a vendor's or DAQ's metadata into that declaration, typically by emitting companion `<stem>_metadata.json` files next to the signal files. There is no plugin API and nothing to register: adapters run outside the server, in any language.
+
+The full contract — declaration parameters, companion file schema, merge precedence, and a worked example — is in the [Adapter Guide](docs/ADAPTER_GUIDE.md).
 
 ### Architecture Contributions
 
@@ -376,7 +384,7 @@ What actually happens (include full error message)
 **Environment:**
 - OS: Windows 11 / macOS 14 / Ubuntu 22.04
 - Python: 3.11.x / 3.12.x
-- Server version: 0.7.1
+- Server version: x.y.z
 ```
 
 ---
@@ -422,7 +430,7 @@ pytest --cov=src --cov-report=term-missing
 ### Commit Message Format
 
 ```
-<type>: <subject>
+<type>(<scope>): <subject>
 
 <body>
 
@@ -431,9 +439,11 @@ pytest --cov=src --cov-report=term-missing
 
 **Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 
+**Scope**: the area the change touches (e.g. `analysis`, `reports`, `acquisition`, `benchmark`, `docs`)
+
 **Example:**
 ```
-feat: Add bearing frequency calculator tool
+feat(analysis): add bearing frequency calculator tool
 
 - Implements calculate_bearing_frequencies() function
 - Adds validation for bearing parameters

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The codebase follows a **modular architecture** organized around the ISO 13374 S
 | [Quickstart for Engineers](docs/QUICKSTART_ENGINEER.md) | Get results fast, no coding required |
 | [Quickstart for Developers](docs/QUICKSTART_DEVELOPER.md) | Understand MCP, extend the server |
 | [Tool Catalog](docs/TOOL_CATALOG.md) | Every MCP endpoint, grouped by category |
+| [Adapter Guide](docs/ADAPTER_GUIDE.md) | Bring vendor/DAQ raw data in via explicit declarations |
 | [Plugin README](plugin/README.md) | Claude Code plugin installation and usage |
 | [HTTPS Deployment](docs/DEPLOYMENT.md) | Docker + HTTPS for enterprise environments |
 | [Ollama Guide](docs/OLLAMA_GUIDE.md) | Use with local LLMs (fully air-gapped) |

--- a/README.md
+++ b/README.md
@@ -8,17 +8,29 @@
 [![codecov](https://codecov.io/gh/LGDiMaggio/predictive-maintenance-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/LGDiMaggio/predictive-maintenance-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Give any AI assistant the ability to analyze vibration data, detect machinery faults, and generate professional diagnostic reports — through natural conversation.**
+**Give your AI assistant evidence-based vibration diagnostics — machinery fault detection, ISO-cited severity, and diagnostic reports built to support and accelerate expert decision-making.**
 
-An open-source [MCP](https://modelcontextprotocol.io/) server and **predictive maintenance AI agent** that turns LLMs into condition monitoring assistants. Engineers describe what they need in plain language; the AI calls the right analysis tools and delivers results — bearing fault detection, risk assessment, anomaly detection, and remaining useful life estimation. Also available as a **Claude Code plugin** with 8 diagnostic skills. It's designed to **support and accelerate expert decision-making**.
+An open-source [MCP](https://modelcontextprotocol.io/) server that turns LLMs into condition monitoring assistants for reliability engineers. Its core design rule: **the server refuses to guess**. No diagnosis is ever inferred from filenames or statistical parameters alone — a fault indication requires matching spectral evidence. Every severity claim cites ISO 20816-3, and the evaluative wording in reports is authored by the server, not improvised by the model. The AI orchestrates the analysis and presents the evidence — detected fault frequencies, matched fault patterns, severity zones — while the final judgment stays with the engineer. Also available as a **Claude Code plugin** with 8 diagnostic skills.
 
 ---
 
-## Who is this for?
+## See It in Action
 
-- **Reliability & maintenance engineers** who want fast vibration diagnostics in plain language — no coding required. It augments and accelerates expert judgment; it doesn't replace it.
-- **Developers & industrial-AI practitioners** who want to expose predictive-maintenance workflows as MCP tools and build on top of them.
-- **Researchers & students** working on bearing fault diagnosis, condition monitoring, or MCP / agent tooling.
+<p align="center">
+  <img src="assets/claude_gif.gif" alt="Predictive Maintenance MCP — diagnostic workflow in Claude Desktop" width="720">
+</p>
+
+<p align="center"><em>Full diagnostic workflow: load signal → spectral analysis → fault detection → severity assessment → report generation</em></p>
+
+---
+
+## Choose Your Path
+
+| You are | Start here |
+|---------|------------|
+| **Reliability / maintenance engineer** — diagnostics in plain language, no coding | [Engineer's Quickstart](docs/QUICKSTART_ENGINEER.md) |
+| **AI / MCP developer** — run, integrate, and extend the server | [Developer's Quickstart](docs/QUICKSTART_DEVELOPER.md) · [Quick Start](#quick-start) below |
+| **Researcher / evaluator** — how the numbers are measured | [Benchmark Methodology](docs/benchmark-methodology.md) · [Benchmark](#benchmark) below |
 
 ---
 
@@ -67,116 +79,59 @@ Find the full path to `uvx` (`which uvx` on macOS/Linux, `where uvx` on Windows)
 
 ---
 
-## See It in Action
+## Benchmark
 
-<p align="center">
-  <img src="assets/claude_gif.gif" alt="Predictive Maintenance MCP — diagnostic workflow in Claude Desktop" width="720">
-</p>
+A blind, reproducible diagnostic-accuracy benchmark on the public
+[CWRU Bearing Data Center](https://engineering.case.edu/bearingdatacenter)
+dataset (12 kHz drive-end subset: 60 fault records + 4 normal baselines).
+Fault labels never reach the system under test — signals enter under opaque
+ids, a separate scorer is the only label reader, and blindness, checksum
+integrity, and determinism are enforced by CI-run guard tests, not prose.
+Results are stratified by the per-record diagnosability grades of the
+Smith & Randall (2015) reference study, so records that study found
+undiagnosable by any classical method are reported separately instead of
+inflating or deflating the headline.
 
-<p align="center"><em>Full diagnostic workflow: load signal → spectral analysis → fault detection → severity assessment → report generation</em></p>
+<!-- cwru-benchmark:start -->
+On records the reference study grades clearly diagnosable (Y1+Y2, <!-- slot: headline.n_records -->44<!-- /slot --> records):
+characteristic fault frequency detected on <!-- slot: headline.frequency_detection.hits -->44<!-- /slot -->/<!-- slot: headline.frequency_detection.total -->44<!-- /slot -->,
+correct fault ranked first on <!-- slot: headline.classification.correct -->34<!-- /slot -->/<!-- slot: headline.classification.total -->44<!-- /slot --> (<!-- slot: headline.classification.rate pct1 -->77.3<!-- /slot -->%),
+and <!-- slot: strata.Y1.classification.correct -->9<!-- /slot -->/<!-- slot: strata.Y1.classification.total -->9<!-- /slot --> on the textbook-signature (Y1) stratum.
+On the <!-- slot: strata.ungraded.false_positives.total_normal -->4<!-- /slot --> healthy baselines, <!-- slot: strata.ungraded.false_positives.records_with_any -->2<!-- /slot --> records raised a false indication under the same criterion.
+<!-- cwru-benchmark:end -->
+
+The numbers above are read from the committed, re-runnable artifact
+([results.json](benchmarks/cwru/results/results.json)) and drift-guarded by CI:
+every value is bound to its key in the artifact, and a mismatch fails the build.
+Methodology, blind protocol, and honest-benchmarking notes:
+[docs/benchmark-methodology.md](docs/benchmark-methodology.md). Reproduce with:
+
+```bash
+python -m benchmarks.cwru all
+```
 
 ---
 
 ## What Can It Do?
 
-**Upload a vibration signal → get a professional diagnosis through conversation.**
+**Point the AI at a vibration signal → get the evidence behind the fault — detected frequencies, matched fault patterns, ISO-cited severity — to support your call.**
 
 | You say | The AI does |
 |---------|-------------|
-| *"Is this bearing healthy?"* | Loads the signal, runs spectral analysis, checks for fault patterns, classifies severity |
-| *"Generate a full diagnostic report"* | Produces an interactive HTML report with charts, fault markers, and severity assessment |
-| *"Extract specs from test_pump_manual.pdf and diagnose the signal"* | Reads the equipment manual, looks up the bearing model, calculates expected fault frequencies, matches them against the signal |
-| *"Train an anomaly detector on my healthy baselines, then flag anomalies"* | Trains a machine learning model on normal data, scores new signals, highlights outliers |
+| *"Is this bearing healthy?"* | Loads the signal, runs spectral analysis, surfaces matching fault-frequency evidence, cites the ISO 20816-3 severity zone |
+| *"Generate a full diagnostic report"* | Produces an interactive HTML report with charts, fault markers, and server-authored severity wording |
+| *"Extract specs from test_pump_manual.pdf and diagnose the signal"* | Reads the equipment manual, looks up the bearing model, calculates expected fault frequencies, flags which ones the signal actually shows |
+| *"Train an anomaly detector on my healthy baselines, then flag anomalies"* | Trains a model on your normal data, scores new signals, flags outliers for your review |
 
 The AI doesn't guess — it calls **37 specialized MCP endpoints** (34 tools + 3 prompts) running locally on your machine. Every signal is referenced by a single `signal_id` handle from load to report. Your data never leaves your infrastructure.
 
-<details>
-<summary><b>See the full endpoint list (37 MCP endpoints: 34 tools, 3 prompts)</b></summary>
-
-### Signal Lifecycle (5)
-
-| Tool | Description |
-|------|-------------|
-| `load_signal` | Load vibration file(s) (CSV, WAV, MAT, NPY, Parquet, raw binary `.bin`/`.raw`/`.dat` with declared decode metadata) with declared sampling rate and unit — returns the `signal_id` handle |
-| `list_signals` | Browse signal files on disk (`scope="disk"`) or loaded signals in memory (`scope="memory"`) |
-| `get_signal_info` | Signal metadata (sampling rate, duration, declared unit, source metadata) |
-| `generate_test_signal` | Create a synthetic signal, auto-registered and immediately analyzable |
-| `clear_signals` | Remove one signal or the whole in-memory cache |
-
-### Spectral & Statistical Analysis (6)
-
-| Tool | Description |
-|------|-------------|
-| `analyze_fft` | Frequency spectrum with automatic peak detection |
-| `analyze_envelope` | Envelope analysis for bearing fault detection (default band 500–5000 Hz) |
-| `analyze_statistics` | Time-domain features (RMS, kurtosis, crest factor) |
-| `extract_features_from_signal` | Segmented statistical feature extraction |
-| `compute_power_spectral_density` | Power spectral density (Welch method) |
-| `compute_spectrogram_stft` | Time-frequency spectrogram |
-
-### Diagnostics & Health Assessment (7)
-
-| Tool | Description |
-|------|-------------|
-| `assess_severity` | Unified ISO 20816-3 severity assessment (signal or direct RMS reading, custom thresholds) — requires a declared signal unit, never guesses |
-| `check_bearing_faults` | Unified fault-frequency matching (catalog bearing, explicit frequencies, or explicit geometry) |
-| `diagnose_vibration` | Integrated evidence-based diagnosis pipeline (one call) |
-| `calculate_bearing_characteristic_frequencies` | Expected fault frequencies from bearing geometry |
-| `search_bearing_catalog` | Look up verified, source-traced bearing geometry |
-| `train_anomaly_model` | Train novelty detection on healthy baselines |
-| `predict_anomalies` | Score a signal against a trained model (bounded output) |
-
-### Documentation (4)
-
-| Tool | Description |
-|------|-------------|
-| `search_documentation` | Semantic search over equipment manuals |
-| `read_manual_excerpt` | Read pages from a manual |
-| `extract_manual_specs` | Extract structured specs from PDFs |
-| `list_machine_manuals` | Browse available documentation |
-
-### Reporting (9)
-
-| Tool | Description |
-|------|-------------|
-| `plot_signal` | Interactive time-domain plot |
-| `generate_fft_report` | Interactive frequency analysis report |
-| `generate_envelope_report` | Envelope analysis with fault markers |
-| `generate_iso_report` | Severity zone visualization |
-| `generate_diagnostic_report` | Integrated diagnostic report, HTML and PDF, wording authored by the server |
-| `generate_diagnostic_report_docx` | Structured Word document report |
-| `generate_pca_visualization_report` | PCA anomaly projection |
-| `generate_feature_comparison_report` | Cross-signal feature comparison |
-| `list_html_reports` | Report management (list all or inspect one) |
-
-### Prognostics (2)
-
-| Tool | Description |
-|------|-------------|
-| `analyze_signal_trend` | Within-recording screening: feature trend + degradation onset in one call |
-| `estimate_rul` | Remaining Useful Life from repeated measurements over time (linear, exponential, Kalman) — refuses single-recording extrapolation |
-
-### Decision Support (1)
-
-| Tool | Description |
-|------|-------------|
-| `generate_maintenance_recommendations` | Maintenance recommendations from severity zone + canonical fault types |
-
-### Guided Workflows (3 prompts)
-
-| Prompt | Description |
-|--------|-------------|
-| `diagnose_bearing` | Complete bearing fault diagnostic decision tree |
-| `diagnose_gear` | Gear fault detection workflow |
-| `quick_diagnostic_report` | Fast health screening |
-
-</details>
+Full endpoint reference, grouped by category: **[Tool Catalog](docs/TOOL_CATALOG.md)**.
 
 ---
 
 ## Claude Code Plugin
 
-The project includes a **plugin for Claude Code** with domain-specific skills that activate automatically during conversation. Install it and Claude gains guided diagnostic workflows, autonomous agents, and quick commands.
+The project includes a **plugin for Claude Code** with domain-specific skills that activate automatically during conversation.
 
 ```shell
 /plugin marketplace add LGDiMaggio/predictive-maintenance-mcp
@@ -187,35 +142,9 @@ The project includes a **plugin for Claude Code** with domain-specific skills th
   <img src="assets/plugin.gif" alt="Claude Code Plugin — skills, agents, and slash commands in action" width="720">
 </p>
 
-<p align="center"><em>Claude Code plugin: domain skills activate automatically, slash commands for quick diagnostics</em></p>
+The plugin adds **8 skills** that activate automatically based on context (bearing-diagnosis, gear-diagnosis, quick-screening, report-generation, anomaly-detection, signal-management, documentation-search, prognostics), **2 agents** that run multi-step diagnostic workflows end-to-end and hand you the evidence (diagnostic-pipeline, signal-explorer), and **3 commands** for quick entry points (`/pm-diagnose`, `/pm-screen`, `/pm-report`).
 
-### Skills (8) — activate automatically based on context
-
-| Skill | What it does |
-|-------|-------------|
-| **bearing-diagnosis** | Walks through a complete bearing fault diagnostic workflow |
-| **gear-diagnosis** | Gear fault detection via spectral pattern analysis |
-| **quick-screening** | 30-second vibration health check |
-| **report-generation** | Professional HTML and Word report generation |
-| **anomaly-detection** | Train and run ML-based anomaly detection models |
-| **signal-management** | Load, inspect, and manage vibration signals |
-| **documentation-search** | Search equipment manuals and bearing catalogs |
-| **prognostics** | Within-recording trend screening and multi-measurement RUL estimation |
-
-### Agents (2) — run autonomously for complex tasks
-
-| Agent | What it does |
-|-------|-------------|
-| **diagnostic-pipeline** | End-to-end: load signal → spectral analysis → fault detection → severity assessment → report |
-| **signal-explorer** | Explore and compare multiple signals, find outliers, characterize patterns |
-
-### Commands (3) — quick entry points
-
-| Command | Example |
-|---------|---------|
-| `/pm-diagnose` | `/pm-diagnose bearing_signal.csv` — full fault diagnosis |
-| `/pm-screen` | `/pm-screen bearing_signal.csv` — quick health check |
-| `/pm-report` | `/pm-report bearing_signal.csv full` — generate all reports |
+Full skill, agent, and command reference: [Plugin README](plugin/README.md).
 
 ---
 
@@ -245,10 +174,7 @@ All analysis tools generate **interactive HTML reports** you can open in any bro
 
 ## Sample Data Included
 
-The project ships with **20 real bearing vibration signals** from production machinery tests — ready to use out of the box.
-
-- **Training set**: 2 healthy baselines + 12 fault signals (inner race, outer race)
-- **Test set**: 1 healthy baseline + 5 fault signals
+The project ships with **20 real bearing vibration signals** from production machinery tests — ready to use out of the box: a training set (2 healthy baselines + 12 fault signals, inner and outer race) and a test set (1 healthy baseline + 5 fault signals).
 
 Try: *"Load real_train/OuterRaceFault_1.csv and diagnose the bearing fault."*
 
@@ -280,34 +206,7 @@ Full dataset documentation: [data/README.md](data/README.md)
     signals · manuals · models
 ```
 
-The codebase follows a **modular architecture** organized around the ISO 13374 Six-Block Diagnostic standard — signal acquisition, processing, diagnostics, prognostics, and decision support as separate sub-packages.
-
-<details>
-<summary><b>Detailed module structure</b></summary>
-
-```
-src/predictive_maintenance_mcp/
-├── mcp_tools/                 # MCP endpoint registration (37 MCP endpoints)
-│   ├── acquisition_tools.py   # Signal loading & management
-│   ├── analysis_tools.py      # Spectral & statistical analysis
-│   ├── diagnostics_tools.py   # Fault detection, ML, document search
-│   ├── report_tools.py        # HTML/DOCX report generation
-│   ├── prompts.py             # Guided diagnostic workflows
-│   └── _utils.py              # Shared utilities
-├── signal_acquisition/        # Multi-format loaders (CSV, MAT, WAV, NPY, Parquet)
-├── signal_processing/         # Spectral analysis & feature extraction
-├── diagnostics/               # Bearing/gear analysis, ISO standards
-├── decision_support/          # Evidence-based diagnosis pipeline
-├── prognostics/               # RUL estimation (linear, exponential, Kalman) & trend analysis
-├── rag.py                     # Document indexing & search (FAISS/TF-IDF)
-├── models.py                  # Pydantic data models
-├── server.py                  # MCPServer entry point
-└── config.py                  # Configuration management
-```
-
-**Standards implemented**: ISO 13374 (diagnostic architecture), ISO 20816-3 (vibration severity classification), MIMOSA OSA-CBM (condition-based maintenance framework).
-
-</details>
+The codebase follows a **modular architecture** organized around the ISO 13374 Six-Block Diagnostic standard — signal acquisition, processing, diagnostics, prognostics, and decision support as separate sub-packages. Standards implemented: ISO 13374, ISO 20816-3, MIMOSA OSA-CBM. Module-level detail: [Architecture guide](docs/architecture.md).
 
 **Key design choices:**
 - **Privacy-first** — raw vibration data never leaves your machine; only computed results flow to the LLM
@@ -322,6 +221,7 @@ src/predictive_maintenance_mcp/
 |-------|-----|
 | [Quickstart for Engineers](docs/QUICKSTART_ENGINEER.md) | Get results fast, no coding required |
 | [Quickstart for Developers](docs/QUICKSTART_DEVELOPER.md) | Understand MCP, extend the server |
+| [Tool Catalog](docs/TOOL_CATALOG.md) | Every MCP endpoint, grouped by category |
 | [Plugin README](plugin/README.md) | Claude Code plugin installation and usage |
 | [HTTPS Deployment](docs/DEPLOYMENT.md) | Docker + HTTPS for enterprise environments |
 | [Ollama Guide](docs/OLLAMA_GUIDE.md) | Use with local LLMs (fully air-gapped) |
@@ -344,39 +244,6 @@ pytest --cov=src --cov-report=html      # with coverage report
 ```
 
 20+ test files covering signal analysis, fault detection, severity assessment, ML models, report generation, RAG search, and real bearing fault data validation.
-
----
-
-## Benchmark
-
-A blind, reproducible diagnostic-accuracy benchmark on the public
-[CWRU Bearing Data Center](https://engineering.case.edu/bearingdatacenter)
-dataset (12 kHz drive-end subset: 60 fault records + 4 normal baselines).
-Fault labels never reach the system under test — signals enter under opaque
-ids, a separate scorer is the only label reader, and blindness, checksum
-integrity, and determinism are enforced by CI-run guard tests, not prose.
-Results are stratified by the per-record diagnosability grades of the
-Smith & Randall (2015) reference study, so records that study found
-undiagnosable by any classical method are reported separately instead of
-inflating or deflating the headline.
-
-<!-- cwru-benchmark:start -->
-On records the reference study grades clearly diagnosable (Y1+Y2, <!-- slot: headline.n_records -->44<!-- /slot --> records):
-characteristic fault frequency detected on <!-- slot: headline.frequency_detection.hits -->44<!-- /slot -->/<!-- slot: headline.frequency_detection.total -->44<!-- /slot -->,
-correct fault ranked first on <!-- slot: headline.classification.correct -->34<!-- /slot -->/<!-- slot: headline.classification.total -->44<!-- /slot --> (<!-- slot: headline.classification.rate pct1 -->77.3<!-- /slot -->%),
-and <!-- slot: strata.Y1.classification.correct -->9<!-- /slot -->/<!-- slot: strata.Y1.classification.total -->9<!-- /slot --> on the textbook-signature (Y1) stratum.
-On the <!-- slot: strata.ungraded.false_positives.total_normal -->4<!-- /slot --> healthy baselines, <!-- slot: strata.ungraded.false_positives.records_with_any -->2<!-- /slot --> records raised a false indication under the same criterion.
-<!-- cwru-benchmark:end -->
-
-The numbers above are read from the committed, re-runnable artifact
-([results.json](benchmarks/cwru/results/results.json)) and drift-guarded by CI:
-every value is bound to its key in the artifact, and a mismatch fails the build.
-Methodology, blind protocol, and honest-benchmarking notes:
-[docs/benchmark-methodology.md](docs/benchmark-methodology.md). Reproduce with:
-
-```bash
-python -m benchmarks.cwru all
-```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ src/predictive_maintenance_mcp/
 
 ## Testing
 
-**86% test coverage** across Windows, macOS, and Linux (Python 3.11 & 3.12).
+**85%+ test coverage**, enforced as a CI minimum, across Windows, macOS, and Linux (Python 3.11 & 3.12) — the current measured figure is on the codecov badge above.
 
 ```bash
 pytest                                  # run all tests
@@ -384,7 +384,7 @@ python -m benchmarks.cwru all
 
 - [x] 37 MCP endpoints (34 tools, 3 prompts) with modular architecture and a single `signal_id` handle
 - [x] Claude Code plugin (8 skills, 2 agents, 3 commands)
-- [x] 86% test coverage, CI/CD on 3 platforms
+- [x] 85%+ test coverage enforced in CI, CI/CD on 3 platforms
 - [x] Docker + SSE/HTTP transport for enterprise deployment
 - [x] Semantic document search (FAISS + TF-IDF)
 - [x] Blind, reproducible diagnostic benchmark on the CWRU dataset (extensible to Paderborn)

--- a/docs/ADAPTER_GUIDE.md
+++ b/docs/ADAPTER_GUIDE.md
@@ -1,0 +1,211 @@
+# Adapter Guide — Loading Vendor Data
+
+This guide documents the **ingestion boundary** of the Predictive Maintenance MCP Server: what the core will and will not do with vendor data files, and how to write an **adapter** for an acquisition system whose format the server does not read directly.
+
+> **The boundary in one sentence**: no vendor format parsers ship in the core and nothing is inferred from file content or names — translating a vendor's metadata into the server's explicit declaration is the user's (or an external adapter's) job.
+
+---
+
+## Table of Contents
+
+1. [The Principle: Declared, Never Guessed](#the-principle-declared-never-guessed)
+2. [Supported Formats](#supported-formats)
+3. [The Declaration Parameters](#the-declaration-parameters)
+4. [The Companion File](#the-companion-file)
+5. [Worked Example: A Headerless DAQ Recording](#worked-example-a-headerless-daq-recording)
+6. [When the Declaration Is Wrong](#when-the-declaration-is-wrong)
+7. [What to Contribute](#what-to-contribute)
+
+---
+
+## The Principle: Declared, Never Guessed
+
+A headerless raw binary file carries zero self-description: nothing in the bytes says whether a sample is `float32` or `int16`, little- or big-endian, one interleaved channel or four. Rather than guessing — and silently producing wrong spectra — the server requires the caller to **declare** the decode contract, then validates that declaration against the file before a single sample reaches any analysis tool.
+
+An **adapter** is anything that translates a vendor's metadata — an XML sidecar, a proprietary header, an exported settings file — into that explicit declaration: either keyword parameters on the `load_signal` tool, or a companion JSON file placed next to the signal. There is nothing to register and no plugin API — **the declaration is the integration surface**.
+
+Three consequences follow:
+
+- **Adapters run outside the server.** An adapter can be a ten-line script in any language. It runs before the server is involved and imports nothing from it.
+- **The core stays vendor-neutral.** New vendor formats never require changes to the server, and no vendor-specific parsing code has to be reviewed, secured, or maintained in the core.
+- **The declaration is validated, never trusted blindly.** A declaration that contradicts the file fails loudly, with the arithmetic shown (see [When the Declaration Is Wrong](#when-the-declaration-is-wrong)).
+
+---
+
+## Supported Formats
+
+The server distinguishes two classes of signal file:
+
+| Class | Extensions | Declaration |
+|-------|------------|-------------|
+| Self-describing | `.csv`, `.txt`, `.npy`, `.mat`, `.wav`, `.parquet` | Not needed for decoding — and not allowed: declaring raw decode parameters for these is refused as a contradiction of the file's own header |
+| Raw headerless | `.bin`, `.raw`, `.dat` | Required — the file cannot be decoded without it |
+
+Self-describing formats still benefit from a declared `sampling_rate` and `signal_unit` (via parameter or companion file): ISO 20816-3 severity verdicts are refused until a unit is declared, because units are never guessed from signal amplitude.
+
+---
+
+## The Declaration Parameters
+
+Raw files load through the standard `load_signal` tool; the declaration is carried by additive keyword parameters. Two of them are **required** for a raw file — a load missing either is refused with one message naming everything missing and both remedies. The rest carry documented defaults.
+
+<!-- adapter-declaration:start -->
+
+| Parameter | Scope | Allowed values | Default |
+|-----------|-------|----------------|---------|
+| `sample_format` | Raw files — **required** | `float32`, `float64`, `int16`, `int32` | none — must be declared |
+| `sampling_rate` | Raw files — **required** (recommended for every format) | positive number, in Hz | none — must be declared |
+| `signal_unit` | Any format — required for ISO severity verdicts | `g`, `m/s2` (acceleration), `mm/s`, `m/s` (velocity) | none — severity verdicts are refused until declared |
+| `byte_order` | Raw files | `little`, `big` | `little` |
+| `n_channels` | Raw files | integer, 1 or more (interleaved channel count) | `1` |
+| `channel_index` | Raw files | integer, 0-based, below `n_channels` | `0` |
+| `header_offset` | Raw files | integer, bytes to skip before the first sample | `0` |
+| `scale_factor` | Raw files | number — multiplier applied after decoding | none (no scaling) |
+
+<!-- adapter-declaration:end -->
+
+Notes:
+
+- **Integer formats decode to raw ADC counts.** There is no implicit normalization. Declare `scale_factor` (the sensor/DAQ calibration multiplier) to convert counts into the declared physical unit — declaring a `signal_unit` on unscaled counts would misrepresent amplitudes to every severity assessment.
+- **Batch loads broadcast the declaration.** When `load_signal` receives a list of file paths, the raw parameters apply to every file in the batch, exactly like `sampling_rate` and `signal_unit`; per-file values come from each file's companion metadata.
+- **Provenance is recorded.** Stored signals record the six effective decode parameters under `raw_format`, so `get_signal_info(signal_id="...")` can answer "how was this file decoded" after the fact.
+
+---
+
+## The Companion File
+
+Instead of repeating parameters on every call, place a JSON file named after the signal file's stem next to it — for `motor_de_001.raw`, the companion is `motor_de_001_metadata.json`:
+
+```json
+{
+  "sampling_rate": 25600.0,
+  "signal_unit": "g",
+  "sample_format": "float32",
+  "byte_order": "little",
+  "n_channels": 1,
+  "channel_index": 0,
+  "header_offset": 0,
+  "rpm": 1480
+}
+```
+
+Honored keys are exactly the declaration parameters above: `sampling_rate`, `signal_unit`, `sample_format`, `byte_order`, `n_channels`, `channel_index`, `header_offset`, and `scale_factor`. Companion values are validated against the same closed vocabularies as explicit parameters — an invalid value is refused with a message naming the offending value, its companion-file source, and the valid vocabulary.
+
+Any other keys (like `rpm` above, shaft speeds, reference frequencies) are not decode parameters: they are preserved verbatim under `source_metadata` and exposed by `get_signal_info(signal_id="...")`.
+
+### Merge precedence
+
+When a parameter is available from more than one place, the effective value is resolved in this order:
+
+| Precedence | Source | Notes |
+|------------|--------|-------|
+| 1 — wins | Explicit `load_signal` parameter | Overrides everything |
+| 2 | Companion `<stem>_metadata.json` field | Validated against the same vocabularies as explicit parameters |
+| 3 | Documented default | Optional parameters only — `sample_format` and `sampling_rate` have no default |
+
+If `sample_format` or `sampling_rate` is still missing after the merge, the raw load is refused with a single message naming everything missing and both remedies (the explicit re-call and the companion-file alternative).
+
+---
+
+## Worked Example: A Headerless DAQ Recording
+
+Scenario: an industrial DAQ unit writes headerless raw files — `float32`, little-endian, single channel, sampled at 25,600 Hz from an accelerometer calibrated in g. A recording lands as `data/signals/motor_de_001.raw`.
+
+### The adapter's output
+
+An adapter for this DAQ reads the unit's own metadata (settings export, sidecar, or fixed configuration) and emits one companion file per recording — `motor_de_001_metadata.json` next to the signal:
+
+```json
+{
+  "sampling_rate": 25600.0,
+  "signal_unit": "g",
+  "sample_format": "float32",
+  "byte_order": "little"
+}
+```
+
+`byte_order` could be omitted (it is the documented default), but an adapter should emit it anyway — an explicit companion file is self-explanatory to whoever opens the folder later.
+
+### Loading — natural language
+
+With the companion file in place, the ask to the assistant needs no technical parameters:
+
+> "Load motor_de_001.raw, run an envelope analysis, and show me the bearing fault evidence."
+
+The assistant calls `load_signal(filepath="motor_de_001.raw")` and the full declaration comes from the companion file.
+
+### Loading — direct call
+
+The equivalent explicit call, with no companion file involved:
+
+```python
+load_signal(
+    filepath="motor_de_001.raw",
+    sample_format="float32",
+    sampling_rate=25600.0,
+    signal_unit="g",
+)
+```
+
+### Multi-channel variant
+
+If the DAQ writes four interleaved channels into one file, the companion declares the layout:
+
+```json
+{
+  "sampling_rate": 25600.0,
+  "signal_unit": "g",
+  "sample_format": "float32",
+  "n_channels": 4
+}
+```
+
+Each load extracts **one** channel:
+
+```python
+load_signal(filepath="motor_de_001.raw", channel_index=2)
+```
+
+When the effective `n_channels` is greater than 1, the derived signal id gains a `_ch<k>` suffix — here `motor_de_001_ch2` — so channels of the same file never collide. An explicit `signal_id` is used verbatim, with no suffix applied.
+
+### Integer formats and calibration
+
+A DAQ that stores 16-bit ADC counts needs a declared calibration multiplier to yield physical units:
+
+```python
+load_signal(
+    filepath="motor_nde_001.raw",
+    sample_format="int16",
+    sampling_rate=25600.0,
+    scale_factor=0.000488,
+    signal_unit="g",
+)
+```
+
+Here `scale_factor` is the counts-to-g conversion from the sensor/DAQ datasheet. Without it, the samples stay raw counts and a declared unit would be a lie.
+
+---
+
+## When the Declaration Is Wrong
+
+A wrong declaration does not silently produce wrong analysis — the loader validates the declared shape against the actual file size before decoding, and refusal messages show the arithmetic. For example, a 6,144,002-byte file declared as single-channel `float32` (4-byte samples) is not a whole number of 4-byte frames — 2 bytes remain — so the load is refused, and the error shows exactly that arithmetic: file size minus `header_offset`, the frame size (sample size times channel count), and the remainder. That remainder is the best available detector of a wrong sample format, a wrong channel count, or a forgotten header.
+
+Other loud failures:
+
+- A float payload that decodes to NaN/Inf samples is refused as a likely `byte_order` or `sample_format` mismatch.
+- A file larger than the `PMM_MAX_SIGNAL_SIZE` cap (bytes, default 500 MB) is refused before a single byte is read, with the environment-variable remedy named in the message.
+- Declaring raw parameters for a self-describing format is refused as a contradiction — the declared-never-guessed policy cuts both ways.
+
+**What validation cannot catch**: a headerless file gives the loader nothing to check `sampling_rate` against — a wrong rate rescales every frequency in every downstream analysis. The same holds for `signal_unit` and `scale_factor`, which set the physical meaning of amplitudes. Getting those three right from the vendor's metadata is precisely an adapter's most valuable job.
+
+---
+
+## What to Contribute
+
+Three kinds of contribution keep this boundary useful without moving it:
+
+1. **An adapter script for a vendor format** — a standalone script (any language) that reads the vendor's sidecar, header, or settings export and emits companion `<stem>_metadata.json` files next to the signal files. It runs before the server is involved and imports nothing from it.
+2. **A worked format mapping** — documentation of which fields in a vendor's metadata map to which declaration keys, with an anonymized sample layout.
+3. **Improvements to this guide** — corrections, clearer examples, additional edge cases.
+
+Start with [CONTRIBUTING.md](../CONTRIBUTING.md) for the general workflow, then [open an issue](https://github.com/LGDiMaggio/predictive-maintenance-mcp/issues) describing the format (byte layout, where the metadata lives, a sample declaration) — or [start a discussion](https://github.com/LGDiMaggio/predictive-maintenance-mcp/discussions) if the approach is still open.

--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -1,0 +1,86 @@
+# Tool Catalog
+
+The complete endpoint reference for the Predictive Maintenance MCP server: every registered MCP tool and guided prompt, grouped by category.
+
+**Total: 37 MCP endpoints — 34 tools and 3 prompts.**
+
+## Signal Lifecycle (5)
+
+| Tool | Description |
+|------|-------------|
+| `load_signal` | Load vibration file(s) (CSV, WAV, MAT, NPY, Parquet, raw binary `.bin`/`.raw`/`.dat` with declared decode metadata) with declared sampling rate and unit — returns the `signal_id` handle |
+| `list_signals` | Browse signal files on disk (`scope="disk"`) or loaded signals in memory (`scope="memory"`) |
+| `get_signal_info` | Signal metadata (sampling rate, duration, declared unit, source metadata) |
+| `generate_test_signal` | Create a synthetic signal, auto-registered and immediately analyzable |
+| `clear_signals` | Remove one signal or the whole in-memory cache |
+
+## Spectral & Statistical Analysis (6)
+
+| Tool | Description |
+|------|-------------|
+| `analyze_fft` | Frequency spectrum with automatic peak detection |
+| `analyze_envelope` | Envelope analysis for bearing fault detection (default band 500–5000 Hz) |
+| `analyze_statistics` | Time-domain features (RMS, kurtosis, crest factor) |
+| `extract_features_from_signal` | Segmented statistical feature extraction |
+| `compute_power_spectral_density` | Power spectral density (Welch method) |
+| `compute_spectrogram_stft` | Time-frequency spectrogram |
+
+## Diagnostics & Health Assessment (7)
+
+| Tool | Description |
+|------|-------------|
+| `assess_severity` | Unified ISO 20816-3 severity assessment (signal or direct RMS reading, custom thresholds) — requires a declared signal unit, never guesses |
+| `check_bearing_faults` | Unified fault-frequency matching (catalog bearing, explicit frequencies, or explicit geometry) |
+| `diagnose_vibration` | Integrated evidence-based diagnosis pipeline (one call) |
+| `calculate_bearing_characteristic_frequencies` | Expected fault frequencies from bearing geometry |
+| `search_bearing_catalog` | Look up verified, source-traced bearing geometry |
+| `train_anomaly_model` | Train novelty detection on healthy baselines |
+| `predict_anomalies` | Score a signal against a trained model (bounded output) |
+
+## Documentation (4)
+
+| Tool | Description |
+|------|-------------|
+| `search_documentation` | Semantic search over equipment manuals |
+| `read_manual_excerpt` | Read pages from a manual |
+| `extract_manual_specs` | Extract structured specs from PDFs |
+| `list_machine_manuals` | Browse available documentation |
+
+## Reporting (9)
+
+| Tool | Description |
+|------|-------------|
+| `plot_signal` | Interactive time-domain plot |
+| `generate_fft_report` | Interactive frequency analysis report |
+| `generate_envelope_report` | Envelope analysis with fault markers |
+| `generate_iso_report` | Severity zone visualization |
+| `generate_diagnostic_report` | Integrated diagnostic report, HTML and PDF, wording authored by the server |
+| `generate_diagnostic_report_docx` | Structured Word document report |
+| `generate_pca_visualization_report` | PCA anomaly projection |
+| `generate_feature_comparison_report` | Cross-signal feature comparison |
+| `list_html_reports` | Report management (list all or inspect one) |
+
+## Prognostics (2)
+
+| Tool | Description |
+|------|-------------|
+| `analyze_signal_trend` | Within-recording screening: feature trend + degradation onset in one call |
+| `estimate_rul` | Remaining Useful Life from repeated measurements over time (linear, exponential, Kalman) — refuses single-recording extrapolation |
+
+## Decision Support (1)
+
+| Tool | Description |
+|------|-------------|
+| `generate_maintenance_recommendations` | Maintenance recommendations from severity zone + canonical fault types |
+
+## Guided Workflows (3 prompts)
+
+| Prompt | Description |
+|--------|-------------|
+| `diagnose_bearing` | Complete bearing fault diagnostic decision tree |
+| `diagnose_gear` | Gear fault detection workflow |
+| `quick_diagnostic_report` | Fast health screening |
+
+---
+
+Back to the [README](../README.md) · developer setup and extension guide: [Developer's Quickstart](QUICKSTART_DEVELOPER.md)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 title: Predictive Maintenance AI Agent — Open-Source MCP Server & Claude Plugin for Condition Monitoring
 description: >-
-  Open-source AI agent for predictive maintenance and condition monitoring. 52 MCP endpoints,
-  7 Claude skills for vibration analysis, bearing fault detection, ISO 20816 severity assessment,
+  Open-source AI agent for predictive maintenance and condition monitoring. 37 MCP endpoints,
+  8 Claude skills for vibration analysis, bearing fault detection, ISO 20816 severity assessment,
   ML anomaly detection, and remaining useful life estimation — via natural language with Claude,
   ChatGPT, or Ollama. Privacy-first: your data never leaves your machine.
 url: "https://lgdimaggio.github.io"

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
 
   <!-- Primary SEO -->
   <title>Predictive Maintenance AI Agent — Open-Source MCP Server & Claude Plugin for Condition Monitoring</title>
-  <meta name="description" content="Open-source AI agent for predictive maintenance and condition monitoring. Analyze vibration data, detect bearing faults, and generate diagnostic reports via natural language — with Claude, ChatGPT, or Ollama. 52 MCP endpoints, privacy-first, runs locally.">
+  <meta name="description" content="Open-source AI agent for predictive maintenance and condition monitoring. Analyze vibration data, detect bearing faults, and generate diagnostic reports via natural language — with Claude, ChatGPT, or Ollama. 37 MCP endpoints, privacy-first, runs locally.">
   <meta name="keywords" content="predictive maintenance AI agent, condition monitoring AI agent, predictive maintenance MCP server, machine maintenance copilot, vibration analysis AI tool, bearing fault detection AI, predictive maintenance claude plugin, claude skills predictive maintenance, AI vibration diagnostics, open source predictive maintenance, machine health monitoring AI, MCP server, vibration analysis, bearing fault detection, ISO 20816 AI analysis, FFT analysis, envelope analysis, AI diagnostics, Industry 4.0, condition monitoring, Model Context Protocol, Claude Code plugin, machine learning condition monitoring, industrial AI agent, mcp tools predictive maintenance, predictive maintenance natural language, remaining useful life estimation, maintenance decision support AI, fault diagnosis AI assistant, industrial AI diagnostics">
   <meta name="author" content="Luigi Gianpio Di Maggio">
   <meta name="robots" content="index, follow">
@@ -18,7 +18,7 @@
   <!-- Open Graph -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="Predictive Maintenance AI Agent — Open-Source MCP Server for Condition Monitoring">
-  <meta property="og:description" content="AI agent for predictive maintenance & machine health monitoring. Analyze vibration data, detect bearing faults, assess severity via ISO 20816, and generate reports — all through natural-language conversation with Claude, ChatGPT, or Ollama. Open-source, privacy-first, 52 MCP endpoints.">
+  <meta property="og:description" content="AI agent for predictive maintenance & machine health monitoring. Analyze vibration data, detect bearing faults, assess severity via ISO 20816, and generate reports — all through natural-language conversation with Claude, ChatGPT, or Ollama. Open-source, privacy-first, 37 MCP endpoints.">
   <meta property="og:url" content="https://lgdimaggio.github.io/predictive-maintenance-mcp/">
   <meta property="og:image" content="https://raw.githubusercontent.com/LGDiMaggio/predictive-maintenance-mcp/main/assets/predictive-maintenance-mcp_com.jpg">
   <meta property="og:image:width" content="1200">
@@ -30,7 +30,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Predictive Maintenance AI Agent — Open-Source MCP Server & Claude Plugin">
-  <meta name="twitter:description" content="AI-powered condition monitoring and vibration diagnostics. Detect bearing faults, assess machine health, generate reports — via natural language. Open-source, 52 MCP endpoints, runs locally.">
+  <meta name="twitter:description" content="AI-powered condition monitoring and vibration diagnostics. Detect bearing faults, assess machine health, generate reports — via natural language. Open-source, 37 MCP endpoints, runs locally.">
   <meta name="twitter:image" content="https://raw.githubusercontent.com/LGDiMaggio/predictive-maintenance-mcp/main/assets/predictive-maintenance-mcp_com.jpg">
   <meta name="twitter:image:alt" content="Predictive Maintenance AI Agent — MCP Server for vibration analysis and fault detection">
 
@@ -41,11 +41,11 @@
     "@type": "SoftwareApplication",
     "name": "Predictive Maintenance MCP Server",
     "alternateName": ["Predictive Maintenance AI Agent", "Condition Monitoring AI Copilot", "Machine Maintenance Copilot"],
-    "description": "Open-source AI agent and MCP server for predictive maintenance and condition monitoring. Analyze vibration data, detect bearing faults, assess severity via ISO 20816, and generate diagnostic reports — all through natural-language conversation with Claude, ChatGPT, or Ollama. 52 MCP endpoints, privacy-first local processing.",
+    "description": "Open-source AI agent and MCP server for predictive maintenance and condition monitoring. Analyze vibration data, detect bearing faults, assess severity via ISO 20816, and generate diagnostic reports — all through natural-language conversation with Claude, ChatGPT, or Ollama. 37 MCP endpoints, privacy-first local processing.",
     "applicationCategory": "EngineeringApplication",
     "applicationSubCategory": "Predictive Maintenance, Condition Monitoring, Industrial AI, Vibration Analysis",
     "operatingSystem": "Windows, macOS, Linux",
-    "softwareVersion": "0.8.0",
+    "softwareVersion": "0.12.0",
     "license": "https://opensource.org/licenses/MIT",
     "url": "https://lgdimaggio.github.io/predictive-maintenance-mcp/",
     "codeRepository": "https://github.com/LGDiMaggio/predictive-maintenance-mcp",
@@ -69,7 +69,7 @@
       "price": "0",
       "priceCurrency": "USD"
     },
-    "featureList": ["Vibration signal analysis (FFT, envelope, statistics)", "Bearing fault detection (inner/outer/ball/cage)", "ISO 20816-3 severity assessment", "ML anomaly detection", "Interactive HTML report generation", "Equipment manual search (RAG)", "Remaining useful life estimation", "Claude Code plugin with 7 skills", "Docker & HTTPS deployment", "Ollama support for air-gapped environments"],
+    "featureList": ["Vibration signal analysis (FFT, envelope, statistics)", "Bearing fault detection (inner/outer/ball/cage)", "ISO 20816-3 severity assessment", "ML anomaly detection", "Interactive HTML report generation", "Equipment manual search (RAG)", "Remaining useful life estimation", "Claude Code plugin with 8 skills", "Docker & HTTPS deployment", "Ollama support for air-gapped environments"],
     "keywords": ["predictive maintenance AI agent", "condition monitoring AI agent", "predictive maintenance MCP server", "machine maintenance copilot", "vibration analysis AI tool", "bearing fault detection AI", "predictive maintenance claude plugin", "claude skills predictive maintenance", "AI vibration diagnostics", "open source predictive maintenance", "machine health monitoring AI", "industrial AI agent", "ISO 20816 AI analysis", "maintenance decision support AI", "remaining useful life estimation"]
   }
   </script>
@@ -85,7 +85,7 @@
         "name": "What is Predictive Maintenance MCP Server?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "An open-source AI agent that lets you ask an AI assistant about your machine's vibration data and get real, evidence-based maintenance answers — running entirely on your computer. It provides 52 MCP endpoints for vibration analysis, bearing fault detection, ISO 20816 severity assessment, and ML anomaly detection."
+          "text": "An open-source AI agent that lets you ask an AI assistant about your machine's vibration data and get real, evidence-based maintenance answers — running entirely on your computer. It provides 37 MCP endpoints for vibration analysis, bearing fault detection, ISO 20816 severity assessment, and ML anomaly detection."
         }
       },
       {
@@ -768,16 +768,16 @@
   <div class="container">
     <div class="numbers-grid">
       <div class="num-card">
-        <div class="num-val" data-target="52">0</div>
+        <div class="num-val" data-target="37">0</div>
         <div class="num-label">MCP Endpoints</div>
       </div>
       <div class="num-card">
-        <div class="num-val" data-target="7">0</div>
+        <div class="num-val" data-target="8">0</div>
         <div class="num-label">Diagnostic Skills</div>
       </div>
       <div class="num-card">
-        <div class="num-val" data-target="86">0</div>
-        <div class="num-label">% Test Coverage</div>
+        <div class="num-val" data-target="85">0</div>
+        <div class="num-label">%+ Test Coverage (CI Minimum)</div>
       </div>
       <div class="num-card">
         <div class="num-val">100%</div>
@@ -990,7 +990,7 @@
     <div class="section-header reveal">
       <span class="overline">Claude Code Plugin</span>
       <h2>Automate Diagnostics From Your Editor</h2>
-      <p>7 skills, 2 autonomous agents, 3 slash commands &mdash; works inside Claude Code.</p>
+      <p>8 skills, 2 autonomous agents, 3 slash commands &mdash; works inside Claude Code.</p>
     </div>
 
     <div class="install-box" style="max-width:580px;margin:0 auto 2rem" id="installPluginBox" title="Click to copy">
@@ -1001,8 +1001,8 @@
     <div class="plugin-grid">
       <div class="feat-card reveal">
         <div class="feat-icon green">&#x1F3AF;</div>
-        <h3>7 Domain Skills</h3>
-        <p>Bearing diagnosis, gear analysis, quick screening, report generation, anomaly detection, signal management, and documentation search.</p>
+        <h3>8 Domain Skills</h3>
+        <p>Bearing diagnosis, gear analysis, quick screening, prognostics, report generation, anomaly detection, signal management, and documentation search.</p>
       </div>
       <div class="feat-card reveal">
         <div class="feat-icon purple">&#x1F916;</div>
@@ -1248,7 +1248,7 @@
   title   = {Predictive Maintenance MCP Server},
   author  = {Di Maggio, Luigi Gianpio},
   year    = {2025},
-  version = {0.8.0},
+  version = {0.12.0},
   url     = {https://github.com/LGDiMaggio/predictive-maintenance-mcp},
   doi     = {10.5281/zenodo.17611542}
 }</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -990,7 +990,7 @@
     <div class="section-header reveal">
       <span class="overline">Claude Code Plugin</span>
       <h2>Automate Diagnostics From Your Editor</h2>
-      <p>8 skills, 2 autonomous agents, 3 slash commands &mdash; works inside Claude Code.</p>
+      <p>8 skills, 2 agents that run multi-step diagnostic workflows end-to-end, 3 slash commands &mdash; works inside Claude Code.</p>
     </div>
 
     <div class="install-box" style="max-width:580px;margin:0 auto 2rem" id="installPluginBox" title="Click to copy">
@@ -1006,7 +1006,7 @@
       </div>
       <div class="feat-card reveal">
         <div class="feat-icon purple">&#x1F916;</div>
-        <h3>2 Autonomous Agents</h3>
+        <h3>2 End-to-End Workflow Agents</h3>
         <p><strong>diagnostic-pipeline</strong>: End-to-end workflow from signal to report. <strong>signal-explorer</strong>: Compare and characterize multiple signals.</p>
       </div>
       <div class="feat-card reveal">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "predictive-maintenance-mcp"
 version = "0.12.0"
-description = "AI agent for predictive maintenance & condition monitoring — Open-source MCP server and Claude Code plugin with 52 endpoints for vibration analysis, bearing fault detection, ISO 20816 severity assessment, ML anomaly detection, and remaining useful life estimation via natural language"
+description = "AI agent for predictive maintenance & condition monitoring — Open-source MCP server and Claude Code plugin with 37 MCP endpoints for vibration analysis, bearing fault detection, ISO 20816 severity assessment, ML anomaly detection, and remaining useful life estimation via natural language"
 readme = "README.md"
 authors = [
     { name = "Luigi Di Maggio", email = "luigi.dimaggio@polito.it" }

--- a/tests/test_cwru_benchmark_guards.py
+++ b/tests/test_cwru_benchmark_guards.py
@@ -23,6 +23,13 @@ legs of the plan (origin acceptance example AE3) map to files like this:
   :class:`TestDriftGuardOnFixtures` (tmp-fixture matrix, mutation
   included) and :class:`TestDriftGuardOnTheRealRepo` (activates
   automatically the moment U7 publishes a section).
+- Unguarded-numbers sweep (AE4, permanent — added in U2): the drift
+  guard validates only INSIDE the marked section, so prose OUTSIDE the
+  ``cwru-benchmark`` markers could reintroduce unguarded percentages or
+  record fractions. :func:`scan_unguarded_benchmark_numbers` scans the
+  full text of README.md and docs/benchmark-methodology.md outside the
+  markers and fails on benchmark-result-shaped numbers, mutation-tested
+  in :class:`TestUnguardedBenchmarkNumbers`.
 - CI wiring -- the Black format gate covers ``benchmarks/``: THIS file,
   :class:`TestFormatGateCoversBenchmarks` (blockingness of the job
   itself is asserted by ``tests/test_ci_gates.py``).
@@ -540,6 +547,176 @@ class TestDriftGuardOnTheRealRepo:
         assert readme == drift_guard.REPO_ROOT / "README.md"
         assert readme.exists(), "the README the guard sweeps must exist"
         assert methodology.name == "benchmark-methodology.md"
+
+
+# ---------------------------------------------------------------------------
+# Unguarded benchmark numbers: prose OUTSIDE the markers stays number-free
+# ---------------------------------------------------------------------------
+
+#: A record fraction like ``34/44`` — inside the marked section every such
+#: value is slot-bound, so a bare fraction in prose is an unguarded
+#: benchmark number by construction. Flagged unconditionally.
+_FRACTION_RE = re.compile(r"\b\d+\s*/\s*\d+\b")
+
+#: A percentage. Flagged only near benchmark-result vocabulary (below), so
+#: legitimate non-benchmark percentages stay green.
+_PCT_RE = re.compile(r"\b\d+(?:\.\d+)?\s*%")
+
+#: Result-shaped vocabulary that turns a nearby percentage into a benchmark
+#: claim. Deliberately narrow — generic words like "benchmark", "fault" or
+#: "coverage" alone are NOT triggers, so the README's CI coverage minimum
+#: ("85%+ test coverage") and the methodology's pinned analyzer tolerance
+#: ("frequency tolerance ±5 %") do not false-positive.
+_BENCHMARK_VOCAB_RE = re.compile(
+    r"\b(accurac\w*|detection|detected|classif\w*|diagnos\w*|"
+    r"false[- ]positive\w*|false indication\w*|strat(?:um|a)|CWRU)\b",
+    re.I,
+)
+
+#: Exact snippets exempt from the sweep. Keep this list SHORT and literal:
+#: each entry must quote the text verbatim and justify itself.
+_UNGUARDED_ALLOWLIST = (
+    # docs/benchmark-methodology.md, honest-benchmarking notes: OTHER
+    # studies' inflated CWRU accuracies, quoted to explain why they are
+    # not comparable — literature context, not a claim about this system.
+    "Widely-cited 99–100 %",
+)
+
+#: The two prose documents the sweep covers (the only public surfaces that
+#: carry a marked benchmark section).
+_SWEPT_DOCUMENTS = (
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "docs" / "benchmark-methodology.md",
+)
+
+
+def _blank_marked_sections(text: str) -> str:
+    """Replace every marked section with whitespace, preserving line count
+    so finding line numbers keep pointing at the real file."""
+    pattern = re.compile(
+        re.escape(drift_guard.SECTION_START)
+        + r".*?"
+        + re.escape(drift_guard.SECTION_END),
+        re.S,
+    )
+    return pattern.sub(lambda m: "\n" * m.group(0).count("\n"), text)
+
+
+def scan_unguarded_benchmark_numbers(text: str) -> list[str]:
+    """Benchmark-result-shaped numbers OUTSIDE the cwru-benchmark markers.
+
+    Pure function over text (same shape as the drift guard and the landing
+    page scanner) so it can be mutation-tested on fixtures. Rules:
+
+    - allowlisted snippets are blanked first (equal-length, so offsets and
+      line numbers survive);
+    - the marked section is blanked (numbers inside it are slot-bound and
+      validated by the drift guard — not this sweep's business);
+    - any ``N/M`` fraction in the remainder is a finding;
+    - any percentage in the remainder is a finding when benchmark-result
+      vocabulary appears within one line of it (percentages with no such
+      vocabulary nearby — CI coverage floors, analyzer tolerances — pass).
+    """
+    for phrase in _UNGUARDED_ALLOWLIST:
+        text = text.replace(phrase, " " * len(phrase))
+    lines = _blank_marked_sections(text).splitlines()
+    findings: list[str] = []
+    for i, line in enumerate(lines):
+        for m in _FRACTION_RE.finditer(line):
+            findings.append(
+                f"line {i + 1}: record fraction '{m.group(0)}' outside the "
+                f"cwru-benchmark markers — benchmark numbers must live in "
+                f"slot-bound text inside the marked section"
+            )
+        for m in _PCT_RE.finditer(line):
+            window = " ".join(lines[max(0, i - 1) : i + 2])
+            if _BENCHMARK_VOCAB_RE.search(window):
+                findings.append(
+                    f"line {i + 1}: percentage '{m.group(0)}' near benchmark "
+                    f"vocabulary outside the cwru-benchmark markers — move it "
+                    f"into a slot inside the marked section or reword"
+                )
+    return findings
+
+
+class TestUnguardedBenchmarkNumbers:
+    """AE4, made permanent: the complement of the drift guard. The drift
+    guard validates inside the markers; this sweep proves the OUTSIDE
+    carries no benchmark-shaped numbers at all."""
+
+    @pytest.mark.parametrize("document", _SWEPT_DOCUMENTS, ids=lambda p: p.name)
+    def test_real_documents_are_clean(self, document):
+        findings = scan_unguarded_benchmark_numbers(
+            document.read_text(encoding="utf-8")
+        )
+        assert findings == [], f"{document.name}:\n  " + "\n  ".join(findings)
+
+    def test_swept_documents_still_carry_a_marked_section(self):
+        """Anchor: 'outside the markers is clean' only means something if
+        the markers are still there (and the sweep blanked something)."""
+        for document in _SWEPT_DOCUMENTS:
+            text = document.read_text(encoding="utf-8")
+            assert drift_guard.SECTION_START in text, document.name
+            assert _PCT_RE.search(text), (
+                f"{document.name}: no percentage found anywhere in the raw "
+                f"text — the sweep may be reading the wrong file"
+            )
+
+    def test_injected_stray_result_goes_red(self):
+        """The mutation that matters: a stray '34/44 (77.3%)' pasted into
+        the real README prose is flagged by BOTH rules, with the offending
+        snippets named."""
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        mutated = readme.replace(
+            "## Testing",
+            "## Testing\n\nClassification stayed correct on 34/44 (77.3%) "
+            "of records.\n",
+            1,
+        )
+        assert mutated != readme
+        findings = scan_unguarded_benchmark_numbers(mutated)
+        assert any("34/44" in f for f in findings), findings
+        assert any("77.3%" in f for f in findings), findings
+
+    def test_numbers_inside_the_marked_section_do_not_flag(self):
+        fixture = (
+            "Prose before, no numbers.\n"
+            f"{drift_guard.SECTION_START}\n"
+            "Classification accuracy 34/44 (77.3%) of records.\n"
+            f"{drift_guard.SECTION_END}\n"
+            "Prose after, no numbers.\n"
+        )
+        assert scan_unguarded_benchmark_numbers(fixture) == []
+
+    def test_bare_fraction_outside_markers_goes_red_without_vocabulary(self):
+        """Fractions are flagged unconditionally — no vocabulary needed."""
+        findings = scan_unguarded_benchmark_numbers("It scored 34/44 overall.\n")
+        assert len(findings) == 1 and "34/44" in findings[0], findings
+
+    def test_percentage_without_benchmark_vocabulary_is_ignored(self):
+        text = (
+            "85%+ test coverage, enforced as a CI minimum.\n"
+            "frequency tolerance is pinned at 5 % here.\n"
+        )
+        assert scan_unguarded_benchmark_numbers(text) == []
+
+    def test_percentage_near_vocabulary_goes_red_across_a_line_break(self):
+        """The window is three lines, so wrapped prose cannot dodge it."""
+        text = "correct on 77.3% of the\nclearly diagnosable records.\n"
+        findings = scan_unguarded_benchmark_numbers(text)
+        assert len(findings) == 1 and "77.3%" in findings[0], findings
+
+    def test_allowlist_masks_only_the_exact_snippet(self):
+        """The allowlisted literature quote stays green, but an unlisted
+        result percentage in the very same text is still flagged."""
+        allowlisted_only = (
+            "Widely-cited 99–100 % accuracies on CWRU typically come from "
+            "segment-level leakage.\n"
+        )
+        assert scan_unguarded_benchmark_numbers(allowlisted_only) == []
+        with_extra = allowlisted_only + "Our detection reached 98.2% there.\n"
+        findings = scan_unguarded_benchmark_numbers(with_extra)
+        assert len(findings) == 1 and "98.2%" in findings[0], findings
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_documented_calls.py
+++ b/tests/test_documented_calls.py
@@ -16,7 +16,13 @@ resource as a tool). This guard makes silent drift impossible:
        ``machine_group`` into ``sampling_rate``). ``...`` placeholders are
        allowed.
 - Retired v0.8.x endpoint names must not appear ANYWHERE in the golden-path
-  docs (plugin, README.md, rendered prompts) — not even as prose.
+  docs (plugin, README.md, docs/TOOL_CATALOG.md, rendered prompts) — not
+  even as prose.
+- ``docs/TOOL_CATALOG.md`` (the catalog migrated out of the README in U2)
+  gets the same call-shape sweep PLUS a name-parity check: the set of
+  backticked names in its table rows must equal the registered surface
+  exactly, so the catalog can neither list a phantom endpoint nor silently
+  omit a real one.
 
 If this test fails after an intentional signature change, fix the docs, not
 the guard: the docs are a public API surface.
@@ -34,6 +40,7 @@ from predictive_maintenance_mcp.mcp_tools import register_all
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PLUGIN_DIR = REPO_ROOT / "plugin"
 README = REPO_ROOT / "README.md"
+TOOL_CATALOG = REPO_ROOT / "docs" / "TOOL_CATALOG.md"
 
 # A documented call: snake_case identifier (>= 1 underscore, all lowercase —
 # every registered endpoint matches this) IMMEDIATELY followed by "(" so that
@@ -313,6 +320,49 @@ class TestPluginDocumentedCalls:
 
 
 # ---------------------------------------------------------------------------
+# docs/TOOL_CATALOG.md: the migrated catalog stays executable and complete
+# ---------------------------------------------------------------------------
+
+#: A catalog table row's name cell: a backticked snake_case identifier as
+#: the FIRST cell of a markdown table row.
+CATALOG_ROW_NAME_RE = re.compile(r"^\|\s*`([a-z][a-z0-9_]*)`\s*\|", re.M)
+
+
+class TestToolCatalogDocumentedCalls:
+    def test_all_calls_executable(self, endpoints):
+        text = TOOL_CATALOG.read_text(encoding="utf-8")
+        violations = validate_documented_calls(text, endpoints, "docs/TOOL_CATALOG.md")
+        assert violations == [], "\n".join(violations)
+
+    def test_catalog_rows_are_exactly_the_registered_surface(self, endpoints):
+        """Name parity, both directions: every table-row name is a real
+        registered endpoint (no phantom or retired names) and every
+        registered endpoint has a row (the catalog is the COMPLETE
+        inventory it claims to be)."""
+        listed = CATALOG_ROW_NAME_RE.findall(TOOL_CATALOG.read_text(encoding="utf-8"))
+        duplicated = sorted({name for name in listed if listed.count(name) > 1})
+        assert duplicated == [], f"docs/TOOL_CATALOG.md: duplicate rows {duplicated}"
+        unknown = sorted(set(listed) - set(endpoints))
+        missing = sorted(set(endpoints) - set(listed))
+        assert unknown == [], (
+            f"docs/TOOL_CATALOG.md lists names that are not registered "
+            f"endpoints: {unknown}"
+        )
+        assert (
+            missing == []
+        ), f"docs/TOOL_CATALOG.md omits registered endpoints: {missing}"
+
+    def test_parity_check_actually_parses_rows(self):
+        """Anti-rot: a table-format change that stopped the row regex from
+        matching would make the parity test pass vacuously."""
+        listed = CATALOG_ROW_NAME_RE.findall(TOOL_CATALOG.read_text(encoding="utf-8"))
+        assert len(listed) >= 30, (
+            f"only {len(listed)} catalog rows parsed — the table format "
+            f"escaped CATALOG_ROW_NAME_RE"
+        )
+
+
+# ---------------------------------------------------------------------------
 # MCP prompt templates: every rendered call template is executable
 # ---------------------------------------------------------------------------
 
@@ -351,6 +401,7 @@ def _golden_path_texts() -> dict[str, str]:
         for p in PLUGIN_FILES
     }
     texts["README.md"] = README.read_text(encoding="utf-8")
+    texts["docs/TOOL_CATALOG.md"] = TOOL_CATALOG.read_text(encoding="utf-8")
     texts.update(rendered_prompt_texts())
     return texts
 

--- a/tests/test_documented_calls.py
+++ b/tests/test_documented_calls.py
@@ -23,6 +23,13 @@ resource as a tool). This guard makes silent drift impossible:
   backticked names in its table rows must equal the registered surface
   exactly, so the catalog can neither list a phantom endpoint nor silently
   omit a real one.
+- ``docs/ADAPTER_GUIDE.md`` (U3) gets the same call-shape and retired-names
+  sweeps PLUS a declaration-parity check: the parameter names in its marked
+  declaration table must equal the raw-declaration surface the code exports
+  (``RAW_PARAM_DEFAULTS`` plus the required ``sample_format``/
+  ``sampling_rate`` and the unit declaration), including allowed-value
+  vocabularies and documented defaults — both directions, so the guide can
+  neither document a parameter the code dropped nor omit one it gained.
 
 If this test fails after an intentional signature change, fix the docs, not
 the guard: the docs are a public API surface.
@@ -30,17 +37,25 @@ the guard: the docs are a public API surface.
 
 import re
 from pathlib import Path
+from typing import Optional
 
 import pytest
 from mcp.server.mcpserver import MCPServer
 
 from predictive_maintenance_mcp.mcp_tools import prompts as prompt_templates
 from predictive_maintenance_mcp.mcp_tools import register_all
+from predictive_maintenance_mcp.signal_acquisition.loaders import (
+    RAW_PARAM_DEFAULTS,
+    VALID_BYTE_ORDERS,
+    VALID_SAMPLE_FORMATS,
+)
+from predictive_maintenance_mcp.signal_acquisition.repository import VALID_SIGNAL_UNITS
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PLUGIN_DIR = REPO_ROOT / "plugin"
 README = REPO_ROOT / "README.md"
 TOOL_CATALOG = REPO_ROOT / "docs" / "TOOL_CATALOG.md"
+ADAPTER_GUIDE = REPO_ROOT / "docs" / "ADAPTER_GUIDE.md"
 
 # A documented call: snake_case identifier (>= 1 underscore, all lowercase —
 # every registered endpoint matches this) IMMEDIATELY followed by "(" so that
@@ -363,6 +378,206 @@ class TestToolCatalogDocumentedCalls:
 
 
 # ---------------------------------------------------------------------------
+# docs/ADAPTER_GUIDE.md: the documented declaration surface cannot drift
+# ---------------------------------------------------------------------------
+
+#: Markers delimiting the guide's declaration-parameter table. The table is
+#: parsed ONLY between these, so other tables in the guide (formats, merge
+#: precedence) can never pollute the parity check.
+ADAPTER_DECL_START = "<!-- adapter-declaration:start -->"
+ADAPTER_DECL_END = "<!-- adapter-declaration:end -->"
+
+
+def expected_adapter_declaration_params() -> set[str]:
+    """The declaration surface an adapter targets, derived from code — never
+    a hand-maintained copy: the two REQUIRED raw declarations (absent from
+    RAW_PARAM_DEFAULTS by design — they have no default), the unit
+    declaration ISO severity verdicts require, and every optional raw
+    parameter with a documented default."""
+    return {"sample_format", "sampling_rate", "signal_unit", *RAW_PARAM_DEFAULTS}
+
+
+def adapter_declaration_rows(text: str) -> Optional[dict[str, str]]:
+    """Parse ``{parameter name: full table row}`` from the marked table.
+
+    Returns None when the markers are missing or misordered — the caller
+    treats that as a violation, so deleting a marker cannot silently
+    disable the guard.
+    """
+    start = text.find(ADAPTER_DECL_START)
+    end = text.find(ADAPTER_DECL_END)
+    if start == -1 or end == -1 or end < start:
+        return None
+    rows: dict[str, str] = {}
+    for line in text[start:end].splitlines():
+        m = CATALOG_ROW_NAME_RE.match(line)
+        if m:
+            rows[m.group(1)] = line
+    return rows
+
+
+def validate_adapter_declaration_table(text: str) -> list[str]:
+    """One violation string per way the guide's declaration table can drift.
+
+    Checks, all derived from the code's own exports:
+    - name parity BOTH ways against :func:`expected_adapter_declaration_params`;
+    - closed vocabularies (VALID_SAMPLE_FORMATS / VALID_BYTE_ORDERS /
+      VALID_SIGNAL_UNITS) each listed backticked in their parameter's row;
+    - each RAW_PARAM_DEFAULTS default shown backticked in its row (None
+      defaults must say 'none');
+    - the two required parameters say 'required'.
+    """
+    rows = adapter_declaration_rows(text)
+    if rows is None:
+        return [
+            "docs/ADAPTER_GUIDE.md: adapter-declaration markers missing or "
+            f"misordered — the declaration table must sit between "
+            f"'{ADAPTER_DECL_START}' and '{ADAPTER_DECL_END}'"
+        ]
+    violations = []
+    expected = expected_adapter_declaration_params()
+    phantom = sorted(set(rows) - expected)
+    missing = sorted(expected - set(rows))
+    if phantom:
+        violations.append(
+            f"docs/ADAPTER_GUIDE.md documents parameter(s) that are not part "
+            f"of the code's raw-declaration surface: {phantom}"
+        )
+    if missing:
+        violations.append(
+            f"docs/ADAPTER_GUIDE.md omits declaration parameter(s) the code "
+            f"exports: {missing}"
+        )
+    vocabularies = {
+        "sample_format": VALID_SAMPLE_FORMATS,
+        "byte_order": VALID_BYTE_ORDERS,
+        "signal_unit": VALID_SIGNAL_UNITS,
+    }
+    for name, vocabulary in vocabularies.items():
+        row = rows.get(name)
+        if row is None:
+            continue  # already reported as missing
+        absent = sorted(v for v in vocabulary if f"`{v}`" not in row)
+        if absent:
+            violations.append(
+                f"docs/ADAPTER_GUIDE.md: row for '{name}' does not list "
+                f"allowed value(s) {absent} (each must appear backticked)"
+            )
+    for name, default in RAW_PARAM_DEFAULTS.items():
+        row = rows.get(name)
+        if row is None:
+            continue
+        if default is None:
+            if "none" not in row.lower():
+                violations.append(
+                    f"docs/ADAPTER_GUIDE.md: row for '{name}' must state its "
+                    f"default is none"
+                )
+        elif f"`{default}`" not in row:
+            violations.append(
+                f"docs/ADAPTER_GUIDE.md: row for '{name}' does not show its "
+                f"documented default `{default}`"
+            )
+    for name in ("sample_format", "sampling_rate"):
+        row = rows.get(name)
+        if row is not None and "required" not in row.lower():
+            violations.append(
+                f"docs/ADAPTER_GUIDE.md: row for '{name}' must say it is "
+                f"required (it has no default by design)"
+            )
+    return violations
+
+
+class TestAdapterGuideDeclarationParams:
+    def test_expected_set_is_on_the_load_signal_surface(self, endpoints):
+        """The code-derived declaration set must itself exist on the
+        registered load_signal tool — ties the loaders module's exports to
+        the MCP surface, so a rename on either side goes red."""
+        extra = sorted(expected_adapter_declaration_params() - endpoints["load_signal"])
+        assert extra == [], (
+            f"declaration parameter(s) {extra} are not parameters of the "
+            f"registered load_signal tool"
+        )
+
+    def test_guide_table_matches_the_code(self):
+        violations = validate_adapter_declaration_table(
+            ADAPTER_GUIDE.read_text(encoding="utf-8")
+        )
+        assert violations == [], "\n".join(violations)
+
+    def test_parity_check_actually_parses_rows(self):
+        """Anti-rot: a table-format change that stopped the row regex from
+        matching would surface as mass 'omits' violations, but assert the
+        parse directly too so the failure names the real cause."""
+        rows = adapter_declaration_rows(ADAPTER_GUIDE.read_text(encoding="utf-8"))
+        assert rows is not None, "adapter-declaration markers not found"
+        assert len(rows) >= 8, (
+            f"only {len(rows)} declaration rows parsed — the table format "
+            f"escaped CATALOG_ROW_NAME_RE"
+        )
+
+    # --- mutation tests: the checker really goes red on drifted text ---
+
+    def test_mutation_renamed_param_goes_red(self):
+        """Renaming a documented parameter (code rename not mirrored, or
+        guide typo) is flagged in BOTH directions."""
+        mutated = ADAPTER_GUIDE.read_text(encoding="utf-8").replace(
+            "`header_offset`", "`hdr_offset`"
+        )
+        violations = validate_adapter_declaration_table(mutated)
+        assert any("hdr_offset" in v for v in violations), violations
+        assert any("header_offset" in v for v in violations), violations
+
+    def test_mutation_phantom_param_goes_red(self):
+        """A documented parameter the code does not export is flagged."""
+        mutated = ADAPTER_GUIDE.read_text(encoding="utf-8").replace(
+            ADAPTER_DECL_END,
+            "| `endianness` | Raw files | `little`, `big` | `little` |\n\n"
+            + ADAPTER_DECL_END,
+        )
+        violations = validate_adapter_declaration_table(mutated)
+        assert any("endianness" in v for v in violations), violations
+
+    def test_mutation_dropped_vocabulary_value_goes_red(self):
+        """A sample format missing from the guide's allowed values is
+        flagged (the vocabularies are checked, not just the names)."""
+        mutated = ADAPTER_GUIDE.read_text(encoding="utf-8").replace(
+            "`int32`", "`int64`"
+        )
+        violations = validate_adapter_declaration_table(mutated)
+        assert any("int32" in v for v in violations), violations
+
+    def test_mutation_stale_default_goes_red(self):
+        """A default that no longer matches RAW_PARAM_DEFAULTS is flagged."""
+        mutated = ADAPTER_GUIDE.read_text(encoding="utf-8").replace(
+            "`little`", "`middle`"
+        )
+        violations = validate_adapter_declaration_table(mutated)
+        assert any("byte_order" in v for v in violations), violations
+
+    def test_mutation_removed_marker_goes_red(self):
+        """Deleting a marker cannot silently disable the guard."""
+        mutated = ADAPTER_GUIDE.read_text(encoding="utf-8").replace(
+            ADAPTER_DECL_START, ""
+        )
+        violations = validate_adapter_declaration_table(mutated)
+        assert any("marker" in v for v in violations), violations
+
+
+class TestAdapterGuideDocumentedCalls:
+    def test_all_calls_executable(self, endpoints):
+        text = ADAPTER_GUIDE.read_text(encoding="utf-8")
+        violations = validate_documented_calls(text, endpoints, "docs/ADAPTER_GUIDE.md")
+        assert violations == [], "\n".join(violations)
+
+    def test_guide_contains_calls(self):
+        """Anti-rot: the guide's worked example DOES document real calls
+        (protects against a rewrite that silently drops them)."""
+        calls = extract_calls(ADAPTER_GUIDE.read_text(encoding="utf-8"))
+        assert len(calls) >= 3, f"only {len(calls)} documented calls found"
+
+
+# ---------------------------------------------------------------------------
 # MCP prompt templates: every rendered call template is executable
 # ---------------------------------------------------------------------------
 
@@ -402,6 +617,7 @@ def _golden_path_texts() -> dict[str, str]:
     }
     texts["README.md"] = README.read_text(encoding="utf-8")
     texts["docs/TOOL_CATALOG.md"] = TOOL_CATALOG.read_text(encoding="utf-8")
+    texts["docs/ADAPTER_GUIDE.md"] = ADAPTER_GUIDE.read_text(encoding="utf-8")
     texts.update(rendered_prompt_texts())
     return texts
 

--- a/tests/test_documented_calls.py
+++ b/tests/test_documented_calls.py
@@ -28,7 +28,8 @@ resource as a tool). This guard makes silent drift impossible:
   declaration table must equal the raw-declaration surface the code exports
   (``RAW_PARAM_DEFAULTS`` plus the required ``sample_format``/
   ``sampling_rate`` and the unit declaration), including allowed-value
-  vocabularies and documented defaults — both directions, so the guide can
+  vocabularies (set-equality, per table cell) and documented defaults (in
+  the 'Default' cell specifically) — both directions, so the guide can
   neither document a parameter the code dropped nor omit one it gained.
 
 If this test fails after an intentional signature change, fix the docs, not
@@ -338,9 +339,32 @@ class TestPluginDocumentedCalls:
 # docs/TOOL_CATALOG.md: the migrated catalog stays executable and complete
 # ---------------------------------------------------------------------------
 
-#: A catalog table row's name cell: a backticked snake_case identifier as
-#: the FIRST cell of a markdown table row.
-CATALOG_ROW_NAME_RE = re.compile(r"^\|\s*`([a-z][a-z0-9_]*)`\s*\|", re.M)
+#: Any backticked-name markdown table row: a backticked snake_case
+#: identifier as the FIRST cell of the row. Shared by the tool-catalog
+#: parity check and the adapter-guide declaration-table parser.
+TABLE_ROW_NAME_RE = re.compile(r"^\|\s*`([a-z][a-z0-9_]*)`\s*\|", re.M)
+
+
+def catalog_parity_violations(text: str, endpoints: dict[str, set[str]]) -> list[str]:
+    """Name parity between catalog *text* and *endpoints*, both directions.
+
+    Pure over its inputs so it can be mutation-tested on small fixtures.
+    One violation string each for: duplicate table rows, table-row names
+    that are not registered endpoints, and registered endpoints without a
+    table row (the catalog is the COMPLETE inventory it claims to be).
+    """
+    listed = TABLE_ROW_NAME_RE.findall(text)
+    violations: list[str] = []
+    duplicated = sorted({name for name in listed if listed.count(name) > 1})
+    if duplicated:
+        violations.append(f"duplicate catalog rows: {duplicated}")
+    unknown = sorted(set(listed) - set(endpoints))
+    if unknown:
+        violations.append(f"lists names that are not registered endpoints: {unknown}")
+    missing = sorted(set(endpoints) - set(listed))
+    if missing:
+        violations.append(f"omits registered endpoints: {missing}")
+    return violations
 
 
 class TestToolCatalogDocumentedCalls:
@@ -354,27 +378,53 @@ class TestToolCatalogDocumentedCalls:
         registered endpoint (no phantom or retired names) and every
         registered endpoint has a row (the catalog is the COMPLETE
         inventory it claims to be)."""
-        listed = CATALOG_ROW_NAME_RE.findall(TOOL_CATALOG.read_text(encoding="utf-8"))
-        duplicated = sorted({name for name in listed if listed.count(name) > 1})
-        assert duplicated == [], f"docs/TOOL_CATALOG.md: duplicate rows {duplicated}"
-        unknown = sorted(set(listed) - set(endpoints))
-        missing = sorted(set(endpoints) - set(listed))
-        assert unknown == [], (
-            f"docs/TOOL_CATALOG.md lists names that are not registered "
-            f"endpoints: {unknown}"
+        violations = catalog_parity_violations(
+            TOOL_CATALOG.read_text(encoding="utf-8"), endpoints
         )
-        assert (
-            missing == []
-        ), f"docs/TOOL_CATALOG.md omits registered endpoints: {missing}"
+        assert violations == [], "docs/TOOL_CATALOG.md: " + "; ".join(violations)
 
     def test_parity_check_actually_parses_rows(self):
         """Anti-rot: a table-format change that stopped the row regex from
         matching would make the parity test pass vacuously."""
-        listed = CATALOG_ROW_NAME_RE.findall(TOOL_CATALOG.read_text(encoding="utf-8"))
+        listed = TABLE_ROW_NAME_RE.findall(TOOL_CATALOG.read_text(encoding="utf-8"))
         assert len(listed) >= 30, (
             f"only {len(listed)} catalog rows parsed — the table format "
-            f"escaped CATALOG_ROW_NAME_RE"
+            f"escaped TABLE_ROW_NAME_RE"
         )
+
+
+class TestCatalogParityMutations:
+    """Executable proof :func:`catalog_parity_violations` catches each
+    drift class (and stays green on clean input) — small-fixture style,
+    like the landing-page scanner mutations."""
+
+    _ENDPOINTS: dict[str, set[str]] = {"analyze_fft": set(), "load_signal": set()}
+    _CLEAN = (
+        "| Tool | Purpose |\n"
+        "|------|---------|\n"
+        "| `analyze_fft` | Spectrum analysis |\n"
+        "| `load_signal` | Load a signal |\n"
+    )
+
+    def test_clean_fixture_is_green(self):
+        assert catalog_parity_violations(self._CLEAN, self._ENDPOINTS) == []
+
+    def test_phantom_name_goes_red(self):
+        mutated = self._CLEAN + "| `plot_spectrum` | Retired name |\n"
+        violations = catalog_parity_violations(mutated, self._ENDPOINTS)
+        assert any("plot_spectrum" in v for v in violations), violations
+
+    def test_omitted_endpoint_goes_red(self):
+        mutated = self._CLEAN.replace("| `load_signal` | Load a signal |\n", "")
+        violations = catalog_parity_violations(mutated, self._ENDPOINTS)
+        assert any("load_signal" in v and "omits" in v for v in violations), violations
+
+    def test_duplicate_row_goes_red(self):
+        mutated = self._CLEAN + "| `analyze_fft` | Duplicate row |\n"
+        violations = catalog_parity_violations(mutated, self._ENDPOINTS)
+        assert any(
+            "duplicate" in v.lower() and "analyze_fft" in v for v in violations
+        ), violations
 
 
 # ---------------------------------------------------------------------------
@@ -397,8 +447,21 @@ def expected_adapter_declaration_params() -> set[str]:
     return {"sample_format", "sampling_rate", "signal_unit", *RAW_PARAM_DEFAULTS}
 
 
-def adapter_declaration_rows(text: str) -> Optional[dict[str, str]]:
-    """Parse ``{parameter name: full table row}`` from the marked table.
+#: A backticked value inside a table cell.
+_BACKTICKED_RE = re.compile(r"`([^`]+)`")
+
+
+def _row_cells(row: str) -> list[str]:
+    """A markdown table row's cells, in order, outer pipes stripped."""
+    return [c.strip() for c in row.strip().strip("|").split("|")]
+
+
+def adapter_declaration_rows(text: str) -> Optional[dict[str, list[str]]]:
+    """Parse ``{parameter name: [full table row, ...]}`` from the marked table.
+
+    EVERY row for a name is kept (not last-wins) so the caller can flag
+    duplicates instead of letting a stale duplicate silently shadow — or
+    be shadowed by — the correct row.
 
     Returns None when the markers are missing or misordered — the caller
     treats that as a violation, so deleting a marker cannot silently
@@ -408,24 +471,43 @@ def adapter_declaration_rows(text: str) -> Optional[dict[str, str]]:
     end = text.find(ADAPTER_DECL_END)
     if start == -1 or end == -1 or end < start:
         return None
-    rows: dict[str, str] = {}
+    rows: dict[str, list[str]] = {}
     for line in text[start:end].splitlines():
-        m = CATALOG_ROW_NAME_RE.match(line)
+        m = TABLE_ROW_NAME_RE.match(line)
         if m:
-            rows[m.group(1)] = line
+            rows.setdefault(m.group(1), []).append(line)
     return rows
+
+
+def _adapter_table_header(text: str) -> Optional[list[str]]:
+    """Lowercased header cells of the marked declaration table (the first
+    ``|``-row between the markers), or None when it cannot be found."""
+    start = text.find(ADAPTER_DECL_START)
+    end = text.find(ADAPTER_DECL_END)
+    if start == -1 or end == -1 or end < start:
+        return None
+    for line in text[start:end].splitlines():
+        if line.lstrip().startswith("|"):
+            return [c.lower() for c in _row_cells(line)]
+    return None
 
 
 def validate_adapter_declaration_table(text: str) -> list[str]:
     """One violation string per way the guide's declaration table can drift.
 
-    Checks, all derived from the code's own exports:
-    - name parity BOTH ways against :func:`expected_adapter_declaration_params`;
+    Checks, all derived from the code's own exports and CELL-anchored
+    (each row is split on ``|`` and every check reads the column the
+    header names, so a value in the wrong column cannot satisfy it):
+    - name parity BOTH ways against :func:`expected_adapter_declaration_params`,
+      with duplicate rows reported by name;
     - closed vocabularies (VALID_SAMPLE_FORMATS / VALID_BYTE_ORDERS /
-      VALID_SIGNAL_UNITS) each listed backticked in their parameter's row;
-    - each RAW_PARAM_DEFAULTS default shown backticked in its row (None
-      defaults must say 'none');
-    - the two required parameters say 'required'.
+      VALID_SIGNAL_UNITS) via SET EQUALITY on the backticked values in the
+      'Allowed values' cell — a missing value and a phantom value both go
+      red;
+    - each RAW_PARAM_DEFAULTS default shown backticked in the 'Default'
+      cell specifically (None defaults must say 'none' there);
+    - the two required parameters marked required in the 'Scope' cell,
+      negation-aware: 'not required' or 'optional' is a violation.
     """
     rows = adapter_declaration_rows(text)
     if rows is None:
@@ -435,6 +517,12 @@ def validate_adapter_declaration_table(text: str) -> list[str]:
             f"'{ADAPTER_DECL_START}' and '{ADAPTER_DECL_END}'"
         ]
     violations = []
+    duplicated = sorted(name for name, lines in rows.items() if len(lines) > 1)
+    if duplicated:
+        violations.append(
+            f"docs/ADAPTER_GUIDE.md: duplicate declaration row(s) for "
+            f"{duplicated} — each parameter must have exactly one row"
+        )
     expected = expected_adapter_declaration_params()
     phantom = sorted(set(rows) - expected)
     missing = sorted(expected - set(rows))
@@ -448,42 +536,84 @@ def validate_adapter_declaration_table(text: str) -> list[str]:
             f"docs/ADAPTER_GUIDE.md omits declaration parameter(s) the code "
             f"exports: {missing}"
         )
+
+    header = _adapter_table_header(text)
+    columns: dict[str, int] = {}
+    if header is None:
+        violations.append(
+            "docs/ADAPTER_GUIDE.md: no header row found in the "
+            "adapter-declaration table"
+        )
+    else:
+        for label in ("scope", "allowed values", "default"):
+            if label in header:
+                columns[label] = header.index(label)
+            else:
+                violations.append(
+                    f"docs/ADAPTER_GUIDE.md: the declaration table header "
+                    f"lacks a '{label}' column — the cell-anchored checks "
+                    f"need it"
+                )
+
+    def cell(name: str, label: str) -> Optional[str]:
+        """The named column's cell of *name*'s (last) row, or None when the
+        row or column is unavailable (each already reported above)."""
+        if label not in columns or name not in rows:
+            return None
+        cells = _row_cells(rows[name][-1])
+        return cells[columns[label]] if columns[label] < len(cells) else ""
+
     vocabularies = {
         "sample_format": VALID_SAMPLE_FORMATS,
         "byte_order": VALID_BYTE_ORDERS,
         "signal_unit": VALID_SIGNAL_UNITS,
     }
     for name, vocabulary in vocabularies.items():
-        row = rows.get(name)
-        if row is None:
-            continue  # already reported as missing
-        absent = sorted(v for v in vocabulary if f"`{v}`" not in row)
+        allowed_cell = cell(name, "allowed values")
+        if allowed_cell is None:
+            continue
+        documented = set(_BACKTICKED_RE.findall(allowed_cell))
+        absent = sorted(set(vocabulary) - documented)
+        extra = sorted(documented - set(vocabulary))
         if absent:
             violations.append(
-                f"docs/ADAPTER_GUIDE.md: row for '{name}' does not list "
-                f"allowed value(s) {absent} (each must appear backticked)"
+                f"docs/ADAPTER_GUIDE.md: 'Allowed values' cell for '{name}' "
+                f"is missing value(s) {absent} (each must appear backticked)"
+            )
+        if extra:
+            violations.append(
+                f"docs/ADAPTER_GUIDE.md: 'Allowed values' cell for '{name}' "
+                f"lists value(s) {extra} the code does not accept"
             )
     for name, default in RAW_PARAM_DEFAULTS.items():
-        row = rows.get(name)
-        if row is None:
+        default_cell = cell(name, "default")
+        if default_cell is None:
             continue
         if default is None:
-            if "none" not in row.lower():
+            if "none" not in default_cell.lower():
                 violations.append(
-                    f"docs/ADAPTER_GUIDE.md: row for '{name}' must state its "
-                    f"default is none"
+                    f"docs/ADAPTER_GUIDE.md: 'Default' cell for '{name}' "
+                    f"must state its default is none"
                 )
-        elif f"`{default}`" not in row:
+        elif f"`{default}`" not in default_cell:
             violations.append(
-                f"docs/ADAPTER_GUIDE.md: row for '{name}' does not show its "
-                f"documented default `{default}`"
+                f"docs/ADAPTER_GUIDE.md: 'Default' cell for '{name}' does "
+                f"not show the documented default `{default}`"
             )
     for name in ("sample_format", "sampling_rate"):
-        row = rows.get(name)
-        if row is not None and "required" not in row.lower():
+        scope_cell = cell(name, "scope")
+        if scope_cell is None:
+            continue
+        lowered = scope_cell.lower()
+        if (
+            "not required" in lowered
+            or "optional" in lowered
+            or "required" not in lowered
+        ):
             violations.append(
-                f"docs/ADAPTER_GUIDE.md: row for '{name}' must say it is "
-                f"required (it has no default by design)"
+                f"docs/ADAPTER_GUIDE.md: 'Scope' cell for '{name}' must "
+                f"state — without negation — that it is required (it has no "
+                f"default by design)"
             )
     return violations
 
@@ -513,7 +643,7 @@ class TestAdapterGuideDeclarationParams:
         assert rows is not None, "adapter-declaration markers not found"
         assert len(rows) >= 8, (
             f"only {len(rows)} declaration rows parsed — the table format "
-            f"escaped CATALOG_ROW_NAME_RE"
+            f"escaped TABLE_ROW_NAME_RE"
         )
 
     # --- mutation tests: the checker really goes red on drifted text ---
@@ -554,6 +684,61 @@ class TestAdapterGuideDeclarationParams:
         )
         violations = validate_adapter_declaration_table(mutated)
         assert any("byte_order" in v for v in violations), violations
+
+    def test_mutation_duplicate_row_goes_red(self):
+        """A stale duplicate row placed BEFORE the correct one is flagged —
+        last-wins parsing used to let the correct row silently mask it."""
+        text = ADAPTER_GUIDE.read_text(encoding="utf-8")
+        row = next(
+            line for line in text.splitlines() if line.startswith("| `byte_order`")
+        )
+        stale = "| `byte_order` | Raw files | `little`, `big` | `big` |"
+        mutated = text.replace(row, stale + "\n" + row)
+        violations = validate_adapter_declaration_table(mutated)
+        assert any(
+            "duplicate" in v.lower() and "byte_order" in v for v in violations
+        ), violations
+
+    def test_mutation_phantom_vocabulary_value_goes_red(self):
+        """A value the code does NOT accept, added to an allowed-values
+        cell, is flagged — the cell must EQUAL the code vocabulary, not
+        merely contain it."""
+        mutated = ADAPTER_GUIDE.read_text(encoding="utf-8").replace(
+            "`int32`", "`int32`, `int64`"
+        )
+        violations = validate_adapter_declaration_table(mutated)
+        assert any("int64" in v for v in violations), violations
+
+    def test_mutation_default_outside_default_cell_goes_red(self):
+        """Cell anchoring: the documented default moved OUT of the 'Default'
+        cell — but still present backticked elsewhere in the same row — is
+        flagged (a whole-row substring check would wrongly pass it)."""
+        text = ADAPTER_GUIDE.read_text(encoding="utf-8")
+        row = next(
+            line for line in text.splitlines() if line.startswith("| `byte_order`")
+        )
+        mutated_row = (
+            "| `byte_order` | Raw files (default `little`) | `little`, `big` | — |"
+        )
+        mutated = text.replace(row, mutated_row)
+        violations = validate_adapter_declaration_table(mutated)
+        assert any(
+            "byte_order" in v and "`little`" in v for v in violations
+        ), violations
+
+    def test_mutation_not_required_wording_goes_red(self):
+        """Negation awareness: 'not required' contains 'required', so a
+        plain substring check would wrongly pass it."""
+        mutated = ADAPTER_GUIDE.read_text(encoding="utf-8").replace(
+            "**required**", "**not required**"
+        )
+        violations = validate_adapter_declaration_table(mutated)
+        assert any(
+            "sample_format" in v and "required" in v for v in violations
+        ), violations
+        assert any(
+            "sampling_rate" in v and "required" in v for v in violations
+        ), violations
 
     def test_mutation_removed_marker_goes_red(self):
         """Deleting a marker cannot silently disable the guard."""

--- a/tests/test_monolith_removed.py
+++ b/tests/test_monolith_removed.py
@@ -48,10 +48,16 @@ SCAN_FILES = [
 SCAN_SUFFIXES = {".py", ".md", ".toml", ".json", ".yml", ".yaml", ".txt", ""}
 
 #: Precise historical-record exceptions (path parts relative to ROOT).
+#: Includes the gitignored local-only doc directories: they never ship in
+#: the public tree, so they are not operational surfaces.
 HISTORICAL = (
     ("docs", "AUDIT-2026-07-10.md"),
     ("docs", "plans"),
     ("docs", "solutions"),
+    ("docs", "brainstorms"),
+    ("docs", "residual-review-findings"),
+    ("docs", "issue-drafts"),
+    ("docs", "distribution-kit"),
 )
 
 

--- a/tests/test_version_alignment.py
+++ b/tests/test_version_alignment.py
@@ -35,6 +35,17 @@ pyproject.toml, src/__init__.py, server.json (x2), CITATION.cff, the
 README.md BibTeX block, and docs/index.html (x2: JSON-LD softwareVersion +
 BibTeX block). The plugin manifests (plugin.json + marketplace.json)
 version independently but must match each other.
+
+U2 (README funnel) widened the guarded surfaces again:
+
+- ``docs/TOOL_CATALOG.md`` (the tool catalog migrated out of the README)
+  joins the count-claim scan, with its own anti-rot check — its stated
+  totals must equal the introspected surface;
+- the ``<!-- mcp-name: ... -->`` marker in README.md must equal the
+  ``name`` field of ``server.json``. The MCP registry validates PyPI
+  package ownership by finding this marker in the long description (the
+  README), and losing it fails ``publish-mcp.yml`` only AFTER the
+  immutable PyPI upload — forcing a patch release.
 """
 
 import json
@@ -134,6 +145,46 @@ class TestPackageVersionAlignment:
 
 
 # ---------------------------------------------------------------------------
+# MCP registry ownership marker (U2)
+# ---------------------------------------------------------------------------
+
+_MCP_NAME_RE = re.compile(r"<!--\s*mcp-name:\s*(\S+)\s*-->")
+
+
+class TestMcpNameMarker:
+    """README must carry the registry ownership marker, equal to server.json.
+
+    The MCP registry validates PyPI-package ownership by finding
+    ``<!-- mcp-name: ... -->`` in the package long description (the README).
+    Losing or mistyping the marker — e.g. in a README restructure — fails
+    ``publish-mcp.yml`` only AFTER the immutable PyPI upload, forcing a
+    patch release. This turns the constraint into an executable check.
+    """
+
+    def test_readme_mcp_name_matches_server_json(self):
+        m = _MCP_NAME_RE.search(_read("README.md"))
+        assert m, "README.md: <!-- mcp-name: ... --> marker not found"
+        expected = json.loads(_read("server.json"))["name"]
+        assert m.group(1) == expected, (
+            f"README.md mcp-name marker says {m.group(1)!r} but server.json "
+            f"name is {expected!r}"
+        )
+
+    def test_marker_sits_in_the_header_block(self):
+        """The marker belongs in the README's top area — before the first
+        '## ' section heading — where a section-level restructure is least
+        likely to orphan or delete it."""
+        readme = _read("README.md")
+        m = _MCP_NAME_RE.search(readme)
+        assert m is not None
+        first_section = readme.find("\n## ")
+        assert first_section != -1 and m.start() < first_section, (
+            "README.md: the mcp-name marker must appear before the first "
+            "'## ' section heading"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Endpoint counts: docs vs the introspected registered surface
 # ---------------------------------------------------------------------------
 
@@ -210,6 +261,7 @@ COUNTED_PROSE_SURFACES: dict[str, Callable[[], str]] = {
     "plugin/README.md": lambda: _read("plugin/README.md"),
     "pyproject.toml (project.description)": _pyproject_description,
     "docs/_config.yml": lambda: _read("docs/_config.yml"),
+    "docs/TOOL_CATALOG.md": lambda: _read("docs/TOOL_CATALOG.md"),
 }
 
 
@@ -284,6 +336,18 @@ class TestEndpointCountClaims:
             assert _claims(COUNTED_PROSE_SURFACES[surface](), "endpoints"), (
                 f"{surface}: no recognizable 'N endpoints' claim found — "
                 f"either the count was removed or the wording escaped "
+                f"CLAIM_PATTERNS"
+            )
+
+    def test_tool_catalog_states_its_totals(self):
+        """Anti-rot for the migrated catalog page (U2): it must keep a
+        recognizable total for endpoints, tools AND prompts — the whole
+        point of the page is the complete guarded inventory."""
+        text = COUNTED_PROSE_SURFACES["docs/TOOL_CATALOG.md"]()
+        for kind in ("endpoints", "tools", "prompts"):
+            assert _claims(text, kind), (
+                f"docs/TOOL_CATALOG.md: no recognizable '{kind}' count claim "
+                f"found — either the total was removed or the wording escaped "
                 f"CLAIM_PATTERNS"
             )
 

--- a/tests/test_version_alignment.py
+++ b/tests/test_version_alignment.py
@@ -151,6 +151,32 @@ class TestPackageVersionAlignment:
 _MCP_NAME_RE = re.compile(r"<!--\s*mcp-name:\s*(\S+)\s*-->")
 
 
+def mcp_name_marker_violations(readme_text: str, expected_name: str) -> list[str]:
+    """Every way the README can break MCP-registry ownership validation.
+
+    Pure over its inputs so each failure mode can be mutation-tested on
+    small fixtures: the marker missing entirely; the marker naming a
+    different server than *expected_name*; the marker sitting after the
+    first '## ' section heading (outside the header block, where a
+    section-level restructure is most likely to orphan or delete it).
+    """
+    m = _MCP_NAME_RE.search(readme_text)
+    if m is None:
+        return ["<!-- mcp-name: ... --> marker not found"]
+    violations: list[str] = []
+    if m.group(1) != expected_name:
+        violations.append(
+            f"mcp-name marker says {m.group(1)!r} but server.json name is "
+            f"{expected_name!r}"
+        )
+    first_section = readme_text.find("\n## ")
+    if first_section != -1 and m.start() > first_section:
+        violations.append(
+            "the mcp-name marker must appear before the first '## ' section " "heading"
+        )
+    return violations
+
+
 class TestMcpNameMarker:
     """README must carry the registry ownership marker, equal to server.json.
 
@@ -161,27 +187,60 @@ class TestMcpNameMarker:
     patch release. This turns the constraint into an executable check.
     """
 
-    def test_readme_mcp_name_matches_server_json(self):
-        m = _MCP_NAME_RE.search(_read("README.md"))
-        assert m, "README.md: <!-- mcp-name: ... --> marker not found"
+    def test_readme_marker_is_valid(self):
         expected = json.loads(_read("server.json"))["name"]
-        assert m.group(1) == expected, (
-            f"README.md mcp-name marker says {m.group(1)!r} but server.json "
-            f"name is {expected!r}"
+        violations = mcp_name_marker_violations(_read("README.md"), expected)
+        assert violations == [], "README.md: " + "; ".join(violations)
+
+    def test_readme_still_has_a_section_heading(self):
+        """Anti-rot for the header-block rule: it compares the marker's
+        position against the first '## ' heading, so a README with no such
+        heading would make that check vacuously green."""
+        assert "\n## " in _read("README.md"), (
+            "README.md has no '## ' section headings — the mcp-name "
+            "header-block check has nothing to anchor to"
         )
 
-    def test_marker_sits_in_the_header_block(self):
-        """The marker belongs in the README's top area — before the first
-        '## ' section heading — where a section-level restructure is least
-        likely to orphan or delete it."""
-        readme = _read("README.md")
-        m = _MCP_NAME_RE.search(readme)
-        assert m is not None
-        first_section = readme.find("\n## ")
-        assert first_section != -1 and m.start() < first_section, (
-            "README.md: the mcp-name marker must appear before the first "
-            "'## ' section heading"
-        )
+
+#: Synthetic README fixture for the marker mutations — deliberately NOT the
+#: real README, so these tests exercise the checker, not the repo state.
+_MARKER_FIXTURE = (
+    "# Predictive Maintenance MCP\n"
+    "\n"
+    "<!-- mcp-name: io.github.acme/pmm -->\n"
+    "\n"
+    "Intro paragraph.\n"
+    "\n"
+    "## Install\n"
+    "\n"
+    "pip install pmm\n"
+)
+
+
+class TestMcpNameMarkerMutations:
+    """Executable proof the marker check catches each failure mode (and
+    stays green on clean input)."""
+
+    def test_clean_fixture_is_green(self):
+        assert mcp_name_marker_violations(_MARKER_FIXTURE, "io.github.acme/pmm") == []
+
+    def test_missing_marker_goes_red(self):
+        mutated = _MARKER_FIXTURE.replace("<!-- mcp-name: io.github.acme/pmm -->\n", "")
+        violations = mcp_name_marker_violations(mutated, "io.github.acme/pmm")
+        assert any("not found" in v for v in violations), violations
+
+    def test_name_mismatch_goes_red(self):
+        violations = mcp_name_marker_violations(_MARKER_FIXTURE, "io.github.acme/other")
+        assert any(
+            "io.github.acme/pmm" in v and "io.github.acme/other" in v
+            for v in violations
+        ), violations
+
+    def test_marker_after_first_heading_goes_red(self):
+        marker = "<!-- mcp-name: io.github.acme/pmm -->\n"
+        mutated = _MARKER_FIXTURE.replace(marker + "\n", "") + "\n" + marker
+        violations = mcp_name_marker_violations(mutated, "io.github.acme/pmm")
+        assert any("before the first" in v for v in violations), violations
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_version_alignment.py
+++ b/tests/test_version_alignment.py
@@ -15,15 +15,32 @@ surfaces at once — audit 4.2/4.7). This guard pins:
 - every "N skills / N agents / N commands" claim equals the number of
   plugin components actually on disk.
 
+U1 (distribution plan) widened the guarded surfaces after "52 endpoints /
+7 skills / 0.8.0 / 86%" shipped stale on the public funnel:
+
+- the count-claim guard also scans ``pyproject.toml``'s ``description`` and
+  ``docs/_config.yml``;
+- ``docs/index.html`` gets a dedicated scanner
+  (:func:`scan_landing_page_claims`): the landing page carries numbers in
+  meta/OG/Twitter descriptions, nested JSON-LD strings, animated
+  ``data-target`` counters (where the number and its noun live in different
+  HTML elements), and a BibTeX block. The scanner DERIVES every occurrence
+  from the text — never from a hardcoded list of N known copies;
+- coverage percentages are compared against the CI-enforced minimum
+  (``[tool.coverage.report] fail_under``), never a measured snapshot;
+- ``.zenodo.json`` must parse as strict JSON (a trailing comma shipped).
+
 U11 release-bump touchpoints (must change together, this test enforces it):
-pyproject.toml, src/__init__.py, server.json (x2), CITATION.cff, and the
-README.md BibTeX block. The plugin manifests (plugin.json +
-marketplace.json) version independently but must match each other.
+pyproject.toml, src/__init__.py, server.json (x2), CITATION.cff, the
+README.md BibTeX block, and docs/index.html (x2: JSON-LD softwareVersion +
+BibTeX block). The plugin manifests (plugin.json + marketplace.json)
+version independently but must match each other.
 """
 
 import json
 import re
 import tomllib
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -36,6 +53,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 def _read(relative: str) -> str:
     return (REPO_ROOT / relative).read_text(encoding="utf-8")
+
+
+#: docs/index.html version markers, shared by the package-version alignment
+#: and the landing-page scanner below.
+_SOFTWARE_VERSION_RE = re.compile(r'"softwareVersion"\s*:\s*"([^"]+)"')
+_BIBTEX_VERSION_RE = re.compile(r"\bversion\s*=\s*\{([^}]+)\}")
 
 
 # ---------------------------------------------------------------------------
@@ -71,9 +94,21 @@ def collect_package_versions() -> dict[str, str]:
     versions["CITATION.cff (top-level)"] = cff_versions[0]
     versions["CITATION.cff (preferred-citation)"] = cff_versions[1]
 
-    m = re.search(r"version\s*=\s*\{([^}]+)\}", _read("README.md"))
+    m = _BIBTEX_VERSION_RE.search(_read("README.md"))
     assert m, "README.md: BibTeX version field not found"
     versions["README.md (BibTeX)"] = m.group(1).strip()
+
+    # docs/index.html declares the version TWICE: the JSON-LD
+    # ``softwareVersion`` and the copyable BibTeX block. Both sat at 0.8.0
+    # while the package moved to 0.12.0 — exactly the drift class this
+    # module exists for — so both join the alignment set.
+    index_html = _read("docs/index.html")
+    m = _SOFTWARE_VERSION_RE.search(index_html)
+    assert m, "docs/index.html: JSON-LD softwareVersion not found"
+    versions["docs/index.html (JSON-LD softwareVersion)"] = m.group(1)
+    m = _BIBTEX_VERSION_RE.search(index_html)
+    assert m, "docs/index.html: BibTeX version field not found"
+    versions["docs/index.html (BibTeX)"] = m.group(1).strip()
     return versions
 
 
@@ -129,7 +164,9 @@ def component_counts() -> dict[str, int]:
     }
 
 
-#: Numeric claims recognized in the READMEs, per counted kind.
+#: Numeric claims recognized on the prose surfaces, per counted kind.
+#: "coverage" is special: its expected value is the CI-enforced minimum
+#: (``fail_under``), not a surface count.
 CLAIM_PATTERNS: dict[str, list[re.Pattern[str]]] = {
     "tools": [re.compile(r"\b(\d+)\s+(?:specialized\s+)?(?:MCP\s+)?tools\b", re.I)],
     "endpoints": [
@@ -138,20 +175,51 @@ CLAIM_PATTERNS: dict[str, list[re.Pattern[str]]] = {
     "prompts": [re.compile(r"\b(\d+)\s+(?:MCP\s+|guided\s+)?prompts\b", re.I)],
     "resources": [re.compile(r"\b(\d+)\s+(?:MCP\s+)?resources?\b", re.I)],
     "skills": [
-        re.compile(r"\b(\d+)\s+(?:diagnostic\s+|domain\s+)?skills\b", re.I),
+        re.compile(r"\b(\d+)\s+(?:diagnostic\s+|domain\s+|Claude\s+)?skills\b", re.I),
         re.compile(r"\bSkills\s*\((\d+)\)", re.I),
     ],
     "agents": [
-        re.compile(r"\b(\d+)\s+agents\b", re.I),
+        re.compile(r"\b(\d+)\s+(?:autonomous\s+)?agents\b", re.I),
         re.compile(r"\bAgents\s*\((\d+)\)", re.I),
     ],
     "commands": [
-        re.compile(r"\b(\d+)\s+commands\b", re.I),
+        re.compile(r"\b(\d+)\s+(?:slash\s+)?commands\b", re.I),
         re.compile(r"\bCommands\s*\((\d+)\)", re.I),
+    ],
+    "coverage": [
+        # "86% test coverage" / "85%+ test coverage"
+        re.compile(r"\b(\d+)\s*%\+?\s+test\s+coverage\b", re.I),
+        # "test coverage: 85%" / "test coverage of 85%"
+        re.compile(r"\btest\s+coverage\b\D{0,15}?(\d+)\s*%", re.I),
     ],
 }
 
 README_FILES = ["README.md", "plugin/README.md"]
+
+
+def _pyproject_description() -> str:
+    return tomllib.loads(_read("pyproject.toml"))["project"]["description"]
+
+
+#: Every public prose surface the count-claim guard scans, mapping a display
+#: name (used in test ids and failure messages) to a loader for its text.
+#: docs/index.html is NOT here: its numbers hide in data-target attributes
+#: and JSON-LD, so it gets the dedicated scanner below.
+COUNTED_PROSE_SURFACES: dict[str, Callable[[], str]] = {
+    "README.md": lambda: _read("README.md"),
+    "plugin/README.md": lambda: _read("plugin/README.md"),
+    "pyproject.toml (project.description)": _pyproject_description,
+    "docs/_config.yml": lambda: _read("docs/_config.yml"),
+}
+
+
+@pytest.fixture(scope="module")
+def coverage_minimum() -> int:
+    """The CI-enforced coverage floor — the only coverage number a public
+    surface may state (a measured snapshot always goes stale; 86% shipped
+    while CI enforced 85%)."""
+    pyproject = tomllib.loads(_read("pyproject.toml"))
+    return int(pyproject["tool"]["coverage"]["report"]["fail_under"])
 
 
 def _claims(text: str, kind: str) -> list[tuple[int, str]]:
@@ -164,30 +232,60 @@ def _claims(text: str, kind: str) -> list[tuple[int, str]]:
 
 
 class TestEndpointCountClaims:
-    @pytest.mark.parametrize("readme", README_FILES)
+    @pytest.mark.parametrize("surface", COUNTED_PROSE_SURFACES)
     @pytest.mark.parametrize("kind", ["tools", "endpoints", "prompts", "resources"])
-    def test_surface_claims_match_introspection(self, readme, kind, surface_counts):
-        text = _read(readme)
+    def test_surface_claims_match_introspection(self, surface, kind, surface_counts):
+        text = COUNTED_PROSE_SURFACES[surface]()
         expected = surface_counts[kind]
         wrong = [
-            f"{readme}: claims '{snippet}' but the registered surface has "
+            f"{surface}: claims '{snippet}' but the registered surface has "
             f"{expected} {kind}"
             for value, snippet in _claims(text, kind)
             if value != expected
         ]
         assert wrong == [], "\n".join(wrong)
 
-    @pytest.mark.parametrize("readme", README_FILES)
+    @pytest.mark.parametrize("surface", COUNTED_PROSE_SURFACES)
     @pytest.mark.parametrize("kind", ["skills", "agents", "commands"])
-    def test_component_claims_match_disk(self, readme, kind, component_counts):
-        text = _read(readme)
+    def test_component_claims_match_disk(self, surface, kind, component_counts):
+        text = COUNTED_PROSE_SURFACES[surface]()
         expected = component_counts[kind]
         wrong = [
-            f"{readme}: claims '{snippet}' but plugin/ contains " f"{expected} {kind}"
+            f"{surface}: claims '{snippet}' but plugin/ contains " f"{expected} {kind}"
             for value, snippet in _claims(text, kind)
             if value != expected
         ]
         assert wrong == [], "\n".join(wrong)
+
+    @pytest.mark.parametrize("surface", COUNTED_PROSE_SURFACES)
+    def test_coverage_claims_state_the_ci_minimum(self, surface, coverage_minimum):
+        text = COUNTED_PROSE_SURFACES[surface]()
+        wrong = [
+            f"{surface}: claims '{snippet}' but the CI-enforced coverage "
+            f"minimum (fail_under) is {coverage_minimum}"
+            for value, snippet in _claims(text, "coverage")
+            if value != coverage_minimum
+        ]
+        assert wrong == [], "\n".join(wrong)
+
+    def test_readme_coverage_claim_recognizable(self):
+        """Anti-rot: README states a coverage number on purpose (bound to
+        fail_under). If the wording drifts out of CLAIM_PATTERNS, fail here
+        instead of the guard silently checking nothing."""
+        assert _claims(_read("README.md"), "coverage"), (
+            "README.md: no recognizable coverage claim found — either the "
+            "number was removed or the wording escaped CLAIM_PATTERNS"
+        )
+
+    def test_config_and_pyproject_state_the_endpoint_count(self):
+        """Anti-rot for the two newly guarded surfaces: each must keep at
+        least one endpoints claim the guard can recognize."""
+        for surface in ("pyproject.toml (project.description)", "docs/_config.yml"):
+            assert _claims(COUNTED_PROSE_SURFACES[surface](), "endpoints"), (
+                f"{surface}: no recognizable 'N endpoints' claim found — "
+                f"either the count was removed or the wording escaped "
+                f"CLAIM_PATTERNS"
+            )
 
     @pytest.mark.parametrize("readme", README_FILES)
     def test_readmes_state_the_tool_count(self, readme):
@@ -218,6 +316,246 @@ class TestEndpointCountClaims:
             "prompts": 3,
             "endpoints": 37,
         }
+
+
+# ---------------------------------------------------------------------------
+# docs/index.html: meta descriptions, JSON-LD, animated counters, BibTeX
+# ---------------------------------------------------------------------------
+
+_DATA_TARGET_RE = re.compile(r'data-target="(\d+)"')
+#: An animated counter paired with its sibling label — the number lives in a
+#: ``data-target`` attribute, the noun in the adjacent ``num-label`` element.
+_COUNTER_WITH_LABEL_RE = re.compile(
+    r'data-target="(\d+)"[^>]*>[^<]*</div>\s*<div class="num-label">([^<]+)</div>'
+)
+
+#: Counter-label substring (lowercased) -> expected-value key. First hit wins.
+_COUNTER_LABEL_KINDS: list[tuple[str, str]] = [
+    ("endpoint", "endpoints"),
+    ("tool", "tools"),
+    ("skill", "skills"),
+    ("prompt", "prompts"),
+    ("agent", "agents"),
+    ("command", "commands"),
+    ("coverage", "coverage"),
+]
+
+
+def scan_landing_page_claims(text: str, expected: dict[str, int | str]) -> list[str]:
+    """Every wrong numeric or version claim in landing-page *text*.
+
+    Occurrence-agnostic by design: claims are DERIVED by scanning the text —
+    prose/meta/JSON-LD strings via CLAIM_PATTERNS, animated counters via
+    their ``data-target`` attribute plus adjacent label, versions via the
+    JSON-LD ``softwareVersion`` and BibTeX markers — never from a hardcoded
+    list of N known copies, so adding or removing a copy keeps the guard
+    valid. Pure function over text so it can be mutation-tested on small
+    fixtures (same shape as the CWRU drift guard).
+
+    *expected* carries the introspected surface counts, plugin component
+    counts, the CI coverage minimum under ``"coverage"``, and the package
+    version under ``"version"``.
+    """
+    findings: list[str] = []
+
+    # 1. Text claims where the noun sits next to the number (prose, meta/OG/
+    #    Twitter descriptions, nested JSON-LD strings — all just text here).
+    for kind in CLAIM_PATTERNS:
+        for value, snippet in _claims(text, kind):
+            if value != expected[kind]:
+                findings.append(
+                    f"claims '{snippet}' but the real value is "
+                    f"{expected[kind]} ({kind})"
+                )
+
+    # 2. Animated counters. Every data-target must be classifiable via its
+    #    label — an unlabeled or unrecognized counter is itself a finding,
+    #    because it would be a number outside any guard.
+    labelled = _COUNTER_WITH_LABEL_RE.findall(text)
+    n_targets = len(_DATA_TARGET_RE.findall(text))
+    if len(labelled) != n_targets:
+        findings.append(
+            f"{n_targets} data-target counters but only {len(labelled)} have "
+            f"an adjacent num-label — every counter needs a label the guard "
+            f"can classify"
+        )
+    for raw_value, label in labelled:
+        kind = next(
+            (k for sub, k in _COUNTER_LABEL_KINDS if sub in label.lower()), None
+        )
+        if kind is None:
+            findings.append(
+                f'counter data-target="{raw_value}" labelled {label!r} is not '
+                f"bound to any introspected value — extend _COUNTER_LABEL_KINDS"
+            )
+        elif int(raw_value) != expected[kind]:
+            findings.append(
+                f'counter data-target="{raw_value}" labelled {label!r} should '
+                f"be {expected[kind]} ({kind})"
+            )
+
+    # 3. Version markers: JSON-LD softwareVersion and the BibTeX block.
+    for version in _SOFTWARE_VERSION_RE.findall(text):
+        if version != expected["version"]:
+            findings.append(
+                f'JSON-LD softwareVersion "{version}" != package version '
+                f'{expected["version"]}'
+            )
+    for version in _BIBTEX_VERSION_RE.findall(text):
+        if version.strip() != expected["version"]:
+            findings.append(
+                f"BibTeX version {{{version.strip()}}} != package version "
+                f'{expected["version"]}'
+            )
+    return findings
+
+
+@pytest.fixture(scope="module")
+def landing_expected(surface_counts, component_counts) -> dict[str, int | str]:
+    pyproject = tomllib.loads(_read("pyproject.toml"))
+    return {
+        **surface_counts,
+        **component_counts,
+        "coverage": int(pyproject["tool"]["coverage"]["report"]["fail_under"]),
+        "version": pyproject["project"]["version"],
+    }
+
+
+class TestLandingPageClaims:
+    def test_index_html_carries_no_stale_claims(self, landing_expected):
+        findings = scan_landing_page_claims(_read("docs/index.html"), landing_expected)
+        assert findings == [], "docs/index.html:\n  " + "\n  ".join(findings)
+
+    def test_index_html_remains_scannable(self):
+        """Anti-rot: the scanner must keep finding something to check on the
+        live page — a restructure that removed all recognizable claims would
+        otherwise leave the guard green while checking nothing."""
+        text = _read("docs/index.html")
+        assert _DATA_TARGET_RE.search(text), "no data-target counters found"
+        assert _SOFTWARE_VERSION_RE.search(text), "no JSON-LD softwareVersion"
+        assert _claims(text, "endpoints"), "no recognizable endpoints claim"
+        assert _claims(text, "skills"), "no recognizable skills claim"
+
+
+#: Synthetic fixture values — deliberately NOT read from the repo, so these
+#: mutation tests exercise the scanner itself, not the repo state.
+_FIXTURE_EXPECTED: dict[str, int | str] = {
+    "tools": 34,
+    "endpoints": 37,
+    "prompts": 3,
+    "resources": 0,
+    "skills": 8,
+    "agents": 2,
+    "commands": 3,
+    "coverage": 85,
+    "version": "0.12.0",
+}
+
+#: Minimal page exercising every claim carrier the scanner knows: meta
+#: description, nested JSON-LD strings + softwareVersion, two labelled
+#: counters, plain prose, and a BibTeX block.
+_CLEAN_PAGE = """\
+<meta name="description" content="Diagnostics via natural language. \
+37 MCP endpoints, runs locally.">
+<script type="application/ld+json">
+{"softwareVersion": "0.12.0",
+ "featureList": ["Claude Code plugin with 8 skills"],
+ "text": "It provides 37 MCP endpoints for vibration analysis."}
+</script>
+<div class="num-val" data-target="37">0</div>
+<div class="num-label">MCP Endpoints</div>
+<div class="num-val" data-target="85">0</div>
+<div class="num-label">%+ Test Coverage (CI Minimum)</div>
+<p>8 skills, 2 autonomous agents, 3 slash commands</p>
+<pre>version = {0.12.0},</pre>
+"""
+
+
+class TestLandingPageScannerMutations:
+    """Executable proof the scanner catches each drift class (and stays
+    green on clean input) — small-fixture style, like the CWRU drift guard."""
+
+    def test_clean_fixture_is_green(self):
+        assert scan_landing_page_claims(_CLEAN_PAGE, _FIXTURE_EXPECTED) == []
+
+    def test_one_stale_occurrence_among_correct_ones_goes_red(self):
+        """The edge case that matters: ONE stale copy among several correct
+        ones must be flagged, and only that one."""
+        mutated = _CLEAN_PAGE.replace("37 MCP endpoints", "52 MCP endpoints", 1)
+        findings = scan_landing_page_claims(mutated, _FIXTURE_EXPECTED)
+        assert len(findings) == 1, findings
+        assert "52 MCP endpoints" in findings[0]
+
+    def test_stale_counter_data_target_goes_red(self):
+        mutated = _CLEAN_PAGE.replace('data-target="37"', 'data-target="52"')
+        findings = scan_landing_page_claims(mutated, _FIXTURE_EXPECTED)
+        assert any(
+            'data-target="52"' in f and "MCP Endpoints" in f for f in findings
+        ), findings
+
+    def test_stale_coverage_counter_goes_red(self):
+        mutated = _CLEAN_PAGE.replace('data-target="85"', 'data-target="86"')
+        findings = scan_landing_page_claims(mutated, _FIXTURE_EXPECTED)
+        assert any('data-target="86"' in f for f in findings), findings
+
+    def test_stale_software_version_goes_red(self):
+        mutated = _CLEAN_PAGE.replace(
+            '"softwareVersion": "0.12.0"', '"softwareVersion": "0.8.0"'
+        )
+        findings = scan_landing_page_claims(mutated, _FIXTURE_EXPECTED)
+        assert any("softwareVersion" in f and "0.8.0" in f for f in findings), findings
+
+    def test_stale_bibtex_version_goes_red(self):
+        mutated = _CLEAN_PAGE.replace("version = {0.12.0}", "version = {0.8.0}")
+        findings = scan_landing_page_claims(mutated, _FIXTURE_EXPECTED)
+        assert any("BibTeX" in f and "0.8.0" in f for f in findings), findings
+
+    def test_version_bump_without_page_update_goes_red(self):
+        """Simulated release bump: expected version moves, page untouched —
+        both version carriers (JSON-LD + BibTeX) must be flagged."""
+        bumped = {**_FIXTURE_EXPECTED, "version": "0.13.0"}
+        findings = scan_landing_page_claims(_CLEAN_PAGE, bumped)
+        assert len(findings) == 2, findings
+
+    def test_unrecognized_counter_label_goes_red(self):
+        mutated = _CLEAN_PAGE.replace("MCP Endpoints</div>", "GitHub Stars</div>")
+        findings = scan_landing_page_claims(mutated, _FIXTURE_EXPECTED)
+        assert any("GitHub Stars" in f for f in findings), findings
+
+    def test_counter_without_label_goes_red(self):
+        mutated = _CLEAN_PAGE.replace('<div class="num-label">MCP Endpoints</div>', "")
+        findings = scan_landing_page_claims(mutated, _FIXTURE_EXPECTED)
+        assert any("num-label" in f for f in findings), findings
+
+    def test_claim_pattern_wordings(self):
+        """The qualifier spellings the public surfaces actually use must
+        stay recognizable to CLAIM_PATTERNS."""
+        assert _claims("8 Claude skills", "skills") == [(8, "8 Claude skills")]
+        assert _claims("2 autonomous agents", "agents") == [(2, "2 autonomous agents")]
+        assert _claims("3 slash commands", "commands") == [(3, "3 slash commands")]
+        assert _claims("86% test coverage", "coverage") == [(86, "86% test coverage")]
+        assert _claims("85%+ test coverage", "coverage")[0][0] == 85
+        assert _claims("test coverage: 85%", "coverage")[0][0] == 85
+
+
+# ---------------------------------------------------------------------------
+# .zenodo.json: Zenodo reads this with a strict JSON parser
+# ---------------------------------------------------------------------------
+
+
+class TestZenodoMetadata:
+    def test_zenodo_json_parses_as_strict_json(self):
+        """A trailing comma once shipped in the keywords array; json.loads
+        (strict, like Zenodo's parser) rejects it, so a deposit would fall
+        back to default metadata. Strict parse is the guard."""
+        try:
+            data = json.loads(_read(".zenodo.json"))
+        except json.JSONDecodeError as exc:
+            pytest.fail(f".zenodo.json is not strict JSON: {exc}")
+        keywords = data.get("keywords", [])
+        assert keywords and all(
+            isinstance(k, str) and k.strip() for k in keywords
+        ), f".zenodo.json: empty or malformed keywords entries: {keywords!r}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Public documentation now tells the truth mechanically: every count, version, and coverage figure on every public surface — README, PyPI description, GitHub Pages landing, Jekyll config, Zenodo metadata — either matches the introspected server surface or fails CI. On that foundation, the README becomes a three-audience entry funnel (reliability engineer / AI developer / researcher) with the measured benchmark above the fold, the full endpoint catalog moves to a dedicated guarded page, and a new adapter guide documents the ingestion boundary for vendor data.

## What was impossible before

- **Stale claims could ship silently.** "52 endpoints", software version 0.8.0, and a hand-typed coverage figure lived on public surfaces no guard watched (landing-page meta tags, Open Graph, JSON-LD blocks, animated counters, the PyPI description). A dedicated scanner now derives every occurrence from the files themselves — including `data-target` counters and JSON-LD strings — and compares each against the registered surface; version alignment now includes the landing page and strict-parses the Zenodo metadata.
- **Benchmark numbers in prose were only guarded inside the marked block.** A new CI sweep fails on any benchmark-shaped number outside the `cwru-benchmark` markers (record fractions unconditionally; percentages near result vocabulary), so a stray copied result can never drift apart from the committed artifact.
- **The registry ownership marker was one careless edit away from a broken release.** The `mcp-name` marker that the MCP registry validates against the PyPI long description is now an executable constraint tied to `server.json`'s name, with red-path tests for missing, mismatched, and misplaced markers.
- **Bringing vendor data in was undocumented.** `docs/ADAPTER_GUIDE.md` covers the declaration parameters, the companion metadata file, merge precedence, and loud-failure behavior on wrong declarations — the worked example was verified executable against the signal repository, and the parameter table is guarded against the code's own exports in both directions (cell-anchored, negation-aware, duplicate-detecting).

## Design decisions

| Decision | Rationale |
|---|---|
| Tool catalog on its own page (`docs/TOOL_CATALOG.md`) | The README stays scannable; the page joins both guard families — counted claims vs the introspected surface, call-shape/retired-name sweeps, and name parity in both directions |
| Coverage stated as the enforced CI minimum ("85%+") | A hand-typed snapshot number is stale the day after it lands; the minimum is a fact the CI config enforces, and the live figure stays on the badge |
| Guards derive expectations by scanning, never from hardcoded occurrence lists | Legitimate doc edits (adding or removing a copy) don't require guard edits, and a single stale occurrence among correct ones still fails |
| README 447 → 313 lines | Progressive disclosure: depth lives in linked guides; every removed claim either moved intact or was stale |

## Test plan

Suite grows 1245 → 1347 (+102), coverage 93%. Every new guard is mutation-tested — each proves it can go red: landing-page scanner (one stale copy among correct ones), outside-marker sweep (injected stray result), catalog and adapter parity (phantom, omitted, and duplicate rows), `mcp-name` marker (missing / mismatched / misplaced), adapter-table cell checks ("not required" wording, default outside its cell, phantom vocabulary value). The benchmark section's marked block is byte-identical after the move (drift-guard sweep green). Landing page verified rendering locally: correct title and counters, zero stale strings.

## Notes for future hardening (report-only from review)

- The outside-marker sweep is symbol-shaped: spelled-out numbers ("34 of 44") or line-wrapped fractions escape it, and it covers only the README and the methodology page.
- The claim scanner's qualifier vocabulary is closed — a stale count attached to an unrecognized noun phrase would pass; anti-rot tests pin the current wordings.
- Marker-span parsing now exists in three modules; a shared helper would consolidate.
- `docs/QUICKSTART_DEVELOPER.md` and `plugin/README.md` could cross-link the adapter guide.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
