### PR TITLE
feat(cwru): record measurement provenance in outcomes and results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the Predictive Maintenance MCP Server project will be doc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Measurement provenance recorded with the CWRU benchmark outcomes.** The
+  runner now collects a measurement-environment block — date, git describe of
+  the measured tree, platform, Python/NumPy/SciPy versions, and the measured
+  pipeline version — once before the run and stores it as a `_provenance`
+  sibling inside the outcomes artifact; the scorer echoes it into
+  `results.json` as `measurement_provenance`, so every published number stays
+  bound to the exact environment that measured it. A dormant CI guard
+  (documented in `docs/benchmark-methodology.md`) arms itself once the
+  committed outcomes are regenerated.
+
 ## [0.13.0] - 2026-08-14
 
 Three additions. `load_signal` now opens headerless raw binary waveforms

--- a/benchmarks/cwru/__main__.py
+++ b/benchmarks/cwru/__main__.py
@@ -31,7 +31,6 @@ import argparse
 import sys
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Mapping, Optional
 
 from benchmarks.cwru import runner, scorer
 from benchmarks.cwru.download import ensure_cached, freeze_checksums
@@ -71,8 +70,7 @@ def _cmd_import(args: argparse.Namespace) -> int:
 def _run_stage(
     records: Sequence[OpsRecord], args: argparse.Namespace
 ) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
-    """
-    Shared measurement stage for ``run`` and ``all``.
+    """Shared measurement stage for ``run`` and ``all``.
 
     Tripwire first, then an in-process re-import (see the module
     docstring's process-boundary note), then the runner — doubled when

--- a/benchmarks/cwru/__main__.py
+++ b/benchmarks/cwru/__main__.py
@@ -29,8 +29,9 @@ from __future__ import annotations
 
 import argparse
 import sys
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any, Optional
 
 from benchmarks.cwru import runner, scorer
 from benchmarks.cwru.download import ensure_cached, freeze_checksums

--- a/benchmarks/cwru/__main__.py
+++ b/benchmarks/cwru/__main__.py
@@ -31,7 +31,7 @@ import argparse
 import sys
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 from benchmarks.cwru import runner, scorer
 from benchmarks.cwru.download import ensure_cached, freeze_checksums
@@ -70,8 +70,9 @@ def _cmd_import(args: argparse.Namespace) -> int:
 
 def _run_stage(
     records: Sequence[OpsRecord], args: argparse.Namespace
-) -> dict[str, dict[str, Any]]:
-    """Shared measurement stage for ``run`` and ``all``.
+) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+    """
+    Shared measurement stage for ``run`` and ``all``.
 
     Tripwire first, then an in-process re-import (see the module
     docstring's process-boundary note), then the runner — doubled when
@@ -82,15 +83,19 @@ def _run_stage(
         args: Parsed CLI namespace (``check_determinism``, ``output``).
 
     Returns:
-        The outcomes produced (and written).
+        ``(outcomes, provenance)`` — the outcomes produced
+        (and written) plus the provenance block that accompanied the write.
+
     """
     runner.assert_import_provenance()
+    provenance = runner.collect_provenance()
     import_records(records, overwrite=True)
     if args.check_determinism:
         outcomes = runner.check_determinism(records)
     else:
         outcomes = runner.run_records(records)
-    target = runner.write_outcomes(outcomes, args.output)
+    outcomes_w_provenance = runner.compose_outcomes_document(outcomes, provenance)
+    target = runner.write_outcomes(outcomes_w_provenance, args.output)
     ok = sum(
         1
         for outcome in outcomes.values()
@@ -100,7 +105,7 @@ def _run_stage(
         f"Wrote {len(outcomes)} outcome(s) ({ok} ok, "
         f"{len(outcomes) - ok} missing/failed) to {target}."
     )
-    return outcomes
+    return outcomes, provenance
 
 
 def _cmd_run(args: argparse.Namespace) -> int:
@@ -110,7 +115,9 @@ def _cmd_run(args: argparse.Namespace) -> int:
 
 
 def _score_outcomes(
-    outcomes: dict[str, dict[str, Any]], results_path: Optional[Path]
+    outcomes: dict[str, dict[str, Any]],
+    results_path: Optional[Path],
+    measurement_provenance: Optional[Mapping[str, str]],
 ) -> Path:
     """Shared scoring stage: label join, metrics, atomic results write.
 
@@ -118,11 +125,14 @@ def _score_outcomes(
         outcomes: Runner outcomes keyed by opaque id.
         results_path: Results destination; ``None`` uses the scorer's
             committed default.
+        measurement_provenance: Provenance values coming from the outcomes.
 
     Returns:
         The results path written.
     """
-    results = scorer.score_results(outcomes)
+    results = scorer.score_results(
+        outcomes, measurement_provenance=measurement_provenance
+    )
     target = scorer.write_results(results, results_path)
     print(f"Scored {len(results['records'])} record(s); wrote {target}.")
     return target
@@ -130,8 +140,8 @@ def _score_outcomes(
 
 def _cmd_score(args: argparse.Namespace) -> int:
     """Score a previously written outcomes artifact against the labels."""
-    outcomes = scorer.read_outcomes(args.outcomes)
-    _score_outcomes(outcomes, args.output)
+    outcomes, measurement_provenance = scorer.read_outcomes(args.outcomes)
+    _score_outcomes(outcomes, args.output, measurement_provenance)
     return 0
 
 
@@ -145,9 +155,9 @@ def _cmd_all(args: argparse.Namespace) -> int:
     records = ops_view()
     for record in records:
         ensure_cached(record)
-    outcomes = _run_stage(records, args)
+    outcomes, measurement_provenance = _run_stage(records, args)
     runner.assert_outcomes_complete(outcomes, records)
-    _score_outcomes(outcomes, args.results_output)
+    _score_outcomes(outcomes, args.results_output, measurement_provenance)
     return 0
 
 
@@ -165,9 +175,7 @@ def _add_measurement_flags(parser: argparse.ArgumentParser) -> None:
         "--output",
         type=Path,
         default=None,
-        help=(
-            "outcomes destination (default: " "benchmarks/cwru/results/outcomes.json)"
-        ),
+        help=("outcomes destination (default: benchmarks/cwru/results/outcomes.json)"),
     )
 
 

--- a/benchmarks/cwru/runner.py
+++ b/benchmarks/cwru/runner.py
@@ -41,9 +41,13 @@ Load-bearing decisions, documented here:
   repr makes the bytes a pure function of the rounded values.
 - **Determinism claim scope** (:func:`check_determinism`): the
   double-run byte-identity check is scoped to the measured environment
-  (one machine, one interpreter, one BLAS). Cross-platform re-runs are
-  expected to reproduce metric-level results, not byte-identical
-  artifacts — scipy/BLAS low-order float bits differ across builds.
+  (one machine, one interpreter, one BLAS).The comparison covers
+  deterministic measurement content only: both runs serialize the clean
+  per-record outcomes, and the ``_provenance``block (date, git describe,
+  platform, versions) is attached only when the artifact document is composed
+  for writing — so a changing date or git describe can never fail this check.
+  Cross-platform re-runs are expected to reproduce metric-level results,
+  not byte-identical artifacts — scipy/BLAS low-order float bits differ across builds.
 
 Outcome schema (per opaque id):
 
@@ -66,13 +70,17 @@ from __future__ import annotations
 import json
 import math
 import os
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Callable
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Optional
 
+from datetime import datetime, timezone
+import platform as platform_module
+import scipy
 import numpy as np
-
+import predictive_maintenance_mcp
+import subprocess
 from benchmarks.cwru.importer import SIGNAL_UNIT
 from benchmarks.cwru.records import OpsRecord
 from predictive_maintenance_mcp.decision_support.diagnosis_pipeline import (
@@ -85,6 +93,7 @@ from predictive_maintenance_mcp.signal_acquisition.repository import (
 
 __all__ = [
     "BEARING_ID",
+    "PROVENANCE_KEYS",
     "DEFAULT_OUTCOMES_PATH",
     "EXCLUDED_ANOMALY_MARKER",
     "EXPECTED_PACKAGE_INIT",
@@ -101,6 +110,9 @@ __all__ = [
     "run_records",
     "serialize_outcomes",
     "write_outcomes",
+    "collect_provenance",
+    "compose_outcomes_document",
+    "split_provenance",
 ]
 
 _PACKAGE_DIR = Path(__file__).resolve().parent
@@ -149,6 +161,19 @@ OUTCOME_STATUS_FAILED: str = "failed"
 EXCLUDED_ANOMALY_MARKER: Mapping[str, str] = MappingProxyType(
     {"status": "excluded_unversioned_models"}
 )
+PROVENANCE_KEYS: frozenset[str] = frozenset(
+    {
+        "date",
+        "git_describe",
+        "platform",
+        "python_version",
+        "numpy_version",
+        "scipy_version",
+        "pipeline_version",
+    }
+)
+
+PROVENANCE_MARKER_KEY: str = "_provenance"
 
 #: Per-fault fields copied verbatim from each ``check_all_bearing_faults``
 #: fault check into the outcome (``fault_type`` itself becomes the key).
@@ -242,6 +267,82 @@ def _extract_iso_context(iso: Mapping[str, Any]) -> dict[str, Any]:
         if key in iso:
             context[key] = iso[key]
     return context
+
+
+def collect_provenance(overrides: Optional[Mapping[str, str]] = None) -> dict[str, str]:
+    """Collect the results-artifact metadata, with deterministic overrides.
+
+    Every value that varies between runs (date, git describe, platform,
+    versions) is produced lazily and can be overridden, so tests never
+    depend on the machine or the clock. Overridden keys skip their
+    producer entirely (no subprocess runs for an overridden
+    ``git_describe``).
+
+    Args:
+        overrides: Values to use verbatim instead of collecting. Keys
+            must be a subset of :data:`PROVENANCE_KEYS`.
+
+    Returns:
+        The complete metadata mapping (every key in
+        :data:`PROVENANCE_KEYS` present).
+
+    Raises:
+        ValueError: On an unknown override key (fail closed — a typo'd
+            override silently ignored would leave a varying value in an
+            artifact a test believed pinned), or from
+            :func:`_git_describe`.
+    """
+    resolved = dict(overrides or {})
+    unknown = sorted(set(resolved) - PROVENANCE_KEYS)
+    if unknown:
+        raise ValueError(
+            f"Unknown metadata override key(s) {unknown} — valid keys are "
+            f"{sorted(PROVENANCE_KEYS)}. Fix the caller."
+        )
+    producers: dict[str, Callable[[], str]] = {
+        "date": lambda: datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "git_describe": _git_describe,
+        "platform": platform_module.platform,
+        "python_version": platform_module.python_version,
+        "numpy_version": lambda: str(np.__version__),
+        "scipy_version": lambda: str(scipy.__version__),
+        "pipeline_version": lambda: str(
+            getattr(predictive_maintenance_mcp, "__version__", "unknown")
+        ),
+    }
+    return {
+        key: resolved[key] if key in resolved else producer()
+        for key, producer in producers.items()
+    }
+
+
+def compose_outcomes_document(
+    outcomes: Mapping[str, Mapping[str, Any]],
+    provenance: Mapping[str, str],
+) -> dict[str, Any]:
+    """Build the outcomes artifact payload from records + provenance."""
+    return {**dict(outcomes), PROVENANCE_MARKER_KEY: dict(provenance)}
+
+
+def split_provenance(
+    payload: Mapping[str, Any],
+) -> tuple[dict[str, dict[str, Any]], Optional[dict[str, str]]]:
+    """Split a read artifact into its records and its provenance block.
+
+    Every key except the ``_provenance`` marker is a record; ``None``
+    provenance means the artifact predates provenance collection.
+    """
+    if PROVENANCE_MARKER_KEY in payload and not isinstance(
+        payload[PROVENANCE_MARKER_KEY], Mapping
+    ):
+        raise ValueError(
+            f"Outcomes artifact carries a non-object {PROVENANCE_MARKER_KEY!r}"
+        )
+    records = {
+        key: value for key, value in payload.items() if key != PROVENANCE_MARKER_KEY
+    }
+    block = payload.get(PROVENANCE_MARKER_KEY)
+    return records, dict(block) if isinstance(block, Mapping) else None
 
 
 def _run_one(record: OpsRecord, repository: SignalRepository) -> dict[str, Any]:
@@ -476,6 +577,47 @@ def write_outcomes(
     return target
 
 
+def _git_describe() -> str:
+    """Run ``git describe --always --dirty`` on the measured tree.
+
+    Returns:
+        The describe output, stripped.
+
+    Raises:
+        ValueError: If git cannot run or reports an error — the results
+            artifact must record which tree was measured, so an unknown
+            tree is a refusal, not a placeholder (override via
+            ``metadata_overrides`` when scoring outside a git checkout).
+    """
+    command = ["git", "describe", "--always", "--dirty"]
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(
+            f"Cannot run '{' '.join(command)}' in {REPO_ROOT} "
+            f"({exc}) — the results artifact must record the measured "
+            f"tree. Install/repair git, or pass "
+            f"metadata_overrides={{'git_describe': ...}} explicitly."
+        ) from exc
+    described = proc.stdout.strip()
+    if proc.returncode != 0 or not described:
+        raise ValueError(
+            f"'{' '.join(command)}' failed in {REPO_ROOT} "
+            f"(exit {proc.returncode}, stderr: {proc.stderr.strip()!r}) — "
+            f"the results artifact must record the measured tree. Run the "
+            f"scorer from the git checkout being measured, or pass "
+            f"metadata_overrides={{'git_describe': ...}} explicitly."
+        )
+    return described
+
+
 def check_determinism(
     records: Iterable[OpsRecord],
     *,
@@ -488,6 +630,12 @@ def check_determinism(
     re-runs are expected to reproduce metric-level results, not
     byte-identical artifacts (low-order float bits differ across
     builds) — the methodology states this explicitly.
+
+    The comparison covers deterministic measurement content only: both
+    runs serialize the clean per-record outcomes, and the ``_provenance``
+    block (date, git describe, platform, versions) is attached only when
+    the artifact document is composed for writing — so a changing date or
+    git describe can never fail this check.
 
     Args:
         records: Ops records to measure (materialized once, run twice).

--- a/benchmarks/cwru/runner.py
+++ b/benchmarks/cwru/runner.py
@@ -103,6 +103,7 @@ __all__ = [
     "OUTCOME_STATUS_MISSING_SIGNAL",
     "OUTCOME_STATUS_OK",
     "PROVENANCE_KEYS",
+    "PROVENANCE_MARKER_KEY",
     "REPO_ROOT",
     "SUPPORT_TYPE",
     "assert_import_provenance",
@@ -586,9 +587,9 @@ def _git_describe() -> str:
 
     Raises:
         ValueError: If git cannot run or reports an error — the results
-            and outcomes artifacts must record which tree was measured, so an unknown
-            tree is a refusal, not a placeholder (override via
-            ``overrides`` when scoring outside a git checkout).
+            and outcomes artifacts must record which tree was measured, so
+            an unknown tree is a refusal, not a placeholder (pass an
+            explicit ``git_describe`` override).
     """
     command = ["git", "describe", "--always", "--dirty"]
     try:
@@ -603,18 +604,18 @@ def _git_describe() -> str:
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise ValueError(
             f"Cannot run '{' '.join(command)}' in {REPO_ROOT} "
-            f"({exc}) — the results and outcomes artifacts must record the measured "
-            f"tree. Install/repair git, or pass "
-            f"overrides={{'git_describe': ...}} explicitly."
+            f"({exc}) — the results and outcomes artifacts must record the "
+            f"measured tree. Install/repair git, or pass an explicit "
+            f"git_describe override."
         ) from exc
     described = proc.stdout.strip()
     if proc.returncode != 0 or not described:
         raise ValueError(
             f"'{' '.join(command)}' failed in {REPO_ROOT} "
             f"(exit {proc.returncode}, stderr: {proc.stderr.strip()!r}) — "
-            f"the results and outcomes artifacts must record the measured tree. Run the "
-            f"scorer from the git checkout being measured, or pass "
-            f"overrides={{'git_describe': ...}} explicitly."
+            f"the results and outcomes artifacts must record the measured "
+            f"tree. Run again from the git checkout being measured, or pass "
+            f"an explicit git_describe override."
         )
     return described
 

--- a/benchmarks/cwru/runner.py
+++ b/benchmarks/cwru/runner.py
@@ -41,9 +41,9 @@ Load-bearing decisions, documented here:
   repr makes the bytes a pure function of the rounded values.
 - **Determinism claim scope** (:func:`check_determinism`): the
   double-run byte-identity check is scoped to the measured environment
-  (one machine, one interpreter, one BLAS).The comparison covers
+  (one machine, one interpreter, one BLAS). The comparison covers
   deterministic measurement content only: both runs serialize the clean
-  per-record outcomes, and the ``_provenance``block (date, git describe,
+  per-record outcomes, and the ``_provenance`` block (date, git describe,
   platform, versions) is attached only when the artifact document is composed
   for writing — so a changing date or git describe can never fail this check.
   Cross-platform re-runs are expected to reproduce metric-level results,
@@ -70,19 +70,17 @@ from __future__ import annotations
 import json
 import math
 import os
-from collections.abc import Iterable, Mapping, Callable
+import platform as platform_module
+import subprocess
+from collections.abc import Callable, Iterable, Mapping
+from datetime import datetime, timezone
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Optional
 
-from datetime import datetime, timezone
-import platform as platform_module
-import scipy
 import numpy as np
 import predictive_maintenance_mcp
-import subprocess
-from benchmarks.cwru.importer import SIGNAL_UNIT
-from benchmarks.cwru.records import OpsRecord
+import scipy
 from predictive_maintenance_mcp.decision_support.diagnosis_pipeline import (
     diagnose_vibration,
 )
@@ -91,9 +89,11 @@ from predictive_maintenance_mcp.signal_acquisition.repository import (
     get_repository,
 )
 
+from benchmarks.cwru.importer import SIGNAL_UNIT
+from benchmarks.cwru.records import OpsRecord
+
 __all__ = [
     "BEARING_ID",
-    "PROVENANCE_KEYS",
     "DEFAULT_OUTCOMES_PATH",
     "EXCLUDED_ANOMALY_MARKER",
     "EXPECTED_PACKAGE_INIT",
@@ -102,17 +102,18 @@ __all__ = [
     "OUTCOME_STATUS_FAILED",
     "OUTCOME_STATUS_MISSING_SIGNAL",
     "OUTCOME_STATUS_OK",
+    "PROVENANCE_KEYS",
     "REPO_ROOT",
     "SUPPORT_TYPE",
     "assert_import_provenance",
     "assert_outcomes_complete",
     "check_determinism",
-    "run_records",
-    "serialize_outcomes",
-    "write_outcomes",
     "collect_provenance",
     "compose_outcomes_document",
+    "run_records",
+    "serialize_outcomes",
     "split_provenance",
+    "write_outcomes",
 ]
 
 _PACKAGE_DIR = Path(__file__).resolve().parent
@@ -270,7 +271,7 @@ def _extract_iso_context(iso: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def collect_provenance(overrides: Optional[Mapping[str, str]] = None) -> dict[str, str]:
-    """Collect the results-artifact metadata, with deterministic overrides.
+    """Collect the measurement provenance, with deterministic overrides.
 
     Every value that varies between runs (date, git describe, platform,
     versions) is produced lazily and can be overridden, so tests never
@@ -283,7 +284,7 @@ def collect_provenance(overrides: Optional[Mapping[str, str]] = None) -> dict[st
             must be a subset of :data:`PROVENANCE_KEYS`.
 
     Returns:
-        The complete metadata mapping (every key in
+        The complete provenance mapping (every key in
         :data:`PROVENANCE_KEYS` present).
 
     Raises:
@@ -296,7 +297,7 @@ def collect_provenance(overrides: Optional[Mapping[str, str]] = None) -> dict[st
     unknown = sorted(set(resolved) - PROVENANCE_KEYS)
     if unknown:
         raise ValueError(
-            f"Unknown metadata override key(s) {unknown} — valid keys are "
+            f"Unknown override key(s) {unknown} — valid keys are "
             f"{sorted(PROVENANCE_KEYS)}. Fix the caller."
         )
     producers: dict[str, Callable[[], str]] = {
@@ -585,9 +586,9 @@ def _git_describe() -> str:
 
     Raises:
         ValueError: If git cannot run or reports an error — the results
-            artifact must record which tree was measured, so an unknown
+            and outcomes artifacts must record which tree was measured, so an unknown
             tree is a refusal, not a placeholder (override via
-            ``metadata_overrides`` when scoring outside a git checkout).
+            ``overrides`` when scoring outside a git checkout).
     """
     command = ["git", "describe", "--always", "--dirty"]
     try:
@@ -602,18 +603,18 @@ def _git_describe() -> str:
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise ValueError(
             f"Cannot run '{' '.join(command)}' in {REPO_ROOT} "
-            f"({exc}) — the results artifact must record the measured "
+            f"({exc}) — the results and outcomes artifacts must record the measured "
             f"tree. Install/repair git, or pass "
-            f"metadata_overrides={{'git_describe': ...}} explicitly."
+            f"overrides={{'git_describe': ...}} explicitly."
         ) from exc
     described = proc.stdout.strip()
     if proc.returncode != 0 or not described:
         raise ValueError(
             f"'{' '.join(command)}' failed in {REPO_ROOT} "
             f"(exit {proc.returncode}, stderr: {proc.stderr.strip()!r}) — "
-            f"the results artifact must record the measured tree. Run the "
+            f"the results and outcomes artifacts must record the measured tree. Run the "
             f"scorer from the git checkout being measured, or pass "
-            f"metadata_overrides={{'git_describe': ...}} explicitly."
+            f"overrides={{'git_describe': ...}} explicitly."
         )
     return described
 

--- a/benchmarks/cwru/scorer.py
+++ b/benchmarks/cwru/scorer.py
@@ -130,6 +130,7 @@ HEADLINE_STRATA: tuple[str, ...] = ("Y1", "Y2")
 #: Metadata keys of the results artifact; every one is overridable so
 #: tests stay deterministic (date, git describe, platform vary by run).
 METADATA_KEYS: frozenset[str] = frozenset({*runner.PROVENANCE_KEYS, "dataset_subset"})
+
 #: Ranking tiers for the primary (detected + evidence) leg.
 _EVIDENCE_TIER: Mapping[str, int] = MappingProxyType({"high": 3, "moderate": 2})
 

--- a/benchmarks/cwru/scorer.py
+++ b/benchmarks/cwru/scorer.py
@@ -59,16 +59,10 @@ a rate over zero records is ``None``, never a fabricated percentage.
 from __future__ import annotations
 
 import json
-import platform as platform_module
-import subprocess
-from collections.abc import Callable, Mapping, Sequence
-from datetime import datetime, timezone
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Optional
-
-import numpy as np
-import scipy
 
 from benchmarks.cwru import runner
 from benchmarks.cwru.records import LabeledRecord, label_view
@@ -135,9 +129,8 @@ HEADLINE_STRATA: tuple[str, ...] = ("Y1", "Y2")
 
 #: Metadata keys of the results artifact; every one is overridable so
 #: tests stay deterministic (date, git describe, platform vary by run).
-METADATA_KEYS = frozenset({*runner.PROVENANCE_KEYS, "dataset_subset"})
+METADATA_KEYS: frozenset[str] = frozenset({*runner.PROVENANCE_KEYS, "dataset_subset"})
 #: Ranking tiers for the primary (detected + evidence) leg.
-
 _EVIDENCE_TIER: Mapping[str, int] = MappingProxyType({"high": 3, "moderate": 2})
 
 #: Ranking tier for a harmonic-only BSF hit — below every primary-leg

--- a/benchmarks/cwru/scorer.py
+++ b/benchmarks/cwru/scorer.py
@@ -70,7 +70,6 @@ from typing import Any, Optional
 import numpy as np
 import scipy
 
-import predictive_maintenance_mcp
 from benchmarks.cwru import runner
 from benchmarks.cwru.records import LabeledRecord, label_view
 
@@ -136,66 +135,14 @@ HEADLINE_STRATA: tuple[str, ...] = ("Y1", "Y2")
 
 #: Metadata keys of the results artifact; every one is overridable so
 #: tests stay deterministic (date, git describe, platform vary by run).
-METADATA_KEYS: frozenset[str] = frozenset(
-    {
-        "dataset_subset",
-        "date",
-        "git_describe",
-        "pipeline_version",
-        "platform",
-        "python_version",
-        "numpy_version",
-        "scipy_version",
-    }
-)
-
+METADATA_KEYS = frozenset({*runner.PROVENANCE_KEYS, "dataset_subset"})
 #: Ranking tiers for the primary (detected + evidence) leg.
+
 _EVIDENCE_TIER: Mapping[str, int] = MappingProxyType({"high": 3, "moderate": 2})
 
 #: Ranking tier for a harmonic-only BSF hit — below every primary-leg
 #: tier: a detected fundamental always outranks a 2x-only finding.
 _HARMONIC_ONLY_TIER: int = 1
-
-
-def _git_describe() -> str:
-    """Run ``git describe --always --dirty`` on the measured tree.
-
-    Returns:
-        The describe output, stripped.
-
-    Raises:
-        ValueError: If git cannot run or reports an error — the results
-            artifact must record which tree was measured, so an unknown
-            tree is a refusal, not a placeholder (override via
-            ``metadata_overrides`` when scoring outside a git checkout).
-    """
-    command = ["git", "describe", "--always", "--dirty"]
-    try:
-        proc = subprocess.run(
-            command,
-            cwd=runner.REPO_ROOT,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        raise ValueError(
-            f"Cannot run '{' '.join(command)}' in {runner.REPO_ROOT} "
-            f"({exc}) — the results artifact must record the measured "
-            f"tree. Install/repair git, or pass "
-            f"metadata_overrides={{'git_describe': ...}} explicitly."
-        ) from exc
-    described = proc.stdout.strip()
-    if proc.returncode != 0 or not described:
-        raise ValueError(
-            f"'{' '.join(command)}' failed in {runner.REPO_ROOT} "
-            f"(exit {proc.returncode}, stderr: {proc.stderr.strip()!r}) — "
-            f"the results artifact must record the measured tree. Run the "
-            f"scorer from the git checkout being measured, or pass "
-            f"metadata_overrides={{'git_describe': ...}} explicitly."
-        )
-    return described
 
 
 def collect_metadata(overrides: Optional[Mapping[str, str]] = None) -> dict[str, str]:
@@ -228,21 +175,12 @@ def collect_metadata(overrides: Optional[Mapping[str, str]] = None) -> dict[str,
             f"Unknown metadata override key(s) {unknown} — valid keys are "
             f"{sorted(METADATA_KEYS)}. Fix the caller."
         )
-    producers: dict[str, Callable[[], str]] = {
-        "dataset_subset": lambda: DATASET_SUBSET,
-        "date": lambda: datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "git_describe": _git_describe,
-        "pipeline_version": lambda: str(
-            getattr(predictive_maintenance_mcp, "__version__", "unknown")
-        ),
-        "platform": platform_module.platform,
-        "python_version": platform_module.python_version,
-        "numpy_version": lambda: str(np.__version__),
-        "scipy_version": lambda: str(scipy.__version__),
-    }
+    provenance = runner.collect_provenance(
+        {key: value for key, value in resolved.items() if key in runner.PROVENANCE_KEYS}
+    )
     return {
-        key: resolved[key] if key in resolved else producer()
-        for key, producer in producers.items()
+        **provenance,
+        "dataset_subset": resolved.get("dataset_subset", DATASET_SUBSET),
     }
 
 
@@ -503,6 +441,7 @@ def score_results(
     labeled: Optional[Sequence[LabeledRecord]] = None,
     *,
     metadata_overrides: Optional[Mapping[str, str]] = None,
+    measurement_provenance: Optional[Mapping[str, str]] = None,
 ) -> dict[str, Any]:
     """Join outcomes with labels and compute the stratified results.
 
@@ -516,13 +455,15 @@ def score_results(
             ``None`` reads the vendored tables via ``label_view()``.
         metadata_overrides: Verbatim metadata values (tests pin date,
             git describe, and platform for determinism).
+        measurement_provenance: Provenance values coming from the outcomes.
 
     Returns:
         The results document (see this module's docstring and
         ``write_results`` for the artifact schema): ``metadata``,
-        ``criteria``, per-stratum aggregates in ``strata``, the
-        Y1/Y2-only ``headline``, the ``known_anomalies_flagged`` line,
-        and the per-record ``records`` table.
+        ``measurement_provenance``, ``criteria``, per-stratum aggregates
+        in ``strata``, the Y1/Y2-only ``headline``, the
+        ``known_anomalies_flagged`` line, and the per-record ``records``
+        table.
 
     Raises:
         ValueError: On empty outcomes, an empty label view, duplicate
@@ -567,6 +508,9 @@ def score_results(
     flagged_ids = sorted(oid for oid, row in rows.items() if row["known_anomalies"])
     return {
         "metadata": collect_metadata(metadata_overrides),
+        "measurement_provenance": (
+            dict(measurement_provenance) if measurement_provenance is not None else None
+        ),
         "criteria": _criteria(),
         "strata": strata,
         "headline": {
@@ -581,7 +525,9 @@ def score_results(
     }
 
 
-def read_outcomes(path: Optional[Path] = None) -> dict[str, Any]:
+def read_outcomes(
+    path: Optional[Path] = None,
+) -> tuple[dict[str, dict[str, Any]], Optional[dict[str, str]]]:
     """Read a runner outcomes artifact for scoring.
 
     Args:
@@ -589,8 +535,9 @@ def read_outcomes(path: Optional[Path] = None) -> dict[str, Any]:
             default (``benchmarks/cwru/results/outcomes.json``).
 
     Returns:
-        The parsed outcomes, keyed by opaque id.
-
+         A ``(outcomes, provenance)`` pair, where ``provenance`` is the
+        ``_provenance`` block when present and ``None`` for artifacts
+        that predate provenance collection.
     Raises:
         ValueError: If the artifact is absent (remedy: run the
             measurement first), unparseable, or not a JSON object.
@@ -615,7 +562,7 @@ def read_outcomes(path: Optional[Path] = None) -> dict[str, Any]:
             f"opaque id, got {type(raw).__name__} — re-run 'python -m "
             f"benchmarks.cwru run' to regenerate it."
         )
-    return raw
+    return runner.split_provenance(raw)
 
 
 def write_results(results: Mapping[str, Any], path: Optional[Path] = None) -> Path:

--- a/docs/benchmark-methodology.md
+++ b/docs/benchmark-methodology.md
@@ -189,6 +189,12 @@ records get hard — most residual misclassifications sit in the ball-fault and
   results (per-record hits and rates), not byte-identical artifacts —
   low-order floating-point bits differ across BLAS builds and operating
   systems.
+- **Measurement provenance is recorded with the outcomes.** Each outcomes
+  artifact carries a `_provenance` block — date, git describe of the measured
+  tree, platform, Python/NumPy/SciPy versions, and the measured pipeline
+  version — collected once before the run. `results.json` echoes it as
+  `measurement_provenance`, so every published number stays bound to the exact
+  environment that measured it.
 - An import-provenance tripwire refuses to run if the measured package does not
   resolve to the working tree being benchmarked (guards against measuring a
   different checkout, e.g. from a stale editable install).

--- a/tests/test_cwru_benchmark_runner.py
+++ b/tests/test_cwru_benchmark_runner.py
@@ -261,7 +261,7 @@ class TestDeterminism:
         assert set(first) == set(second)
         for key in outcomes:
             assert first[key] == second[key]
-        # Only the provenance block differs, and it is a namedable
+        # Only the provenance block differs, and it is a nameable
         # divergence (git describe), not a byte count.
         block_a = first[runner.PROVENANCE_MARKER_KEY]
         block_b = second[runner.PROVENANCE_MARKER_KEY]
@@ -529,9 +529,6 @@ class TestMeasurementProvenance:
     def test_unknown_override_key_refused(self):
         with pytest.raises(ValueError, match="bogus_key"):
             runner.collect_provenance({"bogus_key": "typo"})
-
-    def test_pipeline_version_is_measured(self):
-        assert "pipeline_version" in runner.PROVENANCE_KEYS
 
     def test_compose_and_split_round_trip(self):
         outcomes = {"cwru_001": {"status": runner.OUTCOME_STATUS_OK}}

--- a/tests/test_cwru_benchmark_runner.py
+++ b/tests/test_cwru_benchmark_runner.py
@@ -235,6 +235,41 @@ class TestDeterminism:
         with pytest.raises(ValueError, match="[Dd]eterminism"):
             runner.check_determinism((), repository=None)
 
+    def test_artifacts_differ_only_in_the_provenance_block(self):
+        """Determinism is about measurement content, not the written bytes.
+
+        Two documents over the SAME outcomes with different provenance
+        blocks differ only in the ``_provenance`` subtree — the exclusion
+        the ``check_determinism`` docstring claims.
+        """
+
+        def build(date: str, describe: str) -> dict:
+            provenance = runner.collect_provenance(
+                {"date": date, "git_describe": describe, "platform": "pin"}
+            )
+            return json.loads(
+                runner.serialize_outcomes(
+                    runner.compose_outcomes_document(outcomes, provenance)
+                ).decode("utf-8")
+            )
+
+        outcomes = {"cwru_001": {"status": runner.OUTCOME_STATUS_OK, "value": 1.5}}
+        first = build("2026-08-10T00:00:00+00:00", "pin-a")
+        second = build("2026-08-11T00:00:00+00:00", "pin-b")
+
+        # Identical measurement content: every record subtree matches.
+        assert set(first) == set(second)
+        for key in outcomes:
+            assert first[key] == second[key]
+        # Only the provenance block differs, and it is a namedable
+        # divergence (git describe), not a byte count.
+        block_a = first[runner.PROVENANCE_MARKER_KEY]
+        block_b = second[runner.PROVENANCE_MARKER_KEY]
+        assert block_a != block_b
+        assert block_a["git_describe"] != block_b["git_describe"]
+        # The block records every provenance key.
+        assert set(block_a) == set(runner.PROVENANCE_KEYS)
+
 
 # ---------------------------------------------------------------------------
 # Happy path: anomaly block excluded even when a local model ran
@@ -459,3 +494,89 @@ class TestScoreSubcommand:
         assert str(missing) in err
         assert "benchmarks.cwru run" in err  # remedy names the run stage
         assert not (tmp_path / "results.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Measurement provenance: collection, composition, and the explicit split
+# ---------------------------------------------------------------------------
+
+
+class TestMeasurementProvenance:
+    """collect_provenance, compose_outcomes_document, split_provenance.
+
+    The measurement block is collected once before the run, composed into
+    a flat ``_provenance`` sibling of the record ids, and split back out
+    on read so the marker never reaches the gate or the status loop.
+    """
+
+    def test_collect_provenance_returns_exactly_provenance_keys(self):
+        provenance = runner.collect_provenance(
+            {
+                "date": "2026-08-10T00:00:00+00:00",
+                "git_describe": "pin",
+                "platform": "pin",
+            }
+        )
+        assert set(provenance) == set(runner.PROVENANCE_KEYS)
+        assert provenance["date"] == "2026-08-10T00:00:00+00:00"
+        assert provenance["git_describe"] == "pin"
+        assert provenance["platform"] == "pin"
+        assert provenance["pipeline_version"] == str(
+            getattr(predictive_maintenance_mcp, "__version__", "unknown")
+        )
+        assert provenance["numpy_version"] == str(np.__version__)
+
+    def test_unknown_override_key_refused(self):
+        with pytest.raises(ValueError, match="bogus_key"):
+            runner.collect_provenance({"bogus_key": "typo"})
+
+    def test_pipeline_version_is_measured(self):
+        assert "pipeline_version" in runner.PROVENANCE_KEYS
+
+    def test_compose_and_split_round_trip(self):
+        outcomes = {"cwru_001": {"status": runner.OUTCOME_STATUS_OK}}
+        provenance = {
+            "date": "2026-08-10T00:00:00+00:00",
+            "git_describe": "pin",
+            "platform": "pin",
+        }
+        document = runner.compose_outcomes_document(outcomes, provenance)
+        assert set(document) == {"cwru_001", runner.PROVENANCE_MARKER_KEY}
+        assert document[runner.PROVENANCE_MARKER_KEY] == provenance
+        records, block = runner.split_provenance(document)
+        assert records == outcomes
+        assert block == provenance
+
+    def test_split_legacy_artifact_returns_none(self):
+        outcomes = {"cwru_001": {"status": runner.OUTCOME_STATUS_OK}}
+        records, block = runner.split_provenance(outcomes)
+        assert records == outcomes
+        assert block is None
+
+    def test_split_refuses_a_non_object_marker(self):
+        with pytest.raises(ValueError, match=runner.PROVENANCE_MARKER_KEY):
+            runner.split_provenance(
+                {
+                    "cwru_001": {"status": runner.OUTCOME_STATUS_OK},
+                    runner.PROVENANCE_MARKER_KEY: "not-a-block",
+                }
+            )
+
+    def test_gate_sees_only_records_after_the_split(self):
+        records = (
+            _record("cwru_001", 105, "X105_DE_time"),
+            _record("cwru_002", 118, "X118_DE_time"),
+        )
+        outcomes = {
+            record.opaque_id: {"status": runner.OUTCOME_STATUS_OK} for record in records
+        }
+        document = runner.compose_outcomes_document(
+            outcomes,
+            {
+                "date": "2026-08-10T00:00:00+00:00",
+                "git_describe": "pin",
+                "platform": "pin",
+            },
+        )
+        clean, _ = runner.split_provenance(document)
+        runner.assert_outcomes_complete(clean, records)

--- a/tests/test_cwru_benchmark_scoring.py
+++ b/tests/test_cwru_benchmark_scoring.py
@@ -874,8 +874,13 @@ class TestCommittedResultsDerivedFromOutcomes:
             metadata_overrides=committed["metadata"],
             measurement_provenance=provenance,
         )
+
+        # Transitional: committed results predate provenance. Once outcomes are
+        # regenerated, provenance is never None and this pop must go.
+
         if provenance is None:
             results.pop("measurement_provenance")
+
         out = tmp_path / "rescored.json"
         scorer.write_results(results, out)
         return out.read_text(encoding="utf-8")
@@ -907,7 +912,10 @@ class TestCommittedResultsDerivedFromOutcomes:
         """
         committed = json.loads(self._committed_outcomes_text())
         if runner.PROVENANCE_MARKER_KEY not in committed:
-            return
+            pytest.skip(
+                "committed outcomes predate provenance collection; "
+                "regenerate to arm this guard"
+            )
         assert set(committed[runner.PROVENANCE_MARKER_KEY]) == set(
             runner.PROVENANCE_KEYS
         )

--- a/tests/test_cwru_benchmark_scoring.py
+++ b/tests/test_cwru_benchmark_scoring.py
@@ -764,6 +764,48 @@ class TestScoreCLI:
         assert set(parsed["records"]) == {"cwru_001", "cwru_002"}
         assert parsed["strata"]["Y1"]["classification"]["correct"] == 1
         assert parsed["metadata"]["git_describe"] == META["git_describe"]
+        # The flat artifact predates provenance: the key is present, null.
+        assert parsed["measurement_provenance"] is None
+
+    def test_score_echoes_measurement_provenance_from_the_artifact(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        labeled = (
+            _labeled("cwru_001", 105, "inner_race", grade="Y1"),
+            _labeled("cwru_002", 97, "normal"),
+        )
+        outcomes = {
+            "cwru_001": _outcome("cwru_001", {"BPFI": _detected("high")}),
+            "cwru_002": _outcome("cwru_002"),
+        }
+        provenance = {
+            "date": "2026-08-10T00:00:00+00:00",
+            "git_describe": "pin",
+            "platform": "pin",
+        }
+        outcomes_path = tmp_path / "outcomes.json"
+        results_path = tmp_path / "results.json"
+        runner.write_outcomes(
+            runner.compose_outcomes_document(outcomes, provenance), outcomes_path
+        )
+        monkeypatch.setattr(scorer, "label_view", lambda: labeled)
+        monkeypatch.setattr(
+            scorer, "collect_metadata", lambda overrides=None: dict(META)
+        )
+
+        exit_code = main(
+            [
+                "score",
+                "--outcomes",
+                str(outcomes_path),
+                "--output",
+                str(results_path),
+            ]
+        )
+
+        assert exit_code == 0
+        parsed = json.loads(results_path.read_text(encoding="utf-8"))
+        assert parsed["measurement_provenance"] == provenance
 
     def test_score_partial_outcomes_exit_2_naming_ids(
         self, tmp_path: Path, monkeypatch, capsys
@@ -809,6 +851,10 @@ class TestCommittedResultsDerivedFromOutcomes:
         return scorer.DEFAULT_RESULTS_PATH.read_text(encoding="utf-8")
 
     @staticmethod
+    def _committed_outcomes_text() -> str:
+        return runner.DEFAULT_OUTCOMES_PATH.read_text(encoding="utf-8")
+
+    @staticmethod
     def _rescore(tmp_path: Path) -> str:
         """Re-score the committed outcomes and return the serialized bytes.
 
@@ -822,10 +868,14 @@ class TestCommittedResultsDerivedFromOutcomes:
         committed = json.loads(
             TestCommittedResultsDerivedFromOutcomes._committed_results_text()
         )
-        outcomes = scorer.read_outcomes()
+        outcomes, provenance = scorer.read_outcomes()
         results = scorer.score_results(
-            outcomes, metadata_overrides=committed["metadata"]
+            outcomes,
+            metadata_overrides=committed["metadata"],
+            measurement_provenance=provenance,
         )
+        if provenance is None:
+            results.pop("measurement_provenance")
         out = tmp_path / "rescored.json"
         scorer.write_results(results, out)
         return out.read_text(encoding="utf-8")
@@ -845,6 +895,22 @@ class TestCommittedResultsDerivedFromOutcomes:
         """
         committed = json.loads(self._committed_results_text())
         assert set(committed["metadata"]) == set(scorer.METADATA_KEYS)
+
+    def test_every_provenance_key_is_pinned_by_the_committed_artifact(self):
+        """The committed outcomes' provenance keys must equal PROVENANCE_KEYS.
+
+        If a new provenance key is added without regenerating the
+        committed outcomes artifact, the derivation guard would silently
+        drop it. The guard is dormant while the committed artifact
+        predates provenance collection (no ``_provenance`` marker) and
+        becomes live once the maintainer re-measures.
+        """
+        committed = json.loads(self._committed_outcomes_text())
+        if runner.PROVENANCE_MARKER_KEY not in committed:
+            return
+        assert set(committed[runner.PROVENANCE_MARKER_KEY]) == set(
+            runner.PROVENANCE_KEYS
+        )
 
     def test_a_perturbed_results_copy_fails_the_comparison(self, tmp_path: Path):
         """Mutation leg: the comparison is demonstrated to fail, not assumed to."""
@@ -871,3 +937,81 @@ class TestCommittedResultsDerivedFromOutcomes:
         """Only the two committed artifacts are read."""
         assert scorer.DEFAULT_RESULTS_PATH.exists()
         assert runner.DEFAULT_OUTCOMES_PATH.exists()
+
+
+# ---------------------------------------------------------------------------
+# Measurement provenance: read split, results echo, schema-stable null
+# ---------------------------------------------------------------------------
+
+
+class TestMeasurementProvenance:
+    """Provenance round-trips from the artifact into the results.
+
+    ``read_outcomes`` splits the ``_provenance`` block from the record
+    ids; ``score_results`` echoes it verbatim into
+    ``measurement_provenance``, which is always present — ``None`` for
+    artifacts that predate provenance collection.
+    """
+
+    @staticmethod
+    def _pair():
+        labeled = (
+            _labeled("cwru_001", 105, "inner_race", grade="Y1"),
+            _labeled("cwru_002", 97, "normal"),
+        )
+        outcomes = {
+            "cwru_001": _outcome("cwru_001", {"BPFI": _detected("high")}),
+            "cwru_002": _outcome("cwru_002"),
+        }
+        return labeled, outcomes
+
+    def test_read_outcomes_round_trips_provenance(self, tmp_path):
+        _, outcomes = self._pair()
+        provenance = {
+            "date": "2026-08-10T00:00:00+00:00",
+            "git_describe": "pin",
+            "platform": "pin",
+        }
+        path = tmp_path / "outcomes.json"
+        runner.write_outcomes(
+            runner.compose_outcomes_document(outcomes, provenance), path
+        )
+        records, block = scorer.read_outcomes(path)
+        assert records == outcomes
+        assert block == provenance
+
+    def test_read_outcomes_legacy_artifact_returns_none(self, tmp_path):
+        _, outcomes = self._pair()
+        path = tmp_path / "outcomes.json"
+        runner.write_outcomes(outcomes, path)
+        records, block = scorer.read_outcomes(path)
+        assert records == outcomes
+        assert block is None
+
+    def test_measurement_provenance_echoed_verbatim(self):
+        labeled, outcomes = self._pair()
+        provenance = {
+            "date": "2026-08-10T00:00:00+00:00",
+            "git_describe": "pin",
+            "platform": "pin",
+        }
+        results = scorer.score_results(
+            outcomes,
+            labeled,
+            metadata_overrides=META,
+            measurement_provenance=provenance,
+        )
+        assert results["measurement_provenance"] == provenance
+
+    def test_measurement_provenance_null_when_omitted(self):
+        labeled, outcomes = self._pair()
+        results = scorer.score_results(outcomes, labeled, metadata_overrides=META)
+        assert "measurement_provenance" in results
+        assert results["measurement_provenance"] is None
+
+    def test_empty_provenance_mapping_honored_verbatim(self):
+        labeled, outcomes = self._pair()
+        results = scorer.score_results(
+            outcomes, labeled, metadata_overrides=META, measurement_provenance={}
+        )
+        assert results["measurement_provenance"] == {}


### PR DESCRIPTION
## Description
Added the provenance outputting to the outcomes.json as well as results.json.
## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🧪 Test improvement

## Testing
- [x] Tests added/updated
- [x] All tests pass (`pytest -v`)
- [x] Code formatted (`black --check src/`)
- [x] Linting clean (`flake8 src/`)
- [x] Coverage maintained or improved

## Checklist
- [x] Self-reviewed the code
- [x] Docstrings updated for new/changed functions
- [] Documentation updated (README, EXAMPLES.md, etc.)
- [x] No hardcoded paths or credentials
- [x] Error messages are clear and helpful

## Related Issues
Fixes #50
