### PR TITLE
docs(readme): add Glama score badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Tests](https://github.com/LGDiMaggio/predictive-maintenance-mcp/actions/workflows/tests.yml/badge.svg)](https://github.com/LGDiMaggio/predictive-maintenance-mcp/actions/workflows/tests.yml)
 [![codecov](https://codecov.io/gh/LGDiMaggio/predictive-maintenance-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/LGDiMaggio/predictive-maintenance-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![LGDiMaggio/predictive-maintenance-mcp MCP server](https://glama.ai/mcp/servers/LGDiMaggio/predictive-maintenance-mcp/badges/score.svg)](https://glama.ai/mcp/servers/LGDiMaggio/predictive-maintenance-mcp)
 
 **Give your AI assistant evidence-based vibration diagnostics — machinery fault detection, ISO-cited severity, and diagnostic reports built to support and accelerate expert decision-making.**
 


### PR DESCRIPTION
## Summary

Adds the Glama score badge to the README badge row, linking to the server's listing (rated A/A/A for license, quality, and maintenance). The listing is live via the MCP registry syndication.

## Test plan

Doc-guard suites pass locally (186 tests: version alignment, documented calls, benchmark guards). Badge SVG verified to resolve (200, image/svg+xml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
