### PR TITLE
fix(cwru): enforce file_id and cache_filename uniqueness in the ops table

### DIFF
--- a/benchmarks/cwru/records.py
+++ b/benchmarks/cwru/records.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from collections.abc import Callable, Sequence
 from typing import Any, Literal, Optional
 
 from pydantic import (
@@ -283,7 +284,7 @@ def ops_view(ops_path: Optional[Path] = None) -> tuple[OpsRecord, ...]:
     Raises:
         ValueError: If the table is missing or malformed, carries a
             label-bearing key, fails model validation, or contains
-            duplicate opaque ids.
+            duplicate opaque ids, file ids, or cache filenames.
     """
     source = ops_path if ops_path is not None else RECORDS_OPS_PATH
     raw = _read_json(source, description="CWRU ops table")
@@ -322,7 +323,45 @@ def ops_view(ops_path: Optional[Path] = None) -> tuple[OpsRecord, ...]:
                 f"must be unique; renumber the table."
             )
         seen[record.opaque_id] = index
+
+    # file_id and cache_filename identify the upstream download and its slot on
+    # disk. A duplicate in either maps two logical records onto one cached file,
+    # which is silent: the second record simply reads the first one's signal.
+    _refuse_duplicate_field(records, source, "file_id", lambda r: r.file_id)
+    _refuse_duplicate_field(
+        records, source, "cache_filename", lambda r: r.cache_filename
+    )
     return tuple(records)
+
+
+def _refuse_duplicate_field(
+    records: Sequence[OpsRecord],
+    source: Path,
+    field: str,
+    getter: Callable[[OpsRecord], str],
+) -> None:
+    """Raise if two ops-table records share a value for ``field``.
+
+    Args:
+        records: The validated records, in table order.
+        source: Path of the ops table, for the error message.
+        field: Field name, as it appears in the table.
+        getter: Reads the field off a record.
+
+    Raises:
+        ValueError: If any two records share a value.
+    """
+    seen: dict[str, int] = {}
+    for index, record in enumerate(records):
+        value = getter(record)
+        if value in seen:
+            raise ValueError(
+                f"Ops table {source} entries {seen[value]} "
+                f"('{records[seen[value]].opaque_id}') and {index} "
+                f"('{record.opaque_id}') share {field} '{value}' — {field} "
+                f"must be unique; fix the vendored table."
+            )
+        seen[value] = index
 
 
 def label_view(

--- a/tests/test_cwru_benchmark_records.py
+++ b/tests/test_cwru_benchmark_records.py
@@ -258,3 +258,49 @@ class TestMutationGuard:
         harness."""
         clean = _write_ops_variant(tmp_path, lambda entries: None)
         assert len(ops_view(clean)) == 64
+
+
+class TestOpsTableUniqueness:
+    """file_id and cache_filename must be unique, not merely opaque_id.
+
+    A duplicate in either maps two logical records onto one cached download,
+    which fails silently: the second record reads the first one's signal.
+    """
+
+    @pytest.mark.parametrize("field", ["file_id", "cache_filename"])
+    def test_injected_duplicate_is_refused(self, tmp_path, field):
+        def mutate(entries: list[dict[str, Any]]) -> None:
+            entries[1][field] = entries[0][field]
+
+        mutated = _write_ops_variant(tmp_path, mutate)
+        with pytest.raises(ValueError, match=field) as excinfo:
+            ops_view(mutated)
+
+        message = str(excinfo.value)
+        # Both offending entries are named, matching the opaque_id error.
+        assert "entries 0" in message
+        assert "and 1" in message
+        assert "must be unique" in message
+
+    @pytest.mark.parametrize("field", ["file_id", "cache_filename"])
+    def test_duplicate_names_the_colliding_opaque_ids(self, tmp_path, field):
+        raw = _raw_ops()
+        first, second = raw[0]["opaque_id"], raw[1]["opaque_id"]
+
+        def mutate(entries: list[dict[str, Any]]) -> None:
+            entries[1][field] = entries[0][field]
+
+        mutated = _write_ops_variant(tmp_path, mutate)
+        with pytest.raises(ValueError) as excinfo:
+            ops_view(mutated)
+
+        message = str(excinfo.value)
+        assert first in message
+        assert second in message
+
+    def test_real_vendored_table_passes(self):
+        """The other half of the mutation test: the shipped table is clean."""
+        records = ops_view()
+        for field in ("file_id", "cache_filename"):
+            values = [getattr(record, field) for record in records]
+            assert len(set(values)) == len(values), f"{field} must be unique"


### PR DESCRIPTION
Closes #52.

`ops_view` validated `opaque_id` uniqueness but not `file_id` or `cache_filename`, so a duplicate-row mistake in either passed validation.

Worth naming why that class of mistake is the bad kind: both fields identify the upstream download and its slot on disk, so a duplicate doesn't error at fetch time — it maps two logical records onto one cached file, and the second record reads the first one's signal. A benchmark run would score a record against another record's data and report a clean result.

## What changed

`_refuse_duplicate_field(records, source, field, getter)`, applied to both fields immediately after the existing `opaque_id` pass, which was the template. Error style matches: field, value, and both offending entries named.

```
Ops table <path> entries 0 ('cwru_001') and 1 ('cwru_002') share
file_id '97' — file_id must be unique; fix the vendored table.
```

The `opaque_id` loop is left inline rather than folded into the new helper — its message has a different remedy ("renumber the table") and I didn't want to flatten that into a generic one.

## Acceptance

- ✅ refuses duplicate `file_id` and duplicate `cache_filename`, naming the colliding rows
- ✅ mutation test both ways — injected duplicate raises, real vendored table passes
- ✅ error style matches `records.py`'s existing validation errors

`TestOpsTableUniqueness` adds 5 tests: injected-duplicate refusal and colliding-opaque-id naming, each parametrized over both fields, plus a check that the shipped table is clean.

## Verification

Red before green — with `records.py` stashed and the tests kept, all four injected-duplicate cases fail:

```
FAILED …::test_injected_duplicate_is_refused[file_id]
FAILED …::test_injected_duplicate_is_refused[cache_filename]
FAILED …::test_duplicate_names_the_colliding_opaque_ids[file_id]
FAILED …::test_duplicate_names_the_colliding_opaque_ids[cache_filename]
4 failed, 1 passed
```

The one that passes without the fix is `test_real_vendored_table_passes`, which is the point of it.

Full suite green: **1351 passed, 23 skipped**, coverage 92.05% against the 85% gate.