### PR TITLE
docs(landing): polish copy per SEO audit

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
 
   <!-- Primary SEO -->
   <title>Build Your Predictive Maintenance AI Agent — Open-Source MCP Server & Claude Plugin</title>
-  <meta name="description" content="Build your own predictive maintenance AI agent: open-source MCP server and Claude plugin for condition monitoring. Analyze vibration data, detect bearing faults, and generate diagnostic reports via natural language — with Claude, ChatGPT, or Ollama. 37 MCP endpoints, privacy-first, runs locally.">
+  <meta name="description" content="Build your predictive maintenance AI agent: open-source MCP server and Claude plugin. Detect bearing faults from vibration data. Raw data stays on your machine.">
   <meta name="keywords" content="predictive maintenance AI agent, build predictive maintenance agent, condition monitoring AI agent, predictive maintenance MCP server, machine maintenance copilot, vibration analysis AI tool, bearing fault detection AI, predictive maintenance claude plugin, claude skills predictive maintenance, AI vibration diagnostics, open source predictive maintenance, machine health monitoring AI, MCP server, vibration analysis, bearing fault detection, ISO 20816 AI analysis, FFT analysis, envelope analysis, AI diagnostics, Industry 4.0, condition monitoring, Model Context Protocol, Claude Code plugin, machine learning condition monitoring, industrial AI agent, mcp tools predictive maintenance, predictive maintenance natural language, remaining useful life estimation, maintenance decision support AI, fault diagnosis AI assistant, industrial AI diagnostics">
   <meta name="author" content="Luigi Gianpio Di Maggio">
   <meta name="robots" content="index, follow">
@@ -18,7 +18,7 @@
   <!-- Open Graph -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="Build Your Predictive Maintenance AI Agent — Open-Source MCP Server">
-  <meta property="og:description" content="Ask your machines what's wrong — with evidence, not guesses. Open-source MCP server and Claude plugin: analyze vibration data, detect bearing faults, assess severity via ISO 20816, and generate reports through natural language. Raw data never leaves your machine.">
+  <meta property="og:description" content="Ask your machines what's wrong, with evidence instead of guesses. Open-source MCP server and Claude plugin: analyze vibration data, detect bearing faults, and generate reports through natural language. Raw data never leaves your machine.">
   <meta property="og:url" content="https://lgdimaggio.github.io/predictive-maintenance-mcp/">
   <meta property="og:image" content="https://raw.githubusercontent.com/LGDiMaggio/predictive-maintenance-mcp/main/assets/predictive-maintenance-mcp_com.jpg">
   <meta property="og:image:width" content="1200">
@@ -30,7 +30,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Build Your Predictive Maintenance AI Agent — Open-Source MCP Server & Claude Plugin">
-  <meta name="twitter:description" content="AI-powered condition monitoring and vibration diagnostics. Detect bearing faults, assess machine health, generate reports — via natural language. Open-source, 37 MCP endpoints, runs locally.">
+  <meta name="twitter:description" content="AI-powered condition monitoring and vibration diagnostics. Detect bearing faults, assess machine health, generate reports via natural language. Open-source, 37 MCP endpoints, runs locally.">
   <meta name="twitter:image" content="https://raw.githubusercontent.com/LGDiMaggio/predictive-maintenance-mcp/main/assets/predictive-maintenance-mcp_com.jpg">
   <meta name="twitter:image:alt" content="Predictive Maintenance AI Agent — MCP Server for vibration analysis and fault detection">
 
@@ -41,7 +41,7 @@
     "@type": "SoftwareApplication",
     "name": "Predictive Maintenance MCP Server",
     "alternateName": ["Predictive Maintenance AI Agent", "Condition Monitoring AI Copilot", "Machine Maintenance Copilot"],
-    "description": "Open-source AI agent and MCP server for predictive maintenance and condition monitoring. Analyze vibration data, detect bearing faults, assess severity via ISO 20816, and generate diagnostic reports — all through natural-language conversation with Claude, ChatGPT, or Ollama. 37 MCP endpoints, privacy-first local processing.",
+    "description": "Open-source AI agent and MCP server for predictive maintenance and condition monitoring. Analyze vibration data, detect bearing faults, assess severity via ISO 20816, and generate diagnostic reports, all through natural-language conversation with Claude, ChatGPT, or Ollama. 37 MCP endpoints, privacy-first local processing.",
     "applicationCategory": "EngineeringApplication",
     "applicationSubCategory": "Predictive Maintenance, Condition Monitoring, Industrial AI, Vibration Analysis",
     "operatingSystem": "Windows, macOS, Linux",
@@ -85,7 +85,7 @@
         "name": "What is Predictive Maintenance MCP Server?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "An open-source AI agent that lets you ask an AI assistant about your machine's vibration data and get real, evidence-based maintenance answers — running entirely on your computer. It provides 37 MCP endpoints for vibration analysis, bearing fault detection, ISO 20816 severity assessment, and ML anomaly detection."
+          "text": "An open-source AI agent that lets you ask an AI assistant about your machine's vibration data and get real, evidence-based maintenance answers, running entirely on your computer. It provides 37 MCP endpoints for vibration analysis, bearing fault detection, ISO 20816 severity assessment, and ML anomaly detection."
         }
       },
       {
@@ -476,7 +476,7 @@
     <h1>Ask your machines what's wrong. With <span class="accent">evidence</span>, not guesses.</h1>
     <p class="hero-tagline">Analyze vibration data, detect likely bearing faults, classify risk, and generate maintenance reports through natural-language AI workflows. Raw data never leaves your machine.</p>
     <div class="cta-row">
-      <a href="#install" class="btn-primary">Install in 5 minutes</a>
+      <a href="#install" class="btn-primary">Get started</a>
       <a href="#demo" class="btn-outline">See example diagnosis</a>
       <a href="https://github.com/LGDiMaggio/predictive-maintenance-mcp" class="link-plain" target="_blank" rel="noopener">★ Star on GitHub</a>
     </div>
@@ -624,7 +624,7 @@
         <span class="step-num">2</span>
         <span class="step-title">Ask</span>
         <code class="ask">"Load OuterRaceFault_1.csv and check if the bearing is healthy."</code>
-        <span class="step-note">Sample bearing data is included in the <a href="https://github.com/LGDiMaggio/predictive-maintenance-mcp" target="_blank" rel="noopener">repository</a> — clone it and try a diagnosis with no sensors connected.</span>
+        <span class="step-note">Sample bearing data is included in the <a href="https://github.com/LGDiMaggio/predictive-maintenance-mcp" target="_blank" rel="noopener">repository</a>. Clone it and try a diagnosis with no sensors connected.</span>
       </div>
       <div class="card step-card">
         <span class="step-num">3</span>
@@ -720,7 +720,7 @@
   <div class="container">
     <div class="section-head">
       <span class="eyebrow">UNDER THE HOOD</span>
-      <h2>Your data never leaves your machine</h2>
+      <h2>Your raw data never leaves your machine</h2>
     </div>
     <div class="card arch-box">
       <div class="arch-flow">
@@ -792,7 +792,7 @@
       <div class="dataset-left">
         <span class="eyebrow" style="color:var(--green);">READY TO TRY</span>
         <h2>Real bearing data included</h2>
-        <p>20 real bearing vibration signals are included in the repository — 3 healthy baselines plus inner-race and outer-race fault signals from the MathWorks rolling-element bearing dataset. Clone the repo and diagnose your first fault without connecting a single sensor.</p>
+        <p>20 real bearing vibration signals are included in the repository: 3 healthy baselines plus inner-race and outer-race fault signals from the MathWorks rolling-element bearing dataset. Clone the repo and diagnose your first fault without connecting a single sensor.</p>
         <code>"Load OuterRaceFault_1.csv and diagnose the bearing."</code>
         <p class="dataset-attr">Dataset: <a href="https://github.com/mathworks/RollingElementBearingFaultDiagnosis-Data" target="_blank" rel="noopener">MathWorks RollingElementBearingFaultDiagnosis-Data</a> (CC BY-NC-SA 4.0). Not included in the PyPI package.</p>
       </div>
@@ -877,7 +877,7 @@
 <section id="get-started" style="padding-bottom:96px;">
   <div class="container">
     <div class="final-cta">
-      <h2>Start your first diagnosis locally in 5 minutes</h2>
+      <h2>Run your first diagnosis locally</h2>
       <p>Open source, MIT licensed, sample data in the repository. Your vibration data stays on your machine.</p>
       <div class="row">
         <a href="https://github.com/LGDiMaggio/predictive-maintenance-mcp/blob/main/INSTALL.md" class="btn-primary" target="_blank" rel="noopener">Install</a>


### PR DESCRIPTION
## Summary
Copy polish on the redesigned landing page, following an SEO/copy audit:

- **Meta description** shortened to ~160 chars so it no longer truncates in SERPs; drops ISO jargon from first-touch metadata (ISO 20816 stays in body sections where it builds credibility)
- **Speed claims** reduced from three to one: hero button is now "Get started", final CTA is "Run your first diagnosis locally"; the install section H2 keeps the single "5 minutes" claim
- **Privacy claim** made precise and consistent with the FAQ: architecture H2 is now "Your raw data never leaves your machine"
- **Em-dashes** removed from all prose copy (meta/OG/Twitter/JSON-LD descriptions, step notes, dataset section); kept only as title separators

No structural or claim changes: counters, BibTeX, and endpoint/skill claims untouched. Guard tests pass locally (69 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)