### PR TITLE
test(cwru): guard that results.json stays derived from outcomes.json

### DIFF
--- a/tests/test_cwru_benchmark_scoring.py
+++ b/tests/test_cwru_benchmark_scoring.py
@@ -791,3 +791,83 @@ class TestScoreCLI:
         assert exit_code == 2
         assert "cwru_002" in capsys.readouterr().err
         assert not results_path.exists()
+
+
+class TestCommittedResultsDerivedFromOutcomes:
+    """The committed results.json is re-derivable from the committed outcomes.
+
+    The drift guard binds the README numbers to results.json; this binds
+    results.json to outcomes.json, so the whole README -> results ->
+    outcomes chain is tamper-evident. A hand-edited results.json turns
+    this red even when the README still agrees with it.
+
+    Reads only the two committed artifacts: no network, no CWRU cache.
+    """
+
+    @staticmethod
+    def _committed_results_text() -> str:
+        return scorer.DEFAULT_RESULTS_PATH.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _rescore(tmp_path: Path) -> str:
+        """Re-score the committed outcomes and return the serialized bytes.
+
+        Metadata is pinned from the committed artifact itself rather than
+        from a literal: date, git describe, platform and library versions
+        record the machine that produced the artifact, so collecting them
+        here would compare this run's environment against the maintainer's
+        and flap on every machine. Everything outside ``metadata`` is
+        recomputed for real.
+        """
+        committed = json.loads(
+            TestCommittedResultsDerivedFromOutcomes._committed_results_text()
+        )
+        outcomes = scorer.read_outcomes()
+        results = scorer.score_results(
+            outcomes, metadata_overrides=committed["metadata"]
+        )
+        out = tmp_path / "rescored.json"
+        scorer.write_results(results, out)
+        return out.read_text(encoding="utf-8")
+
+    def test_rescoring_committed_outcomes_reproduces_results_byte_for_byte(
+        self, tmp_path: Path
+    ):
+        assert self._rescore(tmp_path) == self._committed_results_text()
+
+    def test_every_metadata_key_is_pinned_by_the_committed_artifact(self):
+        """The override set above must cover every environment-dependent key.
+
+        If a new metadata key is added and not present in the committed
+        artifact, the guard above would silently start collecting it from
+        this machine — and pass locally for the maintainer while flapping
+        in CI.
+        """
+        committed = json.loads(self._committed_results_text())
+        assert set(committed["metadata"]) == set(scorer.METADATA_KEYS)
+
+    def test_a_perturbed_results_copy_fails_the_comparison(self, tmp_path: Path):
+        """Mutation leg: the comparison is demonstrated to fail, not assumed to."""
+        rescored = self._rescore(tmp_path)
+        perturbed = json.loads(rescored)
+        before = perturbed["headline"]["n_records"]
+        perturbed["headline"]["n_records"] = before + 1
+
+        perturbed_path = tmp_path / "perturbed.json"
+        scorer.write_results(perturbed, perturbed_path)
+        perturbed_text = perturbed_path.read_text(encoding="utf-8")
+
+        assert perturbed_text != self._committed_results_text()
+        # The divergence is nameable, not just a byte count.
+        differing = [
+            key
+            for key in json.loads(perturbed_text)["headline"]
+            if json.loads(rescored)["headline"].get(key)
+            != json.loads(perturbed_text)["headline"][key]
+        ]
+        assert differing == ["n_records"]
+
+    def test_guard_needs_no_cache(self):
+        """Only the two committed artifacts are read."""
+        assert scorer.DEFAULT_RESULTS_PATH.exists()
+        assert runner.DEFAULT_OUTCOMES_PATH.exists()


### PR DESCRIPTION
Closes #51.

The drift guard binds the README numbers to `results.json`; nothing bound `results.json` to `outcomes.json`. `TestCommittedResultsDerivedFromOutcomes` re-scores the committed outcomes and asserts byte-identity with the committed results, so the full README → results → outcomes chain is tamper-evident.

## On pinning metadata

`metadata_overrides` is fed from the **committed artifact's own metadata**, not from literals in the test. `date`, `git_describe`, `platform`, `python_version`, `numpy_version`, `scipy_version` all record the machine that produced the artifact, so collecting them here would compare the test runner's environment against the maintainer's and fail on every machine but one.

That creates a quieter risk, so there's a second test for it: if a new key is added to `METADATA_KEYS` but isn't in the committed artifact, the override mapping stops covering it and the guard silently starts collecting it live — passing for whoever regenerated the artifact last, flapping everywhere else. `test_every_metadata_key_is_pinned_by_the_committed_artifact` asserts `set(committed["metadata"]) == set(scorer.METADATA_KEYS)` and turns that into a clear failure.

Everything outside `metadata` is recomputed for real — the join, the strata, the aggregates, the per-record table.

## Acceptance

- ✅ re-scores committed `outcomes.json`, metadata pinned, asserts serialized output equals committed `results.json` byte-for-byte
- ✅ mutation leg — perturbing one value fails the comparison, and the assertion names the diverging key (`["n_records"]`) rather than just reporting a byte mismatch
- ✅ no network, no CWRU cache — only the two committed artifacts are read (there's an explicit test for that)

## Verification

The guard reproduces byte-identically as the issue predicted, on Windows/py3.11 — so the reproducibility claim holds outside the measured environment too, at least here.

I also checked it actually catches the thing it exists to catch, rather than trusting the mutation leg on a tmp copy: incremented `headline.n_records` in the **committed** `benchmarks/cwru/results/results.json` and re-ran —

```
FAILED …::test_rescoring_committed_outcomes_reproduces_results_byte_for_byte
```

(reverted; `git status` clean apart from the test file).

Full suite: **1350 passed, 23 skipped**, coverage 91.94% against the 85% gate.